### PR TITLE
Change default output path to `job-<job-id>/<task-id>.{stdout, stderr}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
   * Time limit for workers
   * Job and task times are shown in job information tables
   * Integers in command line options can be now written with an underscore separator (e.g. ``--array=1-1_000``)
-  * The default path of stdout and stderr has been changed to Storing tasks default stdout by new rule `` job-%{JOB_ID}/[stdout/stderr].%{TASK_ID}``
 
 ## Changes
   * Job id is now represented as u32
   * Normalization of stream's end behavior when job is canceled
   * `hq submit --wait` and `hq wait` will no longer display a progress bar while waiting for the job(s) to finish.
   The progress bar was moved to `hq submit --progress` and `hq progress`.
+  * The default path of job stdout and stderr has been changed to ``job-%{JOB_ID}/%{TASK_ID}.[stdout/stderr]``
 
 # v0.4.0
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -61,7 +61,7 @@ You can also disable creating stdout/stderr completely by setting value ``none``
 $ hq submit --stdout=none ...
 ```
 
-The default values for these paths are ``job-%{JOB_ID}/stdout.%{TASK_ID}`` and ``job-%{JOB_ID}/stderr.%{TASK_ID}``. You can read
+The default values for these paths are ``job-%{JOB_ID}/%{TASK_ID}.stdout`` and ``job-%{JOB_ID}/%{TASK_ID}.stderr``. You can read
 about the `%{JOB_ID}` and `%{TASK_ID}` placeholders [below](#placeholders).
 
 !!! Hint

--- a/src/client/commands/submit.rs
+++ b/src/client/commands/submit.rs
@@ -24,10 +24,22 @@ use crate::transfer::messages::{
 use crate::{rpc_call, JobId, JobTaskCount, Map};
 
 const SUBMIT_ARRAY_LIMIT: JobTaskCount = 999;
-const DEFAULT_STDOUT_PATH: &str =
-    const_format::concatcp!("job-", JOB_ID_PLACEHOLDER, "/stdout.", TASK_ID_PLACEHOLDER);
-const DEFAULT_STDERR_PATH: &str =
-    const_format::concatcp!("job-", JOB_ID_PLACEHOLDER, "/stderr.", TASK_ID_PLACEHOLDER);
+
+// Keep in sync with tests/util/job.py::default_task_output
+const DEFAULT_STDOUT_PATH: &str = const_format::concatcp!(
+    "job-",
+    JOB_ID_PLACEHOLDER,
+    "/",
+    TASK_ID_PLACEHOLDER,
+    ".stdout"
+);
+const DEFAULT_STDERR_PATH: &str = const_format::concatcp!(
+    "job-",
+    JOB_ID_PLACEHOLDER,
+    "/",
+    TASK_ID_PLACEHOLDER,
+    ".stderr"
+);
 
 struct ArgCpuRequest(CpuRequest);
 

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -4,6 +4,7 @@ import time
 
 from .conftest import HqEnv
 from .utils import JOB_TABLE_ROWS, wait_for_job_state
+from .utils.job import default_task_output
 
 
 def test_job_array_submit(hq_env: HqEnv):
@@ -15,13 +16,27 @@ def test_job_array_submit(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FINISHED")
 
     for i in list(range(0, 30)) + list(range(37, 40)):
-        assert not os.path.isfile(os.path.join(hq_env.work_path, f"job-1/stdout.{i}"))
-        assert not os.path.isfile(os.path.join(hq_env.work_path, f"job-1/stderr.{i}"))
+        assert not os.path.isfile(
+            os.path.join(hq_env.work_path, default_task_output(job_id=1, task_id=i))
+        )
+        assert not os.path.isfile(
+            os.path.join(
+                hq_env.work_path,
+                default_task_output(job_id=1, task_id=i, type="stderr"),
+            )
+        )
 
     for i in range(36, 37):
-        stdout = os.path.join(hq_env.work_path, f"job-1/stdout.{i}")
+        stdout = os.path.join(
+            hq_env.work_path, default_task_output(job_id=1, task_id=i)
+        )
         assert os.path.isfile(stdout)
-        assert os.path.isfile(os.path.join(hq_env.work_path, f"job-1/stderr.{i}"))
+        assert os.path.isfile(
+            os.path.join(
+                hq_env.work_path,
+                default_task_output(job_id=1, task_id=i, type="stderr"),
+            )
+        )
         with open(stdout) as f:
             assert f.read() == f"1-{i}\n"
 

--- a/tests/test_cpus.py
+++ b/tests/test_cpus.py
@@ -5,6 +5,7 @@ import pytest
 
 from .conftest import RUNNING_IN_CI, HqEnv
 from .utils import wait_for_job_state
+from .utils.job import default_task_output
 
 
 def read_list(filename):
@@ -38,27 +39,27 @@ def test_job_num_of_cpus(hq_env: HqEnv):
 
     table = hq_env.command(["job", "1"], as_table=True)
     table.check_value_row("Resources", "1 compact")
-    assert len(read_list("job-1/stdout.0")) == 1
+    assert len(read_list(default_task_output(job_id=1))) == 1
 
     table = hq_env.command(["job", "2"], as_table=True)
     table.check_value_row("Resources", "2 scatter")
-    assert len(set(x // 4 for x in read_list("job-2/stdout.0"))) == 2
+    assert len(set(x // 4 for x in read_list(default_task_output(job_id=2)))) == 2
 
     table = hq_env.command(["job", "4"], as_table=True)
     table.check_value_row("Resources", "4 compact!")
-    lst = read_list("job-4/stdout.0")
+    lst = read_list(default_task_output(job_id=4))
     assert len(set(x // 4 for x in lst)) == 1
     assert len(lst) == 4
 
     table = hq_env.command(["job", "5"], as_table=True)
     table.check_value_row("Resources", "5 compact!")
-    lst = read_list("job-5/stdout.0")
+    lst = read_list(default_task_output(job_id=5))
     assert len(set(x // 4 for x in lst)) == 2
     assert len(lst) == 5
 
     table = hq_env.command(["job", "6"], as_table=True)
     table.check_value_row("Resources", "all")
-    lst = read_list("job-6/stdout.0")
+    lst = read_list(default_task_output(job_id=6))
     assert list(range(12)) == lst
 
 
@@ -114,7 +115,7 @@ def test_job_no_pin(hq_env: HqEnv):
     table.check_value_row("State", "FINISHED")
     table.check_value_row("Resources", "2 compact!")
 
-    with open("job-1/stdout.0", "rb") as f:
+    with open(default_task_output(), "rb") as f:
         f.readline()  # skip line
         line = f.readline().split()
         del line[1]  # Remove actual PID
@@ -143,6 +144,6 @@ def test_job_pin(hq_env: HqEnv):
     table.check_value_row("State", "FINISHED")
     table.check_value_row("Resources", "2 compact! [pin]")
 
-    with open("job-1/stdout.0") as f:
+    with open(default_task_output()) as f:
         hq_cpus = f.readline().rstrip()
         assert hq_cpus == f.readline().rstrip().split(" ")[5]

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -2,6 +2,7 @@ import os
 
 from .conftest import HqEnv
 from .utils import wait_for_job_state
+from .utils.job import default_task_output
 
 
 def test_entries_no_newline(hq_env: HqEnv):
@@ -24,10 +25,10 @@ def test_entries_no_newline(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FINISHED")
 
     for i, test in enumerate(["One\n", "Two\n", "Three\n", "Four\n"]):
-        with open(f"job-{1}/stdout.{i}") as f:
+        with open(default_task_output(job_id=1, task_id=i)) as f:
             line = f.read()
         assert line == test
-    assert not os.path.isfile("stdout.0.4")
+    assert not os.path.isfile(default_task_output(job_id=1, task_id=4))
 
     table = hq_env.command(["job", "1"], as_table=True)
     assert table.get_row_value("State").split("\n")[-1] == "FINISHED (4)"
@@ -53,10 +54,10 @@ def test_entries_with_newline(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FINISHED")
 
     for i, test in enumerate(["One\n", "Two\n", "Three\n", "Four\n"]):
-        with open(f"job-1/stdout.{i}") as f:
+        with open(default_task_output(job_id=1, task_id=i)) as f:
             line = f.read()
         assert line == test
-    assert not os.path.isfile("stdout.0.4")
+    assert not os.path.isfile(default_task_output(task_id=4))
 
     table = hq_env.command(["job", "1"], as_table=True)
     assert table.get_row_value("State").split("\n")[-1] == "FINISHED (4)"

--- a/tests/utils/job.py
+++ b/tests/utils/job.py
@@ -1,0 +1,2 @@
+def default_task_output(job_id=1, task_id=0, type="stdout") -> str:
+    return f"job-{job_id}/{task_id}.{type}"


### PR DESCRIPTION
This makes it easier to sort the files by task id.

This commit also adds a test function that generates the default file name to make it easier to change in the future.
It also removes false negatives from tests that were using the old format.