### PR TITLE
Change method of finding remaining worker time in Slurm

### DIFF
--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -23,7 +23,7 @@ pub struct AutoAllocOpts {
 enum AutoAllocCommand {
     /// Displays allocation queues
     List,
-    /// Display event log for a specified allocation queue
+    /// Display event log for the specified allocation queue
     Events(EventsOpts),
     /// Display allocations of the specified allocation queue
     Info(AllocationsOpts),

--- a/crates/hyperqueue/src/server/autoalloc/descriptor/slurm.rs
+++ b/crates/hyperqueue/src/server/autoalloc/descriptor/slurm.rs
@@ -147,7 +147,7 @@ impl QueueHandler for SlurmHandler {
             let status = get_key("JobState")?;
             let status = match status {
                 "PENDING" | "CONFIGURING" => AllocationStatus::Queued,
-                "RUNNING" => {
+                "RUNNING" | "COMPLETING" => {
                     let started_at = parse_time(get_key("StartTime")?)?;
                     AllocationStatus::Running { started_at }
                 }

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -79,7 +79,7 @@ def test_manager_autodetect(hq_env: HqEnv):
 
             table = hq_env.command(["worker", "info", "3"], as_table=True)
             table.check_value_row("Manager", "SLURM")
-            table.check_value_row("Time Limit", "13m 26s")
+            table.check_value_row("Time Limit", "15m")
 
 
 def test_manager_set_none(hq_env: HqEnv):


### PR DESCRIPTION
TimeLimit could contain a number of days, which we would have to parse in a special way. We can already parse Slurm dates, so I used `EndTime - StartTime` instead.