### PR TITLE
Add Python bindings basic infrastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-targets
+          args: --all --all-targets
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all
 
       - name: Setup Python
         uses: actions/setup-python@v1
@@ -65,7 +66,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all -- -D warnings
 
       - name: Check Rust formatting
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
+name = "ctor"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,9 +525,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -530,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -540,15 +550,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -557,18 +567,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -576,23 +584,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -602,8 +609,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -635,6 +640,17 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -769,12 +785,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8"
+dependencies = [
+ "indoc-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "indoc-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unindent",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "inventory"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
+dependencies = [
+ "ctor",
+ "ghost",
+ "inventory-impl",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1065,6 +1126,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+dependencies = [
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,12 +1237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1262,104 @@ dependencies = [
  "platforms",
  "thiserror",
  "unescape",
+]
+
+[[package]]
+name = "pyhq"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hyperqueue",
+ "pyo3",
+ "pyo3-asyncio",
+ "pythonize",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf01dbf1c05af0a14c7779ed6f3aa9deac9c3419606ac9de537a2d649005720"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "indoc",
+ "libc",
+ "parking_lot",
+ "paste",
+ "pyo3-build-config",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-asyncio"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0897c7e36110a32b726b975359b2bbe90c37fcf1266046d3b1c08c616a47a886"
+dependencies = [
+ "futures",
+ "inventory",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "pyo3-asyncio-macros",
+ "tokio",
+]
+
+[[package]]
+name = "pyo3-asyncio-macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4daada7260db6d6dbc1f9b50f3e3d21f9eb28c034722c9a61ac05ff56ffd62db"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf9e4d128bfbddc898ad3409900080d8d5095c379632fbbfbb9c8cfb1fb852b"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67701eb32b1f9a9722b4bc54b548ff9d7ebfded011c12daece7b9063be1fd755"
+dependencies = [
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44f09e825ee49a105f2c7b23ebee50886a9aee0746f4dd5a704138a64b0218a"
+dependencies = [
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pythonize"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445529621b8801c031b9e43f12f543fdf64379584646f132d6dcf2731c814e03"
+dependencies = [
+ "pyo3",
+ "serde",
 ]
 
 [[package]]
@@ -1865,6 +2037,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
     "crates/hyperqueue",
-    "crates/tako"
+    "crates/tako",
+    "crates/pyhq"
 ]
 default-members = [
     "crates/hyperqueue",

--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -16,6 +16,7 @@ use hyperqueue::client::commands::wait::{wait_for_jobs, wait_for_jobs_with_progr
 use hyperqueue::client::commands::worker::{
     get_worker_info, get_worker_list, start_hq_worker, stop_worker, WorkerStartOpts,
 };
+use hyperqueue::client::default_server_directory_path;
 use hyperqueue::client::globalsettings::GlobalSettings;
 use hyperqueue::client::output::cli::CliOutput;
 use hyperqueue::client::output::json::JsonOutput;
@@ -468,12 +469,6 @@ impl FromStr for ColorPolicy {
 }
 
 fn make_global_settings(opts: CommonOpts) -> GlobalSettings {
-    fn default_server_directory_path() -> PathBuf {
-        let mut home = dirs::home_dir().unwrap_or_else(std::env::temp_dir);
-        home.push(".hq-server");
-        home
-    }
-
     let server_dir = absolute_path(
         opts.server_dir
             .unwrap_or_else(default_server_directory_path),

--- a/crates/hyperqueue/src/client/mod.rs
+++ b/crates/hyperqueue/src/client/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub mod commands;
 pub mod globalsettings;
 pub mod job;
@@ -5,3 +7,9 @@ pub mod output;
 pub mod resources;
 pub mod status;
 pub mod utils;
+
+pub fn default_server_directory_path() -> PathBuf {
+    let mut home = dirs::home_dir().unwrap_or_else(std::env::temp_dir);
+    home.push(".hq-server");
+    home
+}

--- a/crates/hyperqueue/src/lib.rs
+++ b/crates/hyperqueue/src/lib.rs
@@ -30,4 +30,5 @@ pub type JobTaskCount = u32;
 pub type JobTaskStep = u32;
 
 // Reexports
+pub use tako;
 pub use tako::common::WrappedRcRefCell;

--- a/crates/pyhq/Cargo.toml
+++ b/crates/pyhq/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "pyhq"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+name = "pyhq"
+# "cdylib" is necessary to produce a shared library for Python to import from.
+#
+# Downstream Rust code (including code in `bin/`, `examples/`, and `tests/`) will not be able
+# to `use string_sum;` unless the "rlib" or "lib" crate type is also included, e.g.:
+# crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
+
+[dependencies]
+hyperqueue = { path = "../hyperqueue" }
+pyo3 = { version = "0.15.1", features = ["extension-module", "abi3", "abi3-py36", "anyhow"] }
+pyo3-asyncio = { version = "0.15.0", features = ["tokio-runtime", "attributes"] }
+pythonize = "0.15.0"
+serde = "1.0.130"
+tokio = "1.15.0"
+anyhow = "1.0.44"
+
+[package.metadata.maturin]
+python-source = "python"

--- a/crates/pyhq/README.md
+++ b/crates/pyhq/README.md
@@ -1,0 +1,19 @@
+# PyHQ binding
+This package provides a Python binding to HyperQueue.
+
+## Development
+1) Install `maturin`
+```bash
+$ pip install maturin
+```
+2) Build the bindings
+```bash
+$ maturin develop
+```
+3) Use the build `pyhq` package
+```python
+from pyhq.client import connect_to_server, stop_server
+
+ctx = connect_to_server()
+stop_server(ctx)
+```

--- a/crates/pyhq/pyproject.toml
+++ b/crates/pyhq/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["maturin>=0.12,<0.13"]
+build-backend = "maturin"
+
+[project]
+name = "pyhq"
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Rust"
+]
+requires-python = ">=3.6"
+description = "HyperQueue Python API"

--- a/crates/pyhq/python/pyhq/client.py
+++ b/crates/pyhq/python/pyhq/client.py
@@ -1,0 +1,9 @@
+from . import pyhq as ffi
+
+
+def connect_to_server():
+    return ffi.connect_to_server()
+
+
+def stop_server(ctx):
+    return ffi.stop_server(ctx)

--- a/crates/pyhq/src/lib.rs
+++ b/crates/pyhq/src/lib.rs
@@ -1,0 +1,50 @@
+use pyo3::types::PyModule;
+use pyo3::{pyclass, pyfunction, pymodule};
+use pyo3::{wrap_pyfunction, Py, PyResult, Python};
+use tokio::runtime::Builder;
+
+use crate::utils::run_future;
+use hyperqueue::client::default_server_directory_path;
+use hyperqueue::server::bootstrap::get_client_connection;
+use hyperqueue::transfer::connection::ClientConnection;
+use hyperqueue::transfer::messages::FromClientMessage;
+
+mod utils;
+
+/// Opaque object that is returned by `connect_to_server` and then passed from the Python side
+/// to various Rust functions.
+#[pyclass]
+struct HqContext {
+    connection: ClientConnection,
+}
+
+#[pyfunction]
+fn connect_to_server(py: Python) -> PyResult<Py<HqContext>> {
+    run_future(async move {
+        let connection = get_client_connection(&default_server_directory_path()).await?;
+        let context = HqContext { connection };
+        Py::new(py, context)
+    })
+}
+
+#[pyfunction]
+fn stop_server(py: Python, ctx: Py<HqContext>) -> PyResult<()> {
+    run_future(async move {
+        let mut ctx = borrow_mut!(py, ctx);
+        ctx.connection.send(FromClientMessage::Stop).await.unwrap();
+        Ok(())
+    })
+}
+
+#[pymodule]
+fn pyhq(_py: Python, m: &PyModule) -> PyResult<()> {
+    // Use a single-threaded Tokio runtime for all Rust async operations
+    let mut builder = Builder::new_current_thread();
+    builder.enable_all();
+    pyo3_asyncio::tokio::init(builder);
+
+    m.add_class::<HqContext>()?;
+    m.add_function(wrap_pyfunction!(connect_to_server, m)?)?;
+    m.add_function(wrap_pyfunction!(stop_server, m)?)?;
+    Ok(())
+}

--- a/crates/pyhq/src/utils.rs
+++ b/crates/pyhq/src/utils.rs
@@ -1,0 +1,25 @@
+use std::future::Future;
+use tokio::task::LocalSet;
+
+/// Borrow a Python object from a Py pointer.
+#[macro_export]
+macro_rules! borrow {
+    ($py:expr, $instance:expr) => {
+        $instance.as_ref($py).borrow()
+    };
+}
+
+/// Borrow a Python object mutably from a Py pointer.
+#[macro_export]
+macro_rules! borrow_mut {
+    ($py:expr, $instance:expr) => {
+        $instance.as_ref($py).borrow_mut()
+    };
+}
+
+/// Run the provided future to completion using a global Tokio runtime managed by `pyo3_asyncio`.
+pub(crate) fn run_future<F: Future>(future: F) -> F::Output {
+    let runtime = pyo3_asyncio::tokio::get_runtime();
+    let set = LocalSet::new();
+    set.block_on(runtime, future)
+}

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -5,7 +5,7 @@ set -e
 cd `dirname $0`/..
 
 # Format Rust code
-cargo fmt
+cargo fmt --all
 
 # Format Python code
 isort --profile black tests benchmarks
@@ -18,11 +18,11 @@ flake8 tests benchmarks
 cargo test
 
 # Run Rust linter
-cargo clippy -- -D warnings
-cargo check --all-targets
+cargo clippy --all -- -D warnings
+cargo check --all --all-targets
 
 # Build Rust binaries
-cargo build
+cargo build --all
 
 # Run Python tests
 python -m pytest tests -n32


### PR DESCRIPTION
This PR adds basic Python bindings. It is synchronous and currently exposes only two functions (connect to server and stop the server).