### PR TITLE
WIP: Dashboard: Add table to monitor jobs on workers

### DIFF
--- a/crates/hyperqueue/src/dashboard/ui/screen.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screen.rs
@@ -2,7 +2,7 @@ use tako::messages::gateway::CollectedOverview;
 use termion::event::Key;
 
 use crate::dashboard::ui::terminal::DashboardFrame;
-use crate::transfer::messages::WorkerInfo;
+use crate::transfer::messages::{JobDetail, WorkerInfo};
 
 pub trait Screen {
     fn draw(&mut self, frame: &mut DashboardFrame);
@@ -16,4 +16,5 @@ pub trait Screen {
 pub struct ClusterState {
     pub overview: CollectedOverview,
     pub worker_info: Vec<WorkerInfo>,
+    pub worker_jobs_info: Vec<(u32, JobDetail)>,
 }

--- a/crates/hyperqueue/src/dashboard/ui/screens/home/info_section.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/home/info_section.rs
@@ -46,23 +46,25 @@ impl WorkerInfoTable {
         }
     }
 
-    pub fn draw(&mut self, rect: Rect, frame: &mut DashboardFrame) {
-        self.table.draw(
-            rect,
-            frame,
-            TableColumnHeaders {
-                title: "Worker Info".to_string(),
-                inline_help: "".to_string(),
-                table_headers: None,
-                column_widths: vec![Constraint::Percentage(30), Constraint::Percentage(70)],
-            },
-            |data| {
-                Row::new(vec![
-                    Cell::from(data.label.to_string()),
-                    Cell::from(data.data.to_string()),
-                ])
-            },
-        );
+    pub fn draw(&mut self, rect: Rect, frame: &mut DashboardFrame, worker_id: Option<u32>) {
+        if let Some(worker_id) = worker_id {
+            self.table.draw(
+                rect,
+                frame,
+                TableColumnHeaders {
+                    title: format!("Worker Info for worker_id = ({})", worker_id).to_string(),
+                    inline_help: "".to_string(),
+                    table_headers: None,
+                    column_widths: vec![Constraint::Percentage(30), Constraint::Percentage(70)],
+                },
+                |data| {
+                    Row::new(vec![
+                        Cell::from(data.label.to_string()),
+                        Cell::from(data.data.to_string()),
+                    ])
+                },
+            );
+        }
     }
 }
 

--- a/crates/hyperqueue/src/dashboard/ui/screens/home/mod.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/home/mod.rs
@@ -1,4 +1,5 @@
 pub mod chart_section;
 pub mod info_section;
 pub mod screen;
+pub mod tasks_table;
 pub mod worker_utilization_table;

--- a/crates/hyperqueue/src/dashboard/ui/screens/home/screen.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/home/screen.rs
@@ -4,17 +4,26 @@ use crate::dashboard::ui::screen::{ClusterState, Screen};
 use crate::dashboard::ui::screens::home::chart_section::ClusterOverviewChart;
 use crate::dashboard::ui::screens::home::info_section::WorkerInfoTable;
 use crate::dashboard::ui::screens::home::worker_utilization_table::WorkerUtilTable;
-use crate::dashboard::ui::styles::style_header_text;
+use crate::dashboard::ui::styles::{style_footer_text, style_header_text};
 use crate::dashboard::ui::terminal::DashboardFrame;
 use crate::dashboard::ui::widgets::text::draw_text;
 
+use crate::dashboard::ui::screens::home::tasks_table::WorkerJobsTable;
 use tui::layout::{Constraint, Direction, Layout, Rect};
 
 #[derive(Default)]
 pub struct HomeScreen {
     worker_info_table: WorkerInfoTable,
     worker_util_table: WorkerUtilTable,
+    worker_job_table: WorkerJobsTable,
+    table_state: HomeScreenTableState,
+
     worker_info_chart: ClusterOverviewChart,
+}
+
+pub enum HomeScreenTableState {
+    WorkerUtilTable,
+    WorkerJobsTable,
 }
 
 impl Screen for HomeScreen {
@@ -24,22 +33,50 @@ impl Screen for HomeScreen {
         // Update the current selected worker for info table
         let selected_worker = self.worker_util_table.get_selected_item();
         self.worker_info_table.change_info(selected_worker);
+        self.worker_job_table.update_current_worker(selected_worker);
 
         self.worker_info_chart.draw(layout.chart_chunk, frame);
-        self.worker_info_table.draw(layout.info_chunk, frame);
-        self.worker_util_table.draw(layout.body_chunk, frame);
+        self.worker_info_table
+            .draw(layout.info_chunk, frame, selected_worker);
+        match &self.table_state {
+            HomeScreenTableState::WorkerUtilTable => {
+                self.worker_util_table.draw(layout.body_chunk, frame);
+            }
+            HomeScreenTableState::WorkerJobsTable => {
+                self.worker_job_table
+                    .draw(layout.body_chunk, frame, selected_worker);
+            }
+        }
+        draw_text("Up/Down to select Worker, Right Arrow key to switch to Jobs for the Worker, Left to be back.", layout.footer_chunk, frame, style_footer_text());
     }
 
     fn update(&mut self, state: ClusterState) {
         self.worker_util_table.update(&state.overview);
         self.worker_info_table.update(state.worker_info);
-        self.worker_info_chart.update(&state.overview)
+        self.worker_info_chart.update(&state.overview);
+        self.worker_job_table.update(state.worker_jobs_info);
     }
 
     fn handle_key(&mut self, key: Key) {
         match key {
-            Key::Down => self.worker_util_table.select_next_worker(),
-            Key::Up => self.worker_util_table.select_previous_worker(),
+            Key::Down => match self.table_state {
+                HomeScreenTableState::WorkerUtilTable => {
+                    self.worker_util_table.select_next_worker();
+                }
+                HomeScreenTableState::WorkerJobsTable => {
+                    self.worker_job_table.select_next_job();
+                }
+            },
+            Key::Up => match self.table_state {
+                HomeScreenTableState::WorkerUtilTable => {
+                    self.worker_util_table.select_previous_worker();
+                }
+                HomeScreenTableState::WorkerJobsTable => {
+                    self.worker_job_table.select_previous_job();
+                }
+            },
+            Key::Right => self.table_state = HomeScreenTableState::WorkerJobsTable,
+            Key::Left => self.table_state = HomeScreenTableState::WorkerUtilTable,
             _ => {}
         }
     }
@@ -58,30 +95,31 @@ struct HomeLayout {
     info_chunk: Rect,
     header_chunk: Rect,
     body_chunk: Rect,
+    footer_chunk: Rect,
 }
 
 impl HomeLayout {
     fn new(frame: &DashboardFrame) -> Self {
-        let base_chunks = tui::layout::Layout::default()
-            .constraints(vec![
-                Constraint::Percentage(30),
-                Constraint::Percentage(10),
-                Constraint::Percentage(30),
-            ])
-            .direction(Direction::Vertical)
-            .split(frame.size());
-
-        let info_chunks = Layout::default()
-            .constraints(vec![Constraint::Percentage(30), Constraint::Percentage(70)])
-            .direction(Direction::Horizontal)
-            .margin(0)
-            .split(base_chunks[0]);
-
+        let base_chunks = vertical_chunks(
+            vec![
+                Constraint::Percentage(35),
+                Constraint::Percentage(5),
+                Constraint::Percentage(56),
+                Constraint::Percentage(4),
+            ],
+            frame.size(),
+        );
+        let info_chunks = horizontal_chunks_with_margin(
+            vec![Constraint::Percentage(30), Constraint::Percentage(70)],
+            base_chunks[0],
+            0,
+        );
         Self {
             chart_chunk: info_chunks[0],
             info_chunk: info_chunks[1],
             header_chunk: base_chunks[1],
             body_chunk: base_chunks[2],
+            footer_chunk: base_chunks[3],
         }
     }
 }
@@ -103,4 +141,10 @@ pub fn horizontal_chunks_with_margin(
         .direction(Direction::Horizontal)
         .margin(margin)
         .split(size)
+}
+
+impl Default for HomeScreenTableState {
+    fn default() -> Self {
+        HomeScreenTableState::WorkerUtilTable
+    }
 }

--- a/crates/hyperqueue/src/dashboard/ui/screens/home/tasks_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/home/tasks_table.rs
@@ -1,0 +1,182 @@
+use tui::layout::{Constraint, Rect};
+use tui::widgets::{Cell, Row};
+
+use crate::dashboard::ui::terminal::DashboardFrame;
+use crate::dashboard::ui::widgets::progressbar::{render_progress_bar_at, ProgressPrintStyle};
+use crate::dashboard::ui::widgets::table::{StatefulTable, TableColumnHeaders};
+use crate::server::job::JobTaskCounters;
+use crate::transfer::messages::{JobDetail, JobType};
+
+#[derive(Default)]
+pub struct WorkerJobsTable {
+    table: StatefulTable<WorkerJobRow>,
+    state: Vec<(u32, JobDetail)>,
+    current_worker: u32,
+}
+
+impl WorkerJobsTable {
+    pub fn update(&mut self, job_detail: Vec<(u32, JobDetail)>) {
+        self.state = job_detail;
+    }
+
+    pub fn update_current_worker(&mut self, worker_id: Option<u32>) {
+        if let Some(worker_id) = worker_id {
+            if self.current_worker != worker_id {
+                self.current_worker = worker_id;
+                let rows = create_rows(self.state.clone(), worker_id);
+                self.table.set_items(rows);
+                self.table.clear_selection();
+            }
+        }
+    }
+
+    pub fn select_next_job(&mut self) {
+        self.table.select_next_wrap();
+    }
+
+    pub fn select_previous_job(&mut self) {
+        self.table.select_previous_wrap();
+    }
+
+    pub fn get_selected_item(&self) -> Option<u32> {
+        let selection = self.table.current_selection();
+        selection.map(|row| row.id)
+    }
+
+    pub fn draw(&mut self, rect: Rect, frame: &mut DashboardFrame, selected_worker: Option<u32>) {
+        if let Some(selected_worker) = selected_worker {
+            self.table.draw(
+                rect,
+                frame,
+                TableColumnHeaders {
+                    title: format!("Jobs running on worker {}", selected_worker).to_string(),
+                    inline_help: "".to_string(),
+                    table_headers: Some(vec![
+                        "id",
+                        "program",
+                        "job_type",
+                        "running",
+                        "finished",
+                        "failed",
+                        "cancelled",
+                        "max_fails",
+                        "time_limit",
+                    ]),
+                    column_widths: vec![
+                        Constraint::Percentage(5),
+                        Constraint::Percentage(10),
+                        Constraint::Percentage(10),
+                        Constraint::Percentage(15),
+                        Constraint::Percentage(15),
+                        Constraint::Percentage(15),
+                        Constraint::Percentage(15),
+                        Constraint::Percentage(10),
+                        Constraint::Percentage(10),
+                    ],
+                },
+                |data| {
+                    let progress =
+                        (data.counters.n_running_tasks / get_num_tasks(data.counters)) as f32;
+                    let progress =
+                        render_progress_bar_at(progress, 12, ProgressPrintStyle::default());
+
+                    let finished =
+                        (data.counters.n_finished_tasks / get_num_tasks(data.counters)) as f32;
+                    let finished =
+                        render_progress_bar_at(finished, 12, ProgressPrintStyle::default());
+
+                    let failed =
+                        (data.counters.n_failed_tasks / get_num_tasks(data.counters)) as f32;
+                    let failed = render_progress_bar_at(failed, 12, ProgressPrintStyle::default());
+
+                    let cancelled =
+                        (data.counters.n_canceled_tasks / get_num_tasks(data.counters)) as f32;
+                    let cancelled =
+                        render_progress_bar_at(cancelled, 12, ProgressPrintStyle::default());
+
+                    Row::new(vec![
+                        Cell::from(data.id.to_string()),
+                        Cell::from(data.info.to_string()),
+                        Cell::from(data.job_type.to_string()),
+                        Cell::from(progress),
+                        Cell::from(finished),
+                        Cell::from(failed),
+                        Cell::from(cancelled),
+                        Cell::from(data.max_fails.to_string()),
+                        Cell::from(data.time_limit.to_string()),
+                    ])
+                },
+            );
+        }
+    }
+}
+
+struct WorkerJobRow {
+    pub id: u32,
+    pub info: String,
+    pub job_type: String,
+    pub tasks: String,
+    pub counters: JobTaskCounters,
+    pub max_fails: String,
+    pub priority: String,
+    pub time_limit: String,
+}
+
+fn create_rows(detail: Vec<(u32, JobDetail)>, for_worker: u32) -> Vec<WorkerJobRow> {
+    detail
+        .iter()
+        .filter_map(|(id, detail)| {
+            if *id == for_worker {
+                Some(WorkerJobRow {
+                    id: detail.clone().info.id,
+                    info: detail.clone().info.name,
+                    job_type: create_job_type_string(detail.clone()),
+                    tasks: create_task_ids_string(detail.clone()),
+                    counters: detail.clone().info.counters,
+                    max_fails: create_max_fails_string(detail.clone()),
+                    priority: create_priority_string(detail.clone()),
+                    time_limit: create_time_limit_string(detail.clone()),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn create_task_ids_string(detail: JobDetail) -> String {
+    let v = serde_json::to_value(&detail.tasks.iter().map(|x| x.task_id).collect::<Vec<u32>>())
+        .unwrap();
+    v.to_string()
+}
+
+fn create_job_type_string(detail: JobDetail) -> String {
+    let v = serde_json::to_value(&detail.job_type).unwrap();
+    let u: JobType = serde_json::from_value(v).unwrap();
+    match u {
+        JobType::Simple => "Simple".to_string(),
+        JobType::Array(_) => "Array".to_string(),
+    }
+}
+
+fn create_max_fails_string(detail: JobDetail) -> String {
+    let v = serde_json::to_value(&detail.max_fails).unwrap();
+    v.to_string()
+}
+
+fn create_priority_string(detail: JobDetail) -> String {
+    let v = serde_json::to_value(&detail.priority).unwrap();
+    v.to_string()
+}
+
+fn create_time_limit_string(detail: JobDetail) -> String {
+    let v = serde_json::to_value(&detail.time_limit).unwrap();
+    v.to_string()
+}
+
+fn get_num_tasks(counters: JobTaskCounters) -> u32 {
+    counters.n_canceled_tasks
+        + counters.n_failed_tasks
+        + counters.n_finished_tasks
+        + counters.n_running_tasks
+}

--- a/crates/hyperqueue/src/dashboard/ui/styles.rs
+++ b/crates/hyperqueue/src/dashboard/ui/styles.rs
@@ -7,7 +7,7 @@ use tui::{
 /// The Style associated with the hyperqueue logo text
 pub fn style_header_text() -> Style {
     Style::default()
-        .fg(Color::White)
+        .fg(Color::Green)
         .bg(Color::Black)
         .add_modifier(Modifier::BOLD)
 }
@@ -48,4 +48,11 @@ pub fn style_table_highlight() -> Style {
 
 pub fn style_table_row() -> Style {
     Style::default().fg(Color::Gray).bg(Color::Black)
+}
+
+pub fn style_footer_text() -> Style {
+    Style::default()
+        .fg(Color::Green)
+        .bg(Color::Black)
+        .add_modifier(Modifier::BOLD)
 }

--- a/crates/hyperqueue/src/dashboard/ui/widgets/progressbar.rs
+++ b/crates/hyperqueue/src/dashboard/ui/widgets/progressbar.rs
@@ -1,3 +1,5 @@
+use crate::server::job::JobTaskCounters;
+
 /**
 *   Progress bar's structure: [StartBlock]<>[indicator][][]<>[][][][unused_area]<>[end_block]
 **/
@@ -39,6 +41,50 @@ pub fn render_progress_bar_at(
         filler,
         style.end_block,
         (progress * 100.00) as u32
+    )
+}
+
+pub fn render_job_task_progress_bar(counters: &JobTaskCounters, style: ProgressPrintStyle) -> String {
+    let num_tasks = (counters.n_canceled_tasks
+        + counters.n_failed_tasks
+        + counters.n_finished_tasks
+        + counters.n_running_tasks) as f32;
+    let num_characters = 20;
+
+    let p_running_tasks = counters.n_running_tasks as f32 / num_tasks ;
+    let p_finished_tasks = counters.n_finished_tasks as f32/ num_tasks;
+    let p_failed_tasks = counters.n_failed_tasks as f32/ num_tasks;
+    let p_cancelled_tasks = counters.n_canceled_tasks as f32/ num_tasks;
+
+    let running_tasks_indicator_count = (p_running_tasks * (num_characters as f32)).ceil();
+    let running_tasks_indicator = std::iter::repeat(">")
+        .take(running_tasks_indicator_count as usize)
+        .collect::<String>();
+
+    let finished_tasks_indicator_count = (p_finished_tasks * (num_characters as f32)).ceil();
+    let finished_tasks_indicator = std::iter::repeat(style.indicator)
+        .take(finished_tasks_indicator_count as usize)
+        .collect::<String>();
+
+    let cancelled_task_indicator_count = (p_cancelled_tasks * (num_characters as f32)).ceil();
+    let cancelled_tasks_indicator = std::iter::repeat('c')
+        .take(cancelled_task_indicator_count as usize)
+        .collect::<String>();
+
+    let failed_tasks_indicator_count = (p_failed_tasks * (num_characters as f32)).ceil();
+    let failed_tasks_indicator = std::iter::repeat('F')
+        .take(failed_tasks_indicator_count as usize)
+        .collect::<String>();
+
+    format!(
+        "{}{}{}{}{}{}: {}%",
+        style.start_block,
+        running_tasks_indicator,
+        finished_tasks_indicator,
+        cancelled_tasks_indicator,
+        failed_tasks_indicator,
+        style.end_block,
+        (running_tasks_indicator_count * 100.00) as u32
     )
 }
 

--- a/crates/hyperqueue/src/dashboard/ui/widgets/table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/widgets/table.rs
@@ -45,6 +45,10 @@ impl<T> StatefulTable<T> {
         }
     }
 
+    pub fn clear_selection(&mut self) {
+        self.state.select(None);
+    }
+
     pub fn current_selection(&self) -> Option<&T> {
         if let Some(selection_index) = self.state.selected() {
             return self.items.get(selection_index);

--- a/crates/hyperqueue/src/dashboard/ui_loop.rs
+++ b/crates/hyperqueue/src/dashboard/ui_loop.rs
@@ -12,7 +12,7 @@ use crate::dashboard::events::DashboardEvent;
 use crate::dashboard::state::DashboardState;
 use crate::dashboard::ui::screen::ClusterState;
 use crate::dashboard::ui::terminal::{initialize_terminal, DashboardTerminal};
-use crate::dashboard::utils::get_hw_overview;
+use crate::dashboard::utils::{get_hw_overview, get_running_job_info};
 use crate::server::bootstrap::get_client_connection;
 use crate::transfer::connection::ClientConnection;
 
@@ -58,12 +58,14 @@ async fn update(
     connection: &mut ClientConnection,
 ) -> anyhow::Result<()> {
     let overview = get_hw_overview(connection).await?;
-    let worker_info = get_worker_list(connection, false).await?;
+    let worker_info = get_worker_list(connection, true).await?;
+    let worker_task_data = get_running_job_info(connection).await?;
 
     let screen = state.get_current_screen_mut();
     screen.update(ClusterState {
         overview,
         worker_info,
+        worker_jobs_info: worker_task_data,
     });
     Ok(())
 }

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -229,7 +229,7 @@ pub struct JobInfoResponse {
     pub jobs: Vec<JobInfo>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct JobDetail {
     pub info: JobInfo,
     pub job_type: JobType,


### PR DESCRIPTION
This is an early implementation to open the discussion about if this table should exist and what information it should have, I'll improve it over the next commits.

Here I have used it to see the tasks that have run on a worker and their status/progress.

![Screenshot from 2021-11-05 08-08-28](https://user-images.githubusercontent.com/9003687/140472099-d2a1b5e8-0a95-43e9-8fb6-0d6bba4216c6.png)


