### PR TITLE
Add colored progress bar that shows progress of job's tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +512,7 @@ dependencies = [
  "chrono",
  "clap",
  "cli-table",
+ "colored",
  "ctrlc",
  "dirs",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ num_cpus = "1.13.0"
 bincode = "1.3.3"
 nom = "6"
 bstr = { version = "0.2", features = ["serde1"] }
+colored = "2"

--- a/src/client/commands/jobs.rs
+++ b/src/client/commands/jobs.rs
@@ -8,7 +8,7 @@ use crate::transfer::messages::{
 };
 use crate::JobId;
 
-pub async fn get_job_list(
+pub async fn output_job_list(
     gsettings: &GlobalSettings,
     connection: &mut ClientConnection,
     job_filters: Vec<Status>,
@@ -27,7 +27,7 @@ pub async fn get_job_list(
     Ok(())
 }
 
-pub async fn get_job_detail(
+pub async fn output_job_detail(
     gsettings: &GlobalSettings,
     connection: &mut ClientConnection,
     job_id: JobId,

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -34,22 +34,21 @@ def test_job_array_report(hq_env: HqEnv):
 
     table = hq_env.command(["job", "1"], as_table=True)
 
-    assert table[5][0] == "Tasks"
-    assert table[5][1] == "10; Ids: 10-19"
+    assert table[6] == ["Tasks", "10; Ids: 10-19"]
 
     assert table[2][0] == "State"
     assert table[3][0] == ""
     assert table[4][0] == ""
 
-    assert table[2][1] == "RUNNING (4)"
-    assert table[3][1] == "FINISHED (4)"
-    assert table[4][1] == "WAITING (2)"
+    assert table[3][1] == "RUNNING (4)"
+    assert table[4][1] == "FINISHED (4)"
+    assert table[5][1] == "WAITING (2)"
 
     time.sleep(1.6)
 
     table = hq_env.command(["job", "1"], as_table=True)
     assert table[2][0] == "State"
-    assert table[2][1] == "FINISHED (10)"
+    assert table[3][1] == "FINISHED (10)"
 
 
 def test_job_array_error_some(hq_env: HqEnv):
@@ -65,16 +64,16 @@ def test_job_array_error_some(hq_env: HqEnv):
         ]
     )
     hq_env.start_worker(cpus=2)
-    time.sleep(0.4)
+    time.sleep(1)
 
     table = hq_env.command(["jobs"], as_table=True)
     assert table[1][2] == "FAILED"
 
     table = hq_env.command(["job", "1"], as_table=True)
-    assert table[2][1] == "FAILED (3)"
-    assert table[3][1] == "FINISHED (7)"
+    assert table[3][1] == "FAILED (3)"
+    assert table[4][1] == "FINISHED (7)"
 
-    offset = 9
+    offset = 10
 
     assert table[offset][0] == "Task Id"
     assert table[offset][1] == "Error"
@@ -106,9 +105,9 @@ def test_job_array_error_all(hq_env: HqEnv):
     assert table[1][2] == "FAILED"
 
     table = hq_env.command(["job", "1"], as_table=True)
-    assert table[2][1] == "FAILED (10)"
+    assert table[3][1] == "FAILED (10)"
 
-    offset = 9
+    offset = 10
 
     for i in range(5):
         assert table[offset + i][0] == str(i)
@@ -117,7 +116,7 @@ def test_job_array_error_all(hq_env: HqEnv):
     assert table[offset + 5] == []
 
     table = hq_env.command(["job", "1", "--tasks"], as_table=True)
-    assert table[2][1] == "FAILED (10)"
+    assert table[3][1] == "FAILED (10)"
 
     for i in range(10):
         assert table[offset + i][0] == str(i)
@@ -134,8 +133,8 @@ def test_job_array_cancel(hq_env: HqEnv):
     time.sleep(0.4)
 
     table = hq_env.command(["job", "1", "--tasks"], as_table=True)
-    assert table[2][1] == "FINISHED (4)"
-    assert table[3][1] == "CANCELED (6)"
+    assert table[3][1] == "FINISHED (4)"
+    assert table[4][1] == "CANCELED (6)"
     c = collections.Counter([x[1] for x in table[9:]])
     assert c.get("FINISHED") == 4
     assert c.get("CANCELED") == 6
@@ -153,14 +152,14 @@ def test_array_reporting_state_after_worker_lost(hq_env: HqEnv):
     time.sleep(0.25)
     table = hq_env.command(["job", "1", "--tasks"], as_table=True)
     c = collections.Counter([x[1] for x in table[8:]])
-    assert table[2][1] == "WAITING (4)"
+    assert table[3][1] == "WAITING (4)"
     assert c.get("WAITING") == 4
     hq_env.start_workers(1, cpus=2)
 
     time.sleep(2.2)
     table = hq_env.command(["job", "1", "--tasks"], as_table=True)
     c = collections.Counter([x[1] for x in table[8:]])
-    assert table[2][1] == "FINISHED (4)"
+    assert table[3][1] == "FINISHED (4)"
     assert c.get("FINISHED") == 4
 
 

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -29,7 +29,7 @@ def test_entries_no_newline(hq_env: HqEnv):
     assert not os.path.isfile("stdout.0.4")
 
     table = hq_env.command(["job", "1"], as_table=True)
-    assert table[2][1] == "FINISHED (4)"
+    assert table[3][1] == "FINISHED (4)"
 
 
 def test_entries_with_newline(hq_env: HqEnv):
@@ -58,4 +58,4 @@ def test_entries_with_newline(hq_env: HqEnv):
     assert not os.path.isfile("stdout.0.4")
 
     table = hq_env.command(["job", "1"], as_table=True)
-    assert table[2][1] == "FINISHED (4)"
+    assert table[3][1] == "FINISHED (4)"


### PR DESCRIPTION
Showcase (using `watch --color`):
![progress-bar](https://user-images.githubusercontent.com/4539057/122388795-86d00a80-cf70-11eb-83d5-81b81b84cd1f.gif)

I looked at existing progress bar libraries and I haven't found any that would allow me to output the progress bar to a string in a simple way. And for this we probably don't need a special dependency anyway. I included `colored` to color the bar though, maybe we can use `termcolor`, which is already used by `cli_table`.

Closes: https://github.com/It4innovations/hyperqueue/issues/49
