### PR TITLE
Change worker list filtering options from `--running` and `--offline` to `--all`

### DIFF
--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -192,13 +192,9 @@ struct WorkerStopOpts {
 
 #[derive(Parser)]
 struct WorkerListOpts {
-    /// shows running workers
+    /// Include offline workers in the list
     #[clap(long)]
-    running: bool,
-
-    /// shows offline workers
-    #[clap(long)]
-    offline: bool,
+    all: bool,
 }
 
 #[derive(Parser)]
@@ -223,13 +219,13 @@ enum WorkerCommand {
     Start(WorkerStartOpts),
     /// Stop worker
     Stop(WorkerStopOpts),
-    /// Display information about all workers
+    /// Display information about workers
     List(WorkerListOpts),
     /// Hwdetect
     Hwdetect,
-    /// Display info about worker
+    /// Display information about a specific worker
     Info(WorkerInfoOpts),
-    /// Print worker's hostname
+    /// Display worker's hostname
     Address(WorkerAddressOpts),
 }
 
@@ -348,13 +344,7 @@ async fn command_worker_list(
 ) -> anyhow::Result<()> {
     let mut connection = get_client_connection(gsettings.server_directory()).await?;
 
-    // If --running and --offline was not set then show all workers
-    let (online, offline) = if !opts.running && !opts.offline {
-        (true, true)
-    } else {
-        (opts.running, opts.offline)
-    };
-    let workers = get_worker_list(&mut connection, online, offline).await?;
+    let workers = get_worker_list(&mut connection, opts.all).await?;
     gsettings.printer().print_worker_list(workers);
     Ok(())
 }

--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -8,8 +8,7 @@ use crate::WorkerId;
 
 pub async fn get_worker_list(
     connection: &mut ClientConnection,
-    get_online: bool,
-    get_offline: bool,
+    include_offline: bool,
 ) -> crate::Result<Vec<WorkerInfo>> {
     let mut msg = rpc_call!(
         connection,
@@ -19,13 +18,10 @@ pub async fn get_worker_list(
     .await?;
 
     msg.workers.sort_unstable_by_key(|w| w.id);
-    msg.workers.retain(|w| {
-        if w.ended.is_none() {
-            get_online
-        } else {
-            get_offline
-        }
-    });
+
+    if !include_offline {
+        msg.workers.retain(|w| w.ended.is_none());
+    }
 
     Ok(msg.workers)
 }

--- a/crates/hyperqueue/src/dashboard/ui_loop.rs
+++ b/crates/hyperqueue/src/dashboard/ui_loop.rs
@@ -58,7 +58,7 @@ async fn update(
     connection: &mut ClientConnection,
 ) -> anyhow::Result<()> {
     let overview = get_hw_overview(connection).await?;
-    let worker_info = get_worker_list(connection, true, false).await?;
+    let worker_info = get_worker_list(connection, false).await?;
 
     let screen = state.get_current_screen_mut();
     screen.update(ClusterState {

--- a/tests/utils/wait.py
+++ b/tests/utils/wait.py
@@ -66,4 +66,4 @@ def wait_for_job_state(
 def wait_for_worker_state(
     env, ids: Union[int, List[int]], target_states: Union[str, List[str]], **kwargs
 ):
-    wait_for_state(env, ids, target_states, ["worker", "list"], 1, **kwargs)
+    wait_for_state(env, ids, target_states, ["worker", "list", "--all"], 1, **kwargs)


### PR DESCRIPTION
Only online workers will now be shown by default. With `--all`, also offline workers will be shown.