### PR TITLE
Reduce number of sleep calls in tests

### DIFF
--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -1,6 +1,8 @@
-from .conftest import HqEnv
 import os
 import time
+
+from .conftest import HqEnv
+from .utils import wait_for_job_state
 
 
 def test_entries_no_newline(hq_env: HqEnv):
@@ -20,7 +22,7 @@ def test_entries_no_newline(hq_env: HqEnv):
             "echo $HQ_ENTRY",
         ]
     )
-    time.sleep(0.4)
+    wait_for_job_state(hq_env, 1, "FINISHED")
 
     for i, test in enumerate(["One\n", "Two\n", "Three\n", "Four\n"]):
         with open(f"stdout.1.{i}") as f:
@@ -49,7 +51,7 @@ def test_entries_with_newline(hq_env: HqEnv):
             "echo $HQ_ENTRY",
         ]
     )
-    time.sleep(0.4)
+    wait_for_job_state(hq_env, 1, "FINISHED")
 
     for i, test in enumerate(["One\n", "Two\n", "Three\n", "Four\n"]):
         with open(f"stdout.1.{i}") as f:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,8 +1,7 @@
-import time
 from typing import Optional
 
 from .conftest import HqEnv
-from .utils import wait_until
+from .utils import wait_until, wait_for_worker_state
 
 
 def test_worker_list(hq_env: HqEnv):
@@ -20,7 +19,7 @@ def test_worker_list(hq_env: HqEnv):
     assert table[2][:2] == ["2", "RUNNING"]
 
     hq_env.kill_worker(2)
-    time.sleep(0.2)
+    wait_for_worker_state(hq_env, 2, "OFFLINE")
 
     table = hq_env.command(["worker", "list"], as_table=True)
     assert len(table) == 3
@@ -29,7 +28,7 @@ def test_worker_list(hq_env: HqEnv):
     assert table[2][:2] == ["2", "OFFLINE"]
 
     hq_env.kill_worker(1)
-    time.sleep(0.2)
+    wait_for_worker_state(hq_env, 1, "OFFLINE")
 
     table = hq_env.command(["worker", "list"], as_table=True)
     assert len(table) == 3
@@ -38,6 +37,7 @@ def test_worker_list(hq_env: HqEnv):
     assert table[2][:2] == ["2", "OFFLINE"]
 
     hq_env.start_worker()
+    wait_for_worker_state(hq_env, 3, "RUNNING")
 
     table = hq_env.command(["worker", "list"], as_table=True)
 
@@ -52,30 +52,27 @@ def test_worker_stop(hq_env: HqEnv):
     hq_env.start_server()
     process = hq_env.start_worker()
 
-    worker_id = wait_until(lambda: get_worker_id(hq_env, 0))
-    hq_env.command(["worker", "stop", worker_id])
+    wait_for_worker_state(hq_env, 1, "RUNNING")
 
-    wait_until(
-        lambda: hq_env.command(["worker", "list"], as_table=True)[1][1] == "OFFLINE"
-    )
+    hq_env.command(["worker", "stop", "1"])
+
+    wait_for_worker_state(hq_env, 1, "OFFLINE")
     hq_env.check_process_exited(process)
-
-
-def get_worker_id(hq_env: HqEnv, index: int) -> Optional[str]:
-    table = hq_env.command(["worker", "list"], as_table=True)
-    if index >= len(table) - 1:
-        return None
-    return table[index + 1][0]
 
 
 def test_worker_list_online_offline_state(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.start_workers(2)
+
+    wait_for_worker_state(hq_env, [1, 2], "RUNNING")
+
     table = hq_env.command(["worker", "list"], as_table=True)
     assert len(table) == 3
     assert table[1][:2] == ["1", "RUNNING"]
     assert table[2][:2] == ["2", "RUNNING"]
     hq_env.kill_worker(2)
+
+    wait_for_worker_state(hq_env, 2, "OFFLINE")
     table = hq_env.command(["worker", "list"], as_table=True)
     assert len(table) == 3
     assert table[1][:2] == ["1", "RUNNING"]
@@ -94,6 +91,8 @@ def test_worker_list_resources(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.start_worker(cpus="10")
     hq_env.start_worker(cpus="4x5")
+
+    wait_for_worker_state(hq_env, [1, 2], "RUNNING")
 
     table = hq_env.command(["worker", "list"], as_table=True)
     assert len(table) == 3

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,7 @@
 import time
-from typing import List
+from typing import List, Union, Set
+
+DEFAULT_TIMEOUT = 5
 
 
 def parse_table(table_string: str) -> List[str]:
@@ -21,7 +23,7 @@ def parse_table(table_string: str) -> List[str]:
     return result
 
 
-def wait_until(fn, sleep_s=0.2, timeout_s=5):
+def wait_until(fn, sleep_s=0.2, timeout_s=DEFAULT_TIMEOUT):
     end = time.time() + timeout_s
 
     while time.time() < end:
@@ -30,3 +32,37 @@ def wait_until(fn, sleep_s=0.2, timeout_s=5):
             return value
         time.sleep(sleep_s)
     raise Exception(f"Wait timeouted after {timeout_s} seconds")
+
+
+def wait_for_state(
+        env,
+        ids: Union[int, List[int]],
+        target_states: Union[str, List[str]],
+        commands: List[str],
+        state_index: int,
+        **kwargs
+):
+    if isinstance(ids, int):
+        ids = {str(ids)}
+    else:
+        ids = set(str(id) for id in ids)
+
+    if isinstance(target_states, str):
+        target_states = {target_states.lower()}
+    else:
+        target_states = set(state.lower() for state in target_states)
+
+    def check():
+        table = env.command(commands, as_table=True)
+        jobs = [row for row in table[1:] if row[0] in ids]
+        return len(jobs) >= len(ids) and all(j[state_index].lower() in target_states for j in jobs)
+
+    wait_until(check, **kwargs)
+
+
+def wait_for_job_state(env, ids: Union[int, List[int]], target_states: Union[str, List[str]], **kwargs):
+    wait_for_state(env, ids, target_states, ["jobs"], 2, **kwargs)
+
+
+def wait_for_worker_state(env, ids: Union[int, List[int]], target_states: Union[str, List[str]], **kwargs):
+    wait_for_state(env, ids, target_states, ["worker", "list"], 1, **kwargs)


### PR DESCRIPTION
This PR introduces `wait_for_job_state` and `wait_for_worker_state` test helper functions which should be used to wait until the specified state is achieved for a specific set of jobs or workers. This should help reduce the "flakiness" of tests.

Using the helpers reduced the number of `time.sleep` calls inside tests from 38 to 10.