### PR TITLE
Do not print job table after submitting a job

### DIFF
--- a/crates/hyperqueue/src/client/commands/jobs.rs
+++ b/crates/hyperqueue/src/client/commands/jobs.rs
@@ -72,7 +72,6 @@ pub async fn output_job_detail(
         if let Some(job) = response.1 {
             gsettings.printer().print_job_detail(
                 job,
-                false,
                 show_tasks,
                 get_worker_map(connection).await?,
                 &resource_names,

--- a/crates/hyperqueue/src/client/commands/submit.rs
+++ b/crates/hyperqueue/src/client/commands/submit.rs
@@ -315,13 +315,7 @@ pub async fn submit_computation(
     let response = rpc_call!(connection, message, ToClientMessage::SubmitResponse(r) => r).await?;
     let info = response.job.info.clone();
 
-    gsettings.printer().print_job_detail(
-        response.job,
-        true,
-        false,
-        get_worker_map(connection).await?,
-        &generic_resource_names,
-    );
+    gsettings.printer().print_job_submitted(response.job);
     if opts.wait {
         wait_for_jobs(
             gsettings,
@@ -397,7 +391,6 @@ pub async fn resubmit_computation(
     let resource_names = get_resource_names(connection, Vec::new()).await?;
     gsettings.printer().print_job_detail(
         response.job,
-        true,
         false,
         get_worker_map(connection).await?,
         &resource_names,

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -241,6 +241,14 @@ impl Output for CliOutput {
         self.print_rows(rows);
     }
 
+    fn print_job_submitted(&self, job: JobDetail) {
+        println!(
+            "Job submitted {}, job ID: {}",
+            "successfully".color(colored::Color::Green),
+            job.info.id
+        );
+    }
+
     fn print_job_list(&self, tasks: Vec<JobInfo>) {
         let rows: Vec<_> = tasks
             .into_iter()
@@ -267,7 +275,6 @@ impl Output for CliOutput {
     fn print_job_detail(
         &self,
         job: JobDetail,
-        just_submitted: bool,
         show_tasks: bool,
         worker_map: WorkerMap,
         resource_names: &[String],
@@ -277,9 +284,7 @@ impl Output for CliOutput {
             vec!["Name".cell().bold(true), job.info.name.as_str().cell()],
         ];
 
-        let status = if just_submitted {
-            "SUBMITTED".cell().foreground_color(Some(Color::Cyan))
-        } else if job.info.n_tasks == 1 {
+        let status = if job.info.n_tasks == 1 {
             task_status_to_cell(job_status(&job.info))
         } else {
             job_status_to_cell(&job.info).cell()

--- a/crates/hyperqueue/src/client/output/outputs.rs
+++ b/crates/hyperqueue/src/client/output/outputs.rs
@@ -43,11 +43,11 @@ pub trait Output {
     fn print_server_stats(&self, stats: StatsResponse);
 
     // Jobs
+    fn print_job_submitted(&self, job: JobDetail);
     fn print_job_list(&self, tasks: Vec<JobInfo>);
     fn print_job_detail(
         &self,
         job: JobDetail,
-        just_submitted: bool,
         show_tasks: bool,
         worker_map: WorkerMap,
         resource_names: &[String],

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -210,14 +210,10 @@ can query the state of a job with the following commands[^1]:
 [^1]: You can use various [shortcuts](../tips/cli-shortcuts.md#id-selector) to select multiple jobs at once.
 
 ### Task state
-Each task starts in the `Submitted` state and can end up in one of the terminal states: `Finished`, `Failed`
+Each task starts in the `Waiting` state and can end up in one of the terminal states: `Finished`, `Failed`
 or `Canceled`.
 
 ```
-Submitted
-   |
-   |
-   v
 Waiting-----------------\
    | ^                  |
    | |                  |
@@ -230,8 +226,7 @@ Running-----------------|
 Finished    Failed   Canceled
 ```
 
-- **Submitted** Only an informative state that a submission was successful; it is only shown immediately after a submit.
-- **Waiting** The task is waiting to be executed.
+- **Waiting** The task was submitted and is now waiting to be executed.
 - **Running** The task is running on a worker. It may become `Waiting` again when the worker where the task is running
   crashes.
 - **Finished** The task has successfully finished.


### PR DESCRIPTION
This will make it easier to see potential warnings. The table also did not contain much useful information for the user.