### PR TITLE
Added command to remove allocation queue

### DIFF
--- a/src/server/autoalloc/state.rs
+++ b/src/server/autoalloc/state.rs
@@ -39,6 +39,9 @@ impl AutoAllocState {
     pub fn add_descriptor(&mut self, id: DescriptorId, descriptor: QueueDescriptor) {
         assert!(self.descriptors.insert(id, descriptor.into()).is_none());
     }
+    pub fn remove_descriptor(&mut self, id: DescriptorId) {
+        assert!(self.descriptors.remove(&id).is_some());
+    }
 
     pub fn get_descriptor(&self, key: DescriptorId) -> Option<&DescriptorState> {
         self.descriptors.get(&key)

--- a/src/transfer/messages.rs
+++ b/src/transfer/messages.rs
@@ -107,6 +107,7 @@ pub enum AutoAllocRequest {
     Events { descriptor: DescriptorId },
     Info { descriptor: DescriptorId },
     AddQueue(AddQueueRequest),
+    RemoveQueue(DescriptorId),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -259,6 +260,7 @@ pub struct WorkerInfoResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum AutoAllocResponse {
     QueueCreated(DescriptorId),
+    QueueRemoved(DescriptorId),
     Events(Vec<AllocationEventHolder>),
     Info(Vec<Allocation>),
     List(AutoAllocListResponse),


### PR DESCRIPTION
PR to the command: hq alloc remove <queue_descriptor_id>

Removes all the allocations for a queue and then deletes the queue descriptor.

Closes: https://github.com/It4innovations/hyperqueue/issues/145