### PR TITLE
Add interactive waiting for job with progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 ## Changes
   * Job id is now represented as u32
   * Normalization of stream's end behavior when job is canceled
-
+  * `hq submit --wait` and `hq wait` will no longer display a progress bar while waiting for the job(s) to finish.
+  The progress bar was moved to `hq submit --progress` and `hq progress`.
 
 # v0.4.0
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -201,7 +201,10 @@ A job cannot be canceled if it is already finished, failed, or canceled.
 
 You can submit a job with flag ``--wait`` and HQ will wait until the submitted job is not terminated (until all tasks are either finished, failed or canceled).
 
-You can also use ``hq wait <job_id>`` to wait for a specific job or ``hq wait last`` to wait for the last submitted job or ``hq wait all`` to wait for all jobs.
+You can also use ``hq wait <job-id>`` to wait for a specific job or ``hq wait last`` to wait for the last submitted job or ``hq wait all`` to wait for all jobs.
+
+If you want to interactively observe the status of the jobs while waiting for them to finish, use `hq submit --progress`
+or `hq progress <job-id>` instead.
 
 
 ## Priorities

--- a/src/client/commands/submit.rs
+++ b/src/client/commands/submit.rs
@@ -9,7 +9,7 @@ use clap::Clap;
 use tako::common::resources::{CpuRequest, ResourceRequest};
 use tako::messages::common::{ProgramDefinition, StdioDef};
 
-use crate::client::commands::wait::wait_for_jobs;
+use crate::client::commands::wait::{wait_for_jobs, wait_for_jobs_with_progress};
 use crate::client::globalsettings::GlobalSettings;
 use crate::client::job::get_worker_map;
 use crate::client::resources::parse_cpu_request;
@@ -147,9 +147,13 @@ pub struct SubmitOpts {
     /// Time limit per task. E.g. --time-limit=10min
     time_limit: Option<ArgDuration>,
 
-    /// Wait on the job(s) execution.
-    #[clap(long)]
+    /// Wait for the job to finish.
+    #[clap(long, conflicts_with("progress"))]
     wait: bool,
+
+    /// Interactively observe the progress of the submitted job.
+    #[clap(long, conflicts_with("wait"))]
+    progress: bool,
 
     /// Stream the output of tasks into this log file.
     #[clap(long)]
@@ -269,6 +273,8 @@ pub async fn submit_computation(
             Selector::Specific(IntArray::from_id(info.id)),
         )
         .await?;
+    } else if opts.progress {
+        wait_for_jobs_with_progress(connection, vec![info]).await?;
     }
     Ok(())
 }

--- a/src/client/commands/wait.rs
+++ b/src/client/commands/wait.rs
@@ -1,9 +1,23 @@
-use std::time::SystemTime;
+use std::io::Write;
+use std::time::{Duration, SystemTime};
+use tokio::time::sleep;
 
 use crate::client::globalsettings::GlobalSettings;
-use crate::rpc_call;
+use crate::client::output::cli::{
+    job_progress_bar, TASK_COLOR_CANCELED, TASK_COLOR_FAILED, TASK_COLOR_FINISHED,
+    TASK_COLOR_RUNNING,
+};
+use crate::client::status::is_terminated;
+use crate::common::arraydef::IntArray;
+use crate::common::strutils::pluralize;
+use crate::server::job::JobTaskCounters;
 use crate::transfer::connection::ClientConnection;
-use crate::transfer::messages::{FromClientMessage, Selector, ToClientMessage, WaitForJobsRequest};
+use crate::transfer::messages::JobInfoRequest;
+use crate::transfer::messages::{
+    FromClientMessage, JobInfo, Selector, ToClientMessage, WaitForJobsRequest,
+};
+use crate::{rpc_call, JobId, JobTaskCount, Set};
+use colored::Colorize;
 
 pub async fn wait_for_jobs(
     gsettings: &GlobalSettings,
@@ -29,5 +43,113 @@ pub async fn wait_for_jobs(
         ));
     }
 
+    Ok(())
+}
+
+pub async fn wait_for_jobs_with_progress(
+    connection: &mut ClientConnection,
+    mut jobs: Vec<JobInfo>,
+) -> anyhow::Result<()> {
+    jobs.retain(|info| !is_terminated(info));
+
+    if jobs.is_empty() {
+        log::warn!("There are no jobs to wait for");
+    } else {
+        let total_tasks: JobTaskCount = jobs.iter().map(|info| info.n_tasks).sum();
+        let mut remaining_job_ids: Set<JobId> = jobs.into_iter().map(|info| info.id).collect();
+
+        let total_jobs = remaining_job_ids.len();
+
+        log::info!(
+            "Waiting for {} {} with {} {}",
+            total_jobs,
+            pluralize("job", total_jobs),
+            total_tasks,
+            pluralize("task", total_tasks as usize),
+        );
+
+        let mut counters = JobTaskCounters::default();
+
+        loop {
+            let ids_ref = &mut remaining_job_ids;
+            let response = rpc_call!(
+                connection,
+                FromClientMessage::JobInfo(JobInfoRequest {
+                    selector: Selector::Specific(IntArray::from_ids(ids_ref.iter().copied().collect())),
+                }),
+                ToClientMessage::JobInfoResponse(r) => r
+            )
+                .await?;
+
+            let mut current_counters = counters;
+            for job in &response.jobs {
+                current_counters = current_counters + job.counters;
+
+                if is_terminated(job) {
+                    remaining_job_ids.remove(&job.id);
+                    counters = counters + job.counters;
+                }
+            }
+
+            let completed_jobs = total_jobs - remaining_job_ids.len();
+            let completed_tasks = current_counters.n_finished_tasks
+                + current_counters.n_canceled_tasks
+                + current_counters.n_failed_tasks;
+
+            let mut statuses = vec![];
+            let mut add_count = |count, name: &str, color| {
+                if count > 0 {
+                    statuses.push(format!("{} {}", count, name.to_string().color(color)));
+                }
+            };
+            add_count(
+                current_counters.n_running_tasks,
+                "RUNNING",
+                TASK_COLOR_RUNNING,
+            );
+            add_count(
+                current_counters.n_finished_tasks,
+                "FINISHED",
+                TASK_COLOR_FINISHED,
+            );
+            add_count(current_counters.n_failed_tasks, "FAILED", TASK_COLOR_FAILED);
+            add_count(
+                current_counters.n_canceled_tasks,
+                "CANCELED",
+                TASK_COLOR_CANCELED,
+            );
+            let status = if !statuses.is_empty() {
+                format!("({})", statuses.join(", "))
+            } else {
+                "".to_string()
+            };
+
+            // \x1b[2K clears the line
+            print!(
+                "\r\x1b[2K{} {}/{} jobs, {}/{} tasks {}",
+                job_progress_bar(current_counters, total_tasks, 40),
+                completed_jobs,
+                total_jobs,
+                completed_tasks,
+                total_tasks,
+                status
+            );
+            std::io::stdout().flush().unwrap();
+
+            if remaining_job_ids.is_empty() {
+                // Move the cursor to a new line
+                println!();
+                break;
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+
+        if counters.n_failed_tasks > 0 {
+            anyhow::bail!("Some jobs have failed");
+        }
+        if counters.n_canceled_tasks > 0 {
+            anyhow::bail!("Some jobs were canceled");
+        }
+    }
     Ok(())
 }

--- a/src/client/output/cli.rs
+++ b/src/client/output/cli.rs
@@ -32,15 +32,16 @@ use std::time::SystemTime;
 use tako::common::resources::ResourceDescriptor;
 use tako::messages::common::{StdioDef, WorkerConfiguration};
 
+use crate::common::strutils::pluralize;
 use colored::Color as Colorization;
 use colored::Colorize;
 use std::collections::BTreeSet;
 
-const TASK_COLOR_CANCELED: Colorization = Colorization::Magenta;
-const TASK_COLOR_FAILED: Colorization = Colorization::Red;
-const TASK_COLOR_FINISHED: Colorization = Colorization::Green;
-const TASK_COLOR_RUNNING: Colorization = Colorization::Yellow;
-const TASK_COLOR_INVALID: Colorization = Colorization::BrightRed;
+pub const TASK_COLOR_CANCELED: Colorization = Colorization::Magenta;
+pub const TASK_COLOR_FAILED: Colorization = Colorization::Red;
+pub const TASK_COLOR_FINISHED: Colorization = Colorization::Green;
+pub const TASK_COLOR_RUNNING: Colorization = Colorization::Yellow;
+pub const TASK_COLOR_INVALID: Colorization = Colorization::BrightRed;
 
 pub struct CliOutput {
     color_policy: ColorChoice,
@@ -444,7 +445,7 @@ impl Output for CliOutput {
 
         let mut format = |count: u32, action: &str, color| {
             if count > 0 {
-                let job = if count == 1 { "job" } else { "jobs" };
+                let job = pluralize("job", count as usize);
                 msgs.push(
                     format!("{} {} {}", count, job, action)
                         .color(color)
@@ -740,7 +741,11 @@ fn job_status_to_cell(info: &JobInfo) -> String {
     result
 }
 
-fn job_progress_bar(counters: JobTaskCounters, n_tasks: JobTaskCount, width: usize) -> String {
+pub(crate) fn job_progress_bar(
+    counters: JobTaskCounters,
+    n_tasks: JobTaskCount,
+    width: usize,
+) -> String {
     let mut buffer = String::from("[");
 
     let parts = vec![

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -12,5 +12,6 @@ pub mod parser;
 pub mod placeholders;
 pub mod serverdir;
 pub mod setup;
+pub mod strutils;
 pub mod timeutils;
 pub mod wrapped;

--- a/src/common/strutils.rs
+++ b/src/common/strutils.rs
@@ -1,0 +1,10 @@
+use std::borrow::Cow;
+
+/// Return the input string with an added "s" at the end if `count` is larger than one.
+pub fn pluralize(value: &str, count: usize) -> Cow<str> {
+    if count > 1 {
+        Cow::Owned(format!("{}s", value))
+    } else {
+        Cow::Borrowed(value)
+    }
+}


### PR DESCRIPTION
Adds `submit --progress` (mutually exclusive with `--wait`), and `hq progress` to interactively wait for job completion with a progress bar.

I didn't add tests nor support for quiet/JSON output, since it's supposed to be used only interactively.

The progress bar was removevd in https://github.com/It4innovations/hyperqueue/pull/136.

Fixes: https://github.com/It4innovations/hyperqueue/issues/151