### PR TITLE
WIP: Overview Streaming

### DIFF
--- a/src/stream/server/control.rs
+++ b/src/stream/server/control.rs
@@ -1,6 +1,7 @@
 use crate::transfer::messages::StreamStats;
 use crate::JobId;
 use std::path::PathBuf;
+use tako::messages::gateway::CollectedOverview;
 use tako::server::rpc::ConnectionDescriptor;
 use tokio::sync::oneshot;
 
@@ -13,4 +14,5 @@ pub enum StreamServerControlMessage {
     UnregisterStream(JobId),
     AddConnection(ConnectionDescriptor),
     Stats(oneshot::Sender<StreamStats>),
+    StreamHwOverview(CollectedOverview),
 }

--- a/src/transfer/stream.rs
+++ b/src/transfer/stream.rs
@@ -1,6 +1,7 @@
 use crate::{JobId, JobTaskId};
 use serde::Deserialize;
 use serde::Serialize;
+use tako::messages::gateway::CollectedOverview;
 use tako::InstanceId;
 
 pub type ChannelId = u32;
@@ -30,11 +31,13 @@ pub struct EndTaskStreamMsg {
     pub instance: InstanceId,
 }
 
+/// To Stream Server
 #[derive(Serialize, Deserialize, Debug)]
 pub enum FromStreamerMessage {
     Start(StartTaskStreamMsg),
     Data(DataMsg),
     End(EndTaskStreamMsg),
+    WorkerHwOverview(CollectedOverview),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -42,6 +45,7 @@ pub struct EndTaskStreamResponseMsg {
     pub task: JobTaskId,
 }
 
+/// From Stream Server
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ToStreamerMessage {
     Error(String),


### PR DESCRIPTION
The PR is to add a feature that allows the hq server to poll for hardware overview and stream it to a file for storage. 
It uses Streaming and modifies it to accept the overview message from the hq server and then persist it to file.

Later the stored data can be used to provide post mortem analysis on the dashboard.