### PR TITLE
Reimplement `hq wait` to avoid using polling

### DIFF
--- a/src/bin/hq.rs
+++ b/src/bin/hq.rs
@@ -12,7 +12,7 @@ use hyperqueue::client::commands::stop::stop_server;
 use hyperqueue::client::commands::submit::{
     resubmit_computation, submit_computation, ResubmitOpts, SubmitOpts,
 };
-use hyperqueue::client::commands::wait::wait_for_job_with_selector;
+use hyperqueue::client::commands::wait::wait_for_jobs;
 use hyperqueue::client::commands::worker::{get_worker_info, get_worker_list, stop_worker};
 use hyperqueue::client::globalsettings::GlobalSettings;
 use hyperqueue::client::status::Status;
@@ -391,7 +391,7 @@ async fn command_worker_address(
 async fn command_wait(gsettings: GlobalSettings, opts: WaitOpts) -> anyhow::Result<()> {
     let mut connection = get_client_connection(gsettings.server_directory()).await?;
 
-    wait_for_job_with_selector(&mut connection, opts.selector_arg.into()).await
+    wait_for_jobs(&mut connection, opts.selector_arg.into()).await
 }
 
 pub enum ColorPolicy {

--- a/src/client/commands/submit.rs
+++ b/src/client/commands/submit.rs
@@ -9,7 +9,7 @@ use clap::Clap;
 use tako::common::resources::{CpuRequest, ResourceRequest};
 use tako::messages::common::{ProgramDefinition, StdioDef};
 
-use crate::client::commands::wait::wait_for_job_with_info;
+use crate::client::commands::wait::wait_for_jobs;
 use crate::client::globalsettings::GlobalSettings;
 use crate::client::job::{get_worker_map, print_job_detail};
 use crate::client::resources::parse_cpu_request;
@@ -18,7 +18,7 @@ use crate::common::arraydef::IntArray;
 use crate::common::timeutils::ArgDuration;
 use crate::transfer::connection::ClientConnection;
 use crate::transfer::messages::{
-    FromClientMessage, JobType, ResubmitRequest, SubmitRequest, ToClientMessage,
+    FromClientMessage, JobType, ResubmitRequest, Selector, SubmitRequest, ToClientMessage,
 };
 use crate::worker::placeholders::{JOB_ID_PLACEHOLDER, TASK_ID_PLACEHOLDER};
 use crate::{rpc_call, JobId, JobTaskCount, Map};
@@ -264,7 +264,7 @@ pub async fn submit_computation(
         get_worker_map(connection).await?,
     );
     if opts.wait {
-        wait_for_job_with_info(connection, info).await?;
+        wait_for_jobs(connection, Selector::Specific(IntArray::from_id(info.id))).await?;
     }
     Ok(())
 }

--- a/src/client/commands/wait.rs
+++ b/src/client/commands/wait.rs
@@ -1,147 +1,50 @@
-use crate::client::status::is_terminated;
+use std::time::SystemTime;
+
+use crate::rpc_call;
 use crate::transfer::connection::ClientConnection;
-use crate::transfer::messages::{
-    FromClientMessage, JobInfo, JobInfoRequest, Selector, ToClientMessage,
-};
-use crate::{rpc_call, JobId, JobTaskCount, Set};
+use crate::transfer::messages::{FromClientMessage, Selector, ToClientMessage, WaitForJobsRequest};
 
-use crate::client::utils::{
-    job_progress_bar, TASK_COLOR_CANCELED, TASK_COLOR_FAILED, TASK_COLOR_FINISHED,
-    TASK_COLOR_RUNNING,
-};
-use crate::common::arraydef::IntArray;
-use crate::server::job::JobTaskCounters;
-use anyhow::bail;
-use colored::Colorize;
-use std::io::Write;
-use std::time::Duration;
-use tokio::time::sleep;
-
-pub async fn wait_for_job_with_info(
-    connection: &mut ClientConnection,
-    job_info: JobInfo,
-) -> anyhow::Result<()> {
-    wait_for_jobs(connection, vec![job_info]).await
-}
-
-pub async fn wait_for_job_with_selector(
+pub async fn wait_for_jobs(
     connection: &mut ClientConnection,
     selector: Selector,
 ) -> anyhow::Result<()> {
+    let start = SystemTime::now();
     let response = rpc_call!(
         connection,
-        FromClientMessage::JobInfo(JobInfoRequest {
+        FromClientMessage::WaitForJobs(WaitForJobsRequest {
             selector,
         }),
-        ToClientMessage::JobInfoResponse(r) => r
+        ToClientMessage::WaitForJobsResponse(r) => r
     )
     .await?;
 
-    wait_for_jobs(connection, response.jobs).await
-}
+    let duration = start.elapsed()?;
 
-async fn wait_for_jobs(
-    connection: &mut ClientConnection,
-    mut jobs: Vec<JobInfo>,
-) -> anyhow::Result<()> {
-    jobs.retain(|info| !is_terminated(info));
+    let mut msgs = vec![];
 
-    if jobs.is_empty() {
-        log::warn!("There are no jobs to wait for");
-    } else {
-        let total_tasks: JobTaskCount = jobs.iter().map(|info| info.n_tasks).sum();
-        let mut remaining_job_ids: Set<JobId> = jobs.into_iter().map(|info| info.id).collect();
-
-        let total_jobs = remaining_job_ids.len();
-
-        log::info!(
-            "Waiting for {} job(s) with a {} task(s)",
-            total_jobs,
-            total_tasks
-        );
-
-        let mut counters = JobTaskCounters::default();
-
-        loop {
-            let ids_ref = &mut remaining_job_ids;
-            let response = rpc_call!(
-                connection,
-                FromClientMessage::JobInfo(JobInfoRequest {
-                    selector: Selector::Specific(IntArray::from_ids(ids_ref.iter().copied().collect())),
-                }),
-                ToClientMessage::JobInfoResponse(r) => r
-            )
-            .await?;
-
-            let mut current_counters = counters;
-            for job in &response.jobs {
-                current_counters = current_counters + job.counters;
-
-                if is_terminated(job) {
-                    remaining_job_ids.remove(&job.id);
-                    counters = counters + job.counters;
-                }
-            }
-
-            let completed_jobs = total_jobs - remaining_job_ids.len();
-            let completed_tasks = current_counters.n_finished_tasks
-                + current_counters.n_canceled_tasks
-                + current_counters.n_failed_tasks;
-
-            let mut statuses = vec![];
-            let mut add_count = |count, name: &str, color| {
-                if count > 0 {
-                    statuses.push(format!("{} {}", count, name.to_string().color(color)));
-                }
-            };
-            add_count(
-                current_counters.n_running_tasks,
-                "RUNNING",
-                TASK_COLOR_RUNNING,
-            );
-            add_count(
-                current_counters.n_finished_tasks,
-                "FINISHED",
-                TASK_COLOR_FINISHED,
-            );
-            add_count(current_counters.n_failed_tasks, "FAILED", TASK_COLOR_FAILED);
-            add_count(
-                current_counters.n_canceled_tasks,
-                "CANCELED",
-                TASK_COLOR_CANCELED,
-            );
-            let status = if !statuses.is_empty() {
-                format!("({})", statuses.join(", "))
-            } else {
-                "".to_string()
-            };
-
-            // \x1b[2K clears the line
-            print!(
-                "\r\x1b[2K{} {}/{} jobs, {}/{} tasks {}",
-                job_progress_bar(current_counters, total_tasks, 40),
-                completed_jobs,
-                total_jobs,
-                completed_tasks,
-                total_tasks,
-                status
-            );
-            std::io::stdout().flush().unwrap();
-
-            if remaining_job_ids.is_empty() {
-                // Move the cursor to a new line
-                println!();
-                break;
-            }
-            sleep(Duration::from_secs(1)).await;
+    let mut format = |count: u32, action: &str| {
+        if count > 0 {
+            let job = if count == 1 { "job" } else { "jobs" };
+            msgs.push(format!("{} {} {}", count, job, action));
         }
+    };
 
-        if counters.n_failed_tasks > 0 {
-            bail!("Some jobs have failed");
-        }
-        if counters.n_canceled_tasks > 0 {
-            bail!("Some jobs were canceled");
-        }
+    format(response.finished, "finished");
+    format(response.failed, "failed");
+    format(response.skipped, "skipped");
+    format(response.invalid, "invalid");
+
+    log::info!(
+        "Wait finished in {}: {}",
+        humantime::format_duration(duration),
+        msgs.join(", ")
+    );
+
+    if response.failed > 0 {
+        return Err(anyhow::anyhow!(
+            "Some jobs have failed or have been canceled"
+        ));
     }
+
     Ok(())
 }

--- a/src/common/arraydef.rs
+++ b/src/common/arraydef.rs
@@ -44,6 +44,9 @@ impl IntArray {
         }
         IntArray { ranges }
     }
+    pub fn from_id(id: u32) -> IntArray {
+        Self::from_ids(vec![id])
+    }
 
     pub fn from_range(start: u32, count: u32) -> Self {
         IntArray {

--- a/src/server/job.rs
+++ b/src/server/job.rs
@@ -113,9 +113,7 @@ pub struct Job {
     pub submission_date: DateTime<Utc>,
     pub completion_date: Option<DateTime<Utc>>,
 
-    /// Holds channels that will receive information about the job task counters after the job
-    /// finishes in any way.
-    ///
+    /// Holds channels that will receive information about the job after the it finishes in any way.
     /// You can subscribe to the completion message with [`Self::subscribe_to_completion`].
     completion_callbacks: Vec<oneshot::Sender<JobId>>,
 }

--- a/src/transfer/messages.rs
+++ b/src/transfer/messages.rs
@@ -27,6 +27,7 @@ pub enum FromClientMessage {
     StopWorker(StopWorkerMessage),
     Stop,
     AutoAlloc(AutoAllocRequest),
+    WaitForJobs(WaitForJobsRequest),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -119,6 +120,11 @@ pub struct AddQueueParams {
     pub timelimit: Option<Duration>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct WaitForJobsRequest {
+    pub selector: Selector,
+}
+
 // Messages server -> client
 #[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug)]
@@ -132,6 +138,7 @@ pub enum ToClientMessage {
     StopWorkerResponse(Vec<(WorkerId, StopWorkerResponse)>),
     CancelJobResponse(Vec<(JobId, CancelJobResponse)>),
     AutoAllocResponse(AutoAllocResponse),
+    WaitForJobsResponse(WaitForJobsResponse),
     Error(String),
 }
 
@@ -260,4 +267,12 @@ pub struct AutoAllocInfoResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct QueueDescriptorData {
     pub info: QueueInfo,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct WaitForJobsResponse {
+    pub finished: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    pub invalid: u32,
 }

--- a/src/transfer/messages.rs
+++ b/src/transfer/messages.rs
@@ -273,6 +273,6 @@ pub struct QueueDescriptorData {
 pub struct WaitForJobsResponse {
     pub finished: u32,
     pub failed: u32,
-    pub skipped: u32,
+    pub canceled: u32,
     pub invalid: u32,
 }

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -633,7 +633,7 @@ def test_job_wait(hq_env: HqEnv):
     table.check_value_row("State", "FINISHED")
 
     r = hq_env.command(["wait", "all"])
-    assert "1 job skipped" in r
+    assert "1 job finished" in r
 
 
 def test_job_submit_wait(hq_env: HqEnv):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -627,20 +627,20 @@ def test_job_wait(hq_env: HqEnv):
     hq_env.start_worker()
     hq_env.command(["submit", "sleep", "1"])
     r = hq_env.command(["wait", "1"])
-    assert "Waiting for 1 job(s)" in r
+    assert "1 job finished" in r
 
     table = hq_env.command(["job", "1"], as_table=True)
     table.check_value_row("State", "FINISHED")
 
     r = hq_env.command(["wait", "all"])
-    assert "There are no jobs to wait for" in r
+    assert "1 job skipped" in r
 
 
 def test_job_submit_wait(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.start_worker()
     r = hq_env.command(["submit", "sleep", "1", "--wait"])
-    assert "Waiting for 1 job(s)" in r
+    assert "1 job finished" in r
 
     table = hq_env.command(["job", "1"], as_table=True)
     table.check_value_row("State", "FINISHED")


### PR DESCRIPTION
Previously, waiting simply polled the server once every second, which meant that it couldn't be used for benchmarking short jobs because of the added polling pauses.

Now waiting connects to the server, waits until the jobs are finished, and then ends immediately.

A disadvantage is that the interactive progress bar is no longer shown. But it can be emulated with `watch hq job <job-id>`. If needed, the progress bar could be moved to another command (`hq wait --interactive` or something like that).

This should unblock https://github.com/It4innovations/hyperqueue/issues/104