### PR TITLE
Remove explicit queue parameter from auto allocation

### DIFF
--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -529,10 +529,10 @@ impl Output for CliOutput {
             "ID".cell().bold(true),
             "Backlog size".cell().bold(true),
             "Workers per alloc".cell().bold(true),
-            "Queue".cell().bold(true),
             "Timelimit".cell().bold(true),
             "Manager".cell().bold(true),
             "Name".cell().bold(true),
+            "Args".cell().bold(true),
         ]];
 
         let mut descriptors: Vec<_> = info.descriptors.into_iter().collect();
@@ -543,7 +543,6 @@ impl Output for CliOutput {
                 id.cell(),
                 data.info.backlog().cell(),
                 data.info.workers_per_alloc().cell(),
-                data.info.queue().cell(),
                 data.info
                     .timelimit()
                     .map(|d| humantime::format_duration(d).to_string())
@@ -551,6 +550,7 @@ impl Output for CliOutput {
                     .cell(),
                 data.manager_type.cell(),
                 data.name.unwrap_or_else(|| "".to_string()).cell(),
+                data.info.additional_args().join(",").cell(),
             ]
         }));
         self.print_rows(rows);

--- a/crates/hyperqueue/src/server/autoalloc/descriptor/mod.rs
+++ b/crates/hyperqueue/src/server/autoalloc/descriptor/mod.rs
@@ -54,38 +54,41 @@ impl QueueDescriptor {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueueInfo {
-    queue: String,
     backlog: u32,
     workers_per_alloc: u32,
     timelimit: Option<Duration>,
+    additional_args: Vec<String>,
 }
 
 impl QueueInfo {
     pub fn new(
-        queue: String,
         backlog: u32,
         workers_per_alloc: u32,
         timelimit: Option<Duration>,
+        additional_args: Vec<String>,
     ) -> Self {
         QueueInfo {
-            queue,
             backlog,
             workers_per_alloc,
             timelimit,
+            additional_args,
         }
     }
 
-    pub fn queue(&self) -> &str {
-        &self.queue
-    }
     pub fn backlog(&self) -> u32 {
         self.backlog
     }
+
     pub fn workers_per_alloc(&self) -> u32 {
         self.workers_per_alloc
     }
+
     pub fn timelimit(&self) -> Option<Duration> {
         self.timelimit
+    }
+
+    pub fn additional_args(&self) -> &[String] {
+        &self.additional_args
     }
 }
 

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -461,7 +461,7 @@ mod tests {
     ) {
         let descriptor = QueueDescriptor::new(
             ManagerType::Pbs,
-            QueueInfo::new("queue".to_string(), backlog, workers_per_alloc, None),
+            QueueInfo::new(backlog, workers_per_alloc, None, vec![]),
             None,
             handler,
         );

--- a/crates/hyperqueue/src/server/client.rs
+++ b/crates/hyperqueue/src/server/client.rs
@@ -303,11 +303,7 @@ fn create_queue(
     let server_directory = server_dir.directory().to_path_buf();
     let (handler, params, manager_type) = match request {
         AddQueueRequest::Pbs(params) => {
-            let handler = PbsHandler::new(
-                server_directory,
-                params.additional_args.clone(),
-                params.name.clone(),
-            );
+            let handler = PbsHandler::new(server_directory, params.name.clone());
             (
                 handler.map::<Box<dyn QueueHandler>, _>(|handler| Box::new(handler)),
                 params,
@@ -315,11 +311,7 @@ fn create_queue(
             )
         }
         AddQueueRequest::Slurm(params) => {
-            let handler = SlurmHandler::new(
-                server_directory,
-                params.additional_args.clone(),
-                params.name.clone(),
-            );
+            let handler = SlurmHandler::new(server_directory, params.name.clone());
             (
                 handler.map::<Box<dyn QueueHandler>, _>(|handler| Box::new(handler)),
                 params,
@@ -329,10 +321,10 @@ fn create_queue(
     };
 
     let queue_info = QueueInfo::new(
-        params.queue,
         params.backlog,
         params.workers_per_alloc,
         params.timelimit,
+        params.additional_args,
     );
 
     match handler {

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -120,7 +120,6 @@ pub enum AddQueueRequest {
 pub struct AddQueueParams {
     pub workers_per_alloc: u32,
     pub backlog: u32,
-    pub queue: String,
     pub timelimit: Option<Duration>,
     pub name: Option<String>,
     pub additional_args: Vec<String>,


### PR DESCRIPTION
It was opaque for HyperQueue and it introduced unnecessary complexity both in code and help/documentation.

Timelimit is similar to queue, but I kept it to let users use the convenient humantime duration syntax for
job walltime.