### PR TITLE
Slurm auto allocation

### DIFF
--- a/src/common/manager/common.rs
+++ b/src/common/manager/common.rs
@@ -1,0 +1,25 @@
+use std::time::Duration;
+
+/// Format a duration as a PBS/Slurm time string, e.g. 01:05:02
+pub(super) fn format_duration(duration: &Duration) -> String {
+    let mut seconds = duration.as_secs();
+    let hours = seconds / 3600;
+    seconds %= 3600;
+    let minutes = seconds / 60;
+    seconds %= 60;
+    format!("{:02}:{:02}:{:02}", hours, minutes, seconds)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::common::manager::common::format_duration;
+    use std::time::Duration;
+
+    #[test]
+    fn test_format_duration() {
+        assert_eq!(format_duration(&Duration::from_secs(0)), "00:00:00");
+        assert_eq!(format_duration(&Duration::from_secs(1)), "00:00:01");
+        assert_eq!(format_duration(&Duration::from_secs(61)), "00:01:01");
+        assert_eq!(format_duration(&Duration::from_secs(3661)), "01:01:01");
+    }
+}

--- a/src/common/manager/mod.rs
+++ b/src/common/manager/mod.rs
@@ -1,2 +1,4 @@
+mod common;
 pub mod info;
 pub mod pbs;
+pub mod slurm;

--- a/src/common/manager/pbs.rs
+++ b/src/common/manager/pbs.rs
@@ -1,11 +1,14 @@
-use crate::common::env::HQ_QSTAT_PATH;
-use anyhow::Context;
-use chrono::Duration as ChronoDuration;
-use serde_json::Value;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str;
 use std::time::Duration;
+
+use anyhow::Context;
+use chrono::Duration as ChronoDuration;
+use serde_json::Value;
+
+use crate::common::env::HQ_QSTAT_PATH;
+use crate::common::manager::common::format_duration;
 
 pub struct PbsContext {
     pub qstat_path: PathBuf,
@@ -82,12 +85,7 @@ pub fn get_remaining_timelimit(ctx: &PbsContext, job_id: &str) -> anyhow::Result
 
 /// Format a duration as a PBS time string, e.g. 01:05:02
 pub fn format_pbs_duration(duration: &Duration) -> String {
-    let mut seconds = duration.as_secs();
-    let hours = seconds / 3600;
-    seconds %= 3600;
-    let minutes = seconds / 60;
-    seconds %= 60;
-    format!("{:02}:{:02}:{:02}", hours, minutes, seconds)
+    format_duration(duration)
 }
 
 pub fn parse_pbs_datetime(datetime: &str) -> anyhow::Result<chrono::NaiveDateTime> {
@@ -99,16 +97,7 @@ pub fn parse_pbs_datetime(datetime: &str) -> anyhow::Result<chrono::NaiveDateTim
 
 #[cfg(test)]
 mod test {
-    use crate::common::manager::pbs::{format_pbs_duration, parse_pbs_datetime};
-    use std::time::Duration;
-
-    #[test]
-    fn test_format_pbs_duration() {
-        assert_eq!(format_pbs_duration(&Duration::from_secs(0)), "00:00:00");
-        assert_eq!(format_pbs_duration(&Duration::from_secs(1)), "00:00:01");
-        assert_eq!(format_pbs_duration(&Duration::from_secs(61)), "00:01:01");
-        assert_eq!(format_pbs_duration(&Duration::from_secs(3661)), "01:01:01");
-    }
+    use crate::common::manager::pbs::parse_pbs_datetime;
 
     #[test]
     fn test_parse_pbs_datetime() {

--- a/src/common/manager/slurm.rs
+++ b/src/common/manager/slurm.rs
@@ -1,0 +1,28 @@
+use crate::common::manager::common::format_duration;
+use std::time::Duration;
+
+/// Format a duration as a SLURM time string, e.g. 01:05:02
+pub fn format_slurm_duration(duration: &Duration) -> String {
+    format_duration(duration)
+}
+
+pub fn parse_slurm_datetime(datetime: &str) -> anyhow::Result<chrono::NaiveDateTime> {
+    Ok(chrono::NaiveDateTime::parse_from_str(
+        datetime,
+        "%Y-%m-%dT%H:%M:%S",
+    )?)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::common::manager::slurm::parse_slurm_datetime;
+
+    #[test]
+    fn test_parse_slurm_datetime() {
+        let date = parse_slurm_datetime("2021-09-29T09:36:56").unwrap();
+        assert_eq!(
+            date.format("%d.%m.%Y %H:%M:%S").to_string(),
+            "29.09.2021 09:36:56"
+        );
+    }
+}

--- a/src/server/autoalloc/descriptor/common.rs
+++ b/src/server/autoalloc/descriptor/common.rs
@@ -1,0 +1,31 @@
+use bstr::ByteSlice;
+use std::path::PathBuf;
+use std::process::Output;
+
+use crate::server::autoalloc::AutoAllocResult;
+
+pub fn create_allocation_dir(
+    server_directory: PathBuf,
+    name: &str,
+) -> Result<PathBuf, std::io::Error> {
+    let mut dir = server_directory;
+    dir.push("autoalloc");
+    dir.push(name);
+
+    std::fs::create_dir_all(&dir)?;
+
+    Ok(tempdir::TempDir::new_in(dir, "allocation")?.into_path())
+}
+
+pub fn check_command_output(output: Output) -> AutoAllocResult<Output> {
+    let status = output.status;
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "Exit code {}\nstderr: {}\nstdout: {}",
+            status.code().unwrap(),
+            output.stderr.to_str().unwrap(),
+            output.stdout.to_str().unwrap()
+        ));
+    }
+    Ok(output)
+}

--- a/src/server/autoalloc/descriptor/mod.rs
+++ b/src/server/autoalloc/descriptor/mod.rs
@@ -1,4 +1,6 @@
+mod common;
 pub mod pbs;
+pub mod slurm;
 
 use crate::common::manager::info::ManagerType;
 use crate::server::autoalloc::state::{AllocationId, AllocationStatus};

--- a/src/server/autoalloc/descriptor/mod.rs
+++ b/src/server/autoalloc/descriptor/mod.rs
@@ -2,7 +2,7 @@ pub mod pbs;
 
 use crate::common::manager::info::ManagerType;
 use crate::server::autoalloc::state::{AllocationId, AllocationStatus};
-use crate::server::autoalloc::AutoAllocResult;
+use crate::server::autoalloc::{AutoAllocResult, DescriptorId};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -84,6 +84,7 @@ impl QueueInfo {
     }
 }
 
+#[derive(Debug)]
 pub struct CreatedAllocation {
     id: AllocationId,
     working_dir: PathBuf,
@@ -105,9 +106,10 @@ impl CreatedAllocation {
 /// Handler that can communicate with some allocation queue (e.g. PBS/Slurm queue)
 pub trait QueueHandler {
     /// Schedule an allocation that will start the corresponding number of workers.
-    /// Returns the string ID of the created allocation.
     fn schedule_allocation(
         &self,
+        descriptor_id: DescriptorId,
+        queue_info: &QueueInfo,
         worker_count: u64,
     ) -> Pin<Box<dyn Future<Output = AutoAllocResult<CreatedAllocation>>>>;
 

--- a/src/server/autoalloc/descriptor/pbs.rs
+++ b/src/server/autoalloc/descriptor/pbs.rs
@@ -1,11 +1,9 @@
-use std::time::Duration;
-
 use crate::common::env::HQ_QSTAT_PATH;
 use crate::common::manager::pbs::{format_pbs_duration, parse_pbs_datetime};
 use crate::common::timeutils::local_to_system_time;
 use crate::server::autoalloc::descriptor::{CreatedAllocation, QueueHandler};
 use crate::server::autoalloc::state::{AllocationId, AllocationStatus};
-use crate::server::autoalloc::{AutoAllocResult, DescriptorId};
+use crate::server::autoalloc::{AutoAllocResult, DescriptorId, QueueInfo};
 use anyhow::Context;
 use bstr::{ByteSlice, ByteVec};
 use std::future::Future;
@@ -15,34 +13,21 @@ use std::process::Output;
 use tokio::process::Command;
 
 pub struct PbsHandler {
-    // TODO: pass as queue info in trait
-    queue: String,
-    timelimit: Option<Duration>,
     server_directory: PathBuf,
-    id: DescriptorId,
     hq_path: PathBuf,
     qstat_path: PathBuf,
     qsub_args: Vec<String>,
 }
 
 impl PbsHandler {
-    pub async fn new(
-        queue: String,
-        timelimit: Option<Duration>,
-        id: DescriptorId,
-        server_directory: PathBuf,
-        qsub_args: Vec<String>,
-    ) -> anyhow::Result<Self> {
+    pub async fn new(server_directory: PathBuf, qsub_args: Vec<String>) -> anyhow::Result<Self> {
         let hq_path = std::env::current_exe().context("Cannot get HyperQueue path")?;
         let qstat_path = check_command_output(Command::new("which").arg("qstat").output().await?)
             .context("Cannot get qstat path")?
             .stdout
             .into_path_buf_lossy();
         Ok(Self {
-            queue,
-            timelimit,
             server_directory,
-            id,
             hq_path,
             qstat_path,
             qsub_args,
@@ -63,14 +48,16 @@ fn create_allocation_dir(server_directory: PathBuf, name: &str) -> Result<PathBu
 impl QueueHandler for PbsHandler {
     fn schedule_allocation(
         &self,
+        descriptor_id: DescriptorId,
+        queue_info: &QueueInfo,
         worker_count: u64,
     ) -> Pin<Box<dyn Future<Output = AutoAllocResult<CreatedAllocation>>>> {
-        let queue = self.queue.clone();
-        let timelimit = self.timelimit;
+        let queue = queue_info.queue.clone();
+        let timelimit = queue_info.timelimit;
         let hq_path = self.hq_path.display().to_string();
         let qstat_path = self.qstat_path.display().to_string();
         let server_directory = self.server_directory.clone();
-        let name = self.id.to_string();
+        let name = descriptor_id.to_string();
         let qsub_args = self.qsub_args.clone();
 
         Box::pin(async move {

--- a/src/server/autoalloc/descriptor/slurm.rs
+++ b/src/server/autoalloc/descriptor/slurm.rs
@@ -1,0 +1,209 @@
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::time::SystemTime;
+
+use anyhow::Context;
+use bstr::ByteSlice;
+use tokio::process::Command;
+
+use crate::common::manager::slurm::{format_slurm_duration, parse_slurm_datetime};
+use crate::common::timeutils::local_to_system_time;
+use crate::server::autoalloc::descriptor::{common, CreatedAllocation, QueueHandler};
+use crate::server::autoalloc::state::{AllocationId, AllocationStatus};
+use crate::server::autoalloc::{AutoAllocResult, DescriptorId, QueueInfo};
+use crate::Map;
+
+pub struct SlurmHandler {
+    server_directory: PathBuf,
+    hq_path: PathBuf,
+    sbatch_args: Vec<String>,
+}
+
+impl SlurmHandler {
+    pub async fn new(server_directory: PathBuf, sbatch_args: Vec<String>) -> anyhow::Result<Self> {
+        let hq_path = std::env::current_exe().context("Cannot get HyperQueue path")?;
+        Ok(Self {
+            server_directory,
+            hq_path,
+            sbatch_args,
+        })
+    }
+}
+
+impl QueueHandler for SlurmHandler {
+    fn schedule_allocation(
+        &self,
+        descriptor_id: DescriptorId,
+        queue_info: &QueueInfo,
+        worker_count: u64,
+    ) -> Pin<Box<dyn Future<Output = AutoAllocResult<CreatedAllocation>>>> {
+        let partition = queue_info.queue.clone();
+        let timelimit = queue_info.timelimit;
+        let hq_path = self.hq_path.display().to_string();
+        let server_directory = self.server_directory.clone();
+        let name = descriptor_id.to_string();
+        let sbatch_args = self.sbatch_args.clone();
+
+        Box::pin(async move {
+            let directory = common::create_allocation_dir(server_directory.clone(), &name)?;
+
+            let mut arguments = vec![
+                "sbatch".to_string(),
+                "--partition".to_string(),
+                partition,
+                "--output".to_string(),
+                directory.join("stdout").display().to_string(),
+                "--error".to_string(),
+                directory.join("stderr").display().to_string(),
+                format!("--nodes={}", worker_count),
+            ];
+
+            if let Some(ref timelimit) = timelimit {
+                arguments.push(format!("--time={}", format_slurm_duration(timelimit)));
+            }
+
+            arguments.extend(sbatch_args);
+
+            // TODO: unify somehow with PBS
+            // `hq worker` arguments
+            let worker_args = vec![
+                hq_path,
+                "worker".to_string(),
+                "start".to_string(),
+                "--idle-timeout".to_string(),
+                "10m".to_string(),
+                "--manager".to_string(),
+                "slurm".to_string(),
+                "--server-dir".to_string(),
+                server_directory.display().to_string(),
+            ];
+            arguments.extend(["--wrap".to_string(), worker_args.join(" ")]);
+
+            log::debug!("Running Slurm command `{}`", arguments.join(" "));
+            let mut command = Command::new(&arguments[0]);
+            command.args(&arguments[1..]);
+
+            let output = command.output().await.context("sbatch start failed")?;
+            let output = common::check_command_output(output).context("sbatch execution failed")?;
+
+            let output = output
+                .stdout
+                .to_str()
+                .map_err(|e| anyhow::anyhow!("Invalid UTF-8 qsub output: {:?}", e))?
+                .trim();
+            let job_id = output
+                .split(' ')
+                .skip(3)
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("Missing job id in sbatch output"))?;
+
+            let job_id = job_id.to_string();
+
+            // Write the Slurm job id to the folder as a debug information
+            std::fs::write(directory.join("jobid"), &job_id)?;
+
+            Ok(CreatedAllocation {
+                id: job_id,
+                working_dir: directory,
+            })
+        })
+    }
+
+    fn get_allocation_status(
+        &self,
+        allocation_id: AllocationId,
+    ) -> Pin<Box<dyn Future<Output = AutoAllocResult<Option<AllocationStatus>>>>> {
+        Box::pin(async move {
+            let arguments = vec!["scontrol", "show", "job", &allocation_id];
+            log::debug!("Running Slurm command `{}`", arguments.join(" "));
+
+            let mut command = Command::new(arguments[0]);
+            command.args(&arguments[1..]);
+
+            let output = command.output().await.context("scontrol start failed")?;
+            let output =
+                common::check_command_output(output).context("scontrol execution failed")?;
+
+            let output = output
+                .stdout
+                .to_str()
+                .map_err(|err| anyhow::anyhow!("Invalid UTF-8 in scontrol output: {:?}", err))?;
+            let items = get_scontrol_items(output);
+
+            let get_key = |key: &str| -> AutoAllocResult<&str> {
+                let value = items.get(key);
+                value
+                    .ok_or_else(|| anyhow::anyhow!("Missing key {} in Slurm scontrol output", key))
+                    .map(|v| *v)
+            };
+            let parse_time = |time: &str| -> AutoAllocResult<SystemTime> {
+                Ok(local_to_system_time(parse_slurm_datetime(time).map_err(
+                    |err| anyhow::anyhow!("Cannot parse Slurm datetime {}: {:?}", time, err),
+                )?))
+            };
+
+            let status = get_key("JobState")?;
+            let status = match status {
+                "PENDING" | "CONFIGURING" => AllocationStatus::Queued,
+                "RUNNING" => {
+                    let started_at = parse_time(get_key("StartTime")?)?;
+                    AllocationStatus::Running { started_at }
+                }
+                "COMPLETED" | "CANCELLED" | "FAILED" | "TIMEOUT" => {
+                    let finished = matches!(status, "COMPLETED" | "TIMEOUT");
+                    let started_at = parse_time(get_key("StartTime")?)?;
+                    let finished_at = parse_time(get_key("EndTime")?)?;
+
+                    if finished {
+                        AllocationStatus::Finished {
+                            started_at,
+                            finished_at,
+                        }
+                    } else {
+                        AllocationStatus::Failed {
+                            started_at,
+                            finished_at,
+                        }
+                    }
+                }
+                _ => anyhow::bail!("Unknown Slurm job status {}", status),
+            };
+
+            Ok(Some(status))
+        })
+    }
+
+    fn remove_allocation(
+        &self,
+        allocation_id: AllocationId,
+    ) -> Pin<Box<dyn Future<Output = AutoAllocResult<()>>>> {
+        Box::pin(async move {
+            let arguments = vec!["scancel", &allocation_id];
+            log::debug!("Running Slurm command `{}`", arguments.join(" "));
+            let mut command = Command::new(&arguments[0]);
+            command.args(&arguments[1..]);
+
+            let output = command.output().await?;
+            common::check_command_output(output)?;
+            Ok(())
+        })
+    }
+}
+
+/// Parse <key>=<value> pairs from the output of `scontrol show job <job-id>`.
+fn get_scontrol_items(output: &str) -> Map<&str, &str> {
+    let mut map = Map::new();
+    for line in output.lines() {
+        for item in line.trim().split(' ') {
+            let iter: Vec<_> = item.split('=').take(2).collect();
+            if iter.len() < 2 {
+                continue;
+            }
+            let (key, value) = (iter[0], iter[1]);
+            map.insert(key, value);
+        }
+    }
+
+    map
+}

--- a/src/server/autoalloc/mod.rs
+++ b/src/server/autoalloc/mod.rs
@@ -14,7 +14,8 @@ mod state;
 pub type AutoAllocResult<T> = anyhow::Result<T>;
 
 pub use descriptor::pbs::PbsHandler;
-pub use descriptor::{QueueDescriptor, QueueInfo};
+pub use descriptor::slurm::SlurmHandler;
+pub use descriptor::{QueueDescriptor, QueueHandler, QueueInfo};
 pub use state::{
     Allocation, AllocationEvent, AllocationEventHolder, AllocationStatus, DescriptorId,
 };

--- a/src/server/autoalloc/process.rs
+++ b/src/server/autoalloc/process.rs
@@ -178,10 +178,16 @@ async fn schedule_new_allocations(id: DescriptorId, state_ref: &StateRef) {
     };
     while remaining > 0 {
         let to_schedule = std::cmp::min(remaining, max_workers_per_alloc);
-        let schedule_fut = get_or_return!(state_ref.get().get_autoalloc_state().get_descriptor(id))
-            .descriptor
-            .handler()
-            .schedule_allocation(to_schedule);
+
+        let schedule_fut = {
+            let state = state_ref.get();
+            let descriptor = get_or_return!(state.get_autoalloc_state().get_descriptor(id));
+            let info = descriptor.descriptor.info();
+            descriptor
+                .descriptor
+                .handler()
+                .schedule_allocation(id, info, to_schedule)
+        };
 
         let result = schedule_fut.await;
 

--- a/src/server/autoalloc/process.rs
+++ b/src/server/autoalloc/process.rs
@@ -230,7 +230,7 @@ mod tests {
     };
     use crate::server::autoalloc::process::autoalloc_tick;
     use crate::server::autoalloc::state::{AllocationEvent, AllocationId, AllocationStatus};
-    use crate::server::autoalloc::AutoAllocResult;
+    use crate::server::autoalloc::{AutoAllocResult, DescriptorId};
     use crate::server::state::StateRef;
     use std::pin::Pin;
 
@@ -396,6 +396,8 @@ mod tests {
     {
         fn schedule_allocation(
             &self,
+            _descriptor_id: DescriptorId,
+            _queue_info: &QueueInfo,
             worker_count: u64,
         ) -> Pin<Box<dyn Future<Output = AutoAllocResult<CreatedAllocation>>>> {
             let schedule_fn = self.schedule_fn.clone();

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -258,21 +258,14 @@ async fn create_queue(
     let result = match request {
         AddQueueRequest::Pbs(params) => {
             let queue_info = QueueInfo::new(
-                params.queue.clone(),
+                params.queue,
                 params.max_workers_per_alloc,
                 params.target_worker_count,
                 params.timelimit,
             );
 
-            let id = state_ref.get_mut().get_autoalloc_state_mut().create_id();
-            let handler = PbsHandler::new(
-                params.queue,
-                params.timelimit,
-                id,
-                server_dir.directory().to_path_buf(),
-                params.qsub_args,
-            )
-            .await;
+            let handler =
+                PbsHandler::new(server_dir.directory().to_path_buf(), params.qsub_args).await;
             match handler {
                 Ok(handler) => {
                     let descriptor = QueueDescriptor::new(
@@ -281,6 +274,7 @@ async fn create_queue(
                         params.name,
                         Box::new(handler),
                     );
+                    let id = state_ref.get_mut().get_autoalloc_state_mut().create_id();
 
                     state_ref
                         .get_mut()

--- a/src/transfer/messages.rs
+++ b/src/transfer/messages.rs
@@ -110,6 +110,7 @@ pub enum AutoAllocRequest {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum AddQueueRequest {
     Pbs(AddQueueParams),
+    Slurm(AddQueueParams),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -119,7 +120,7 @@ pub struct AddQueueParams {
     pub queue: String,
     pub timelimit: Option<Duration>,
     pub name: Option<String>,
-    pub qsub_args: Vec<String>,
+    pub additional_args: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Adds a new `QueueHandler` that can schedule Slurm allocations. Some code could be unified with PBS and more tests could be added in the future.

Fixes: https://github.com/It4innovations/hyperqueue/issues/129