### PR TITLE
Use newtype indices for resource index types

### DIFF
--- a/crates/hyperqueue/src/client/commands/submit.rs
+++ b/crates/hyperqueue/src/client/commands/submit.rs
@@ -193,11 +193,13 @@ impl SubmitOpts {
             .map(|gr| {
                 let rq = gr.get();
                 GenericResourceRequest {
-                    resource: generic_resource_names
-                        .iter()
-                        .position(|name| name == &rq.0)
-                        .expect("Server does not return requested name")
-                        as GenericResourceId,
+                    resource: GenericResourceId::new(
+                        generic_resource_names
+                            .iter()
+                            .position(|name| name == &rq.0)
+                            .expect("Server does not return requested name")
+                            as u32,
+                    ),
                     amount: rq.1,
                 }
             })

--- a/crates/hyperqueue/src/client/resources.rs
+++ b/crates/hyperqueue/src/client/resources.rs
@@ -79,7 +79,8 @@ pub fn resource_request_to_string(rq: &ResourceRequest, resource_names: &[String
     for grq in rq.generic_requests() {
         result.push_str(&format!(
             "\n{}: {}",
-            resource_names[grq.resource as usize], grq.amount,
+            resource_names[grq.resource.as_num() as usize],
+            grq.amount,
         ))
     }
     result

--- a/crates/hyperqueue/src/server/client.rs
+++ b/crates/hyperqueue/src/server/client.rs
@@ -615,7 +615,7 @@ async fn handle_submit(
             JobType::Simple => 1,
             JobType::Array(a) => a.id_count(),
         };
-        let tako_base_id = state.new_task_id(task_count).as_u64();
+        let tako_base_id = state.new_task_id(task_count).as_num();
         let task_defs = match (&message.job_type, message.entries.clone()) {
             (JobType::Simple, _) => vec![make_task(job_id, 0.into(), tako_base_id.into(), None)],
             (JobType::Array(a), None) => a

--- a/crates/hyperqueue/src/server/job.rs
+++ b/crates/hyperqueue/src/server/job.rs
@@ -136,7 +136,7 @@ impl Job {
         time_limit: Option<std::time::Duration>,
         job_log: Option<PathBuf>,
     ) -> Self {
-        let base = base_task_id.as_u64();
+        let base = base_task_id.as_num();
         let state = match &job_type {
             JobType::Simple => JobState::SingleTask(JobTaskState::Waiting),
             JobType::Array(m) if m.id_count() == 1 => JobState::SingleTask(JobTaskState::Waiting),

--- a/crates/hyperqueue/src/server/state.rs
+++ b/crates/hyperqueue/src/server/state.rs
@@ -110,7 +110,7 @@ impl State {
             .next()?
             .1;
         let job = self.jobs.get_mut(&job_id)?;
-        if task_id < TakoTaskId::new(job.base_task_id.as_u64() + job.n_tasks() as u64) {
+        if task_id < TakoTaskId::new(job.base_task_id.as_num() + job.n_tasks() as u64) {
             Some(job)
         } else {
             None
@@ -295,7 +295,7 @@ mod tests {
                 .get_job_mut_by_tako_task_id(100.into())
                 .unwrap()
                 .job_id
-                .as_u32(),
+                .as_num(),
             223
         );
         assert_eq!(
@@ -303,7 +303,7 @@ mod tests {
                 .get_job_mut_by_tako_task_id(101.into())
                 .unwrap()
                 .job_id
-                .as_u32(),
+                .as_num(),
             223
         );
         assert_eq!(
@@ -311,7 +311,7 @@ mod tests {
                 .get_job_mut_by_tako_task_id(109.into())
                 .unwrap()
                 .job_id
-                .as_u32(),
+                .as_num(),
             223
         );
         assert_eq!(
@@ -319,7 +319,7 @@ mod tests {
                 .get_job_mut_by_tako_task_id(110.into())
                 .unwrap()
                 .job_id
-                .as_u32(),
+                .as_num(),
             224
         );
         assert_eq!(
@@ -327,7 +327,7 @@ mod tests {
                 .get_job_mut_by_tako_task_id(124.into())
                 .unwrap()
                 .job_id
-                .as_u32(),
+                .as_num(),
             224
         );
         assert_eq!(
@@ -335,7 +335,7 @@ mod tests {
                 .get_job_mut_by_tako_task_id(125.into())
                 .unwrap()
                 .job_id
-                .as_u32(),
+                .as_num(),
             225
         );
         assert_eq!(
@@ -343,7 +343,7 @@ mod tests {
                 .get_job_mut_by_tako_task_id(126.into())
                 .unwrap()
                 .job_id
-                .as_u32(),
+                .as_num(),
             226
         );
         assert!(state.get_job_mut_by_tako_task_id(127.into()).is_none());
@@ -353,7 +353,7 @@ mod tests {
                 .get_job_mut_by_tako_task_id(130.into())
                 .unwrap()
                 .job_id
-                .as_u32(),
+                .as_num(),
             227
         );
         assert!(state.get_job_mut_by_tako_task_id(131.into()).is_none());

--- a/crates/hyperqueue/src/stream/reader/logfile.rs
+++ b/crates/hyperqueue/src/stream/reader/logfile.rs
@@ -332,7 +332,7 @@ impl LogFile {
                         if buffer.last() != Some(&b'\n') {
                             buffer.push(b'\n');
                         }
-                        let color = colors[task_id.as_u32() as usize % colors.len()];
+                        let color = colors[task_id.as_num() as usize % colors.len()];
                         let header =
                             format!("{:0width$}:{}>", task_id, channel_id, width = id_width,);
                         write!(
@@ -354,7 +354,7 @@ impl LogFile {
                         if !opts.show_empty && !has_content.contains(&task_id) {
                             continue;
                         }
-                        let color = colors[task_id.as_u32() as usize % colors.len()];
+                        let color = colors[task_id.as_num() as usize % colors.len()];
                         writeln!(
                             stdout_buf,
                             "{}",

--- a/crates/hyperqueue/src/worker/hwdetect.rs
+++ b/crates/hyperqueue/src/worker/hwdetect.rs
@@ -1,7 +1,8 @@
 use crate::common::parser::{format_parse_error, p_u32, NomResult};
 
 use tako::common::resources::{
-    CpuId, CpusDescriptor, GenericResourceDescriptor, GenericResourceDescriptorKind, NumOfCpus,
+    CpuId, CpusDescriptor, GenericResourceDescriptor, GenericResourceDescriptorKind,
+    GenericResourceIndex, NumOfCpus,
 };
 
 use nom::bytes::complete::tag;
@@ -33,8 +34,8 @@ pub fn detect_generic_resource() -> anyhow::Result<Vec<GenericResourceDescriptor
             generic.push(GenericResourceDescriptor {
                 name: "gpus".to_string(),
                 kind: GenericResourceDescriptorKind::Indices(GenericResourceKindIndices {
-                    start: 0,
-                    end: count as u32 - 1,
+                    start: GenericResourceIndex::new(0),
+                    end: GenericResourceIndex::new(count as u32 - 1),
                 }),
             })
         }

--- a/crates/hyperqueue/src/worker/hwdetect.rs
+++ b/crates/hyperqueue/src/worker/hwdetect.rs
@@ -73,7 +73,7 @@ fn p_cpu_range(input: &str) -> NomResult<Vec<CpuId>> {
                 space0,
             )),
         )),
-        |(u, v)| crate::Result::Ok((u..=v.unwrap_or(u)).collect()),
+        |(u, v)| crate::Result::Ok((u..=v.unwrap_or(u)).map(|id| id.into()).collect()),
     )(input)
 }
 
@@ -91,20 +91,21 @@ fn parse_range(input: &str) -> anyhow::Result<Vec<CpuId>> {
 #[cfg(test)]
 mod tests {
     use super::{parse_range, read_linux_numa};
+    use tako::common::macros::AsIdVec;
 
     #[test]
     fn test_parse_range() {
-        assert_eq!(parse_range("10").unwrap(), vec![10]);
-        assert_eq!(parse_range("10\n").unwrap(), vec![10]);
-        assert_eq!(parse_range("0-3\n").unwrap(), vec![0, 1, 2, 3]);
+        assert_eq!(parse_range("10").unwrap(), vec![10].to_ids());
+        assert_eq!(parse_range("10\n").unwrap(), vec![10].to_ids());
+        assert_eq!(parse_range("0-3\n").unwrap(), vec![0, 1, 2, 3].to_ids());
         assert_eq!(
             parse_range("111-115\n").unwrap(),
-            vec![111, 112, 113, 114, 115]
+            vec![111, 112, 113, 114, 115].to_ids()
         );
-        assert_eq!(parse_range("2,7, 10").unwrap(), vec![2, 7, 10]);
+        assert_eq!(parse_range("2,7, 10").unwrap(), vec![2, 7, 10].to_ids());
         assert_eq!(
             parse_range("2-7,10-12,20").unwrap(),
-            vec![2, 3, 4, 5, 6, 7, 10, 11, 12, 20]
+            vec![2, 3, 4, 5, 6, 7, 10, 11, 12, 20].to_ids()
         );
         assert!(parse_range("xx\n").is_err());
         assert!(parse_range("-\n").is_err());

--- a/crates/hyperqueue/src/worker/parser.rs
+++ b/crates/hyperqueue/src/worker/parser.rs
@@ -87,13 +87,17 @@ fn parse_resource_definition(input: &str) -> anyhow::Result<GenericResourceDescr
 #[cfg(test)]
 mod test {
     use super::*;
+    use tako::common::macros::AsIdVec;
 
     #[test]
     fn test_parse_cpu_def() {
-        assert_eq!(parse_cpu_definition("4").unwrap(), vec![vec![0, 1, 2, 3]]);
+        assert_eq!(
+            parse_cpu_definition("4").unwrap(),
+            vec![vec![0, 1, 2, 3].to_ids()]
+        );
         assert_eq!(
             parse_cpu_definition("2x3").unwrap(),
-            vec![vec![0, 1, 2], vec![3, 4, 5]]
+            vec![vec![0, 1, 2].to_ids(), vec![3, 4, 5].to_ids()]
         );
     }
 

--- a/crates/hyperqueue/src/worker/parser.rs
+++ b/crates/hyperqueue/src/worker/parser.rs
@@ -43,7 +43,10 @@ fn p_kind_indices(input: &str) -> NomResult<GenericResourceDescriptorKind> {
             tuple((multispace0, char(')'), multispace0)),
         ),
         |(start, end)| {
-            GenericResourceDescriptorKind::Indices(GenericResourceKindIndices { start, end })
+            GenericResourceDescriptorKind::Indices(GenericResourceKindIndices {
+                start: start.into(),
+                end: end.into(),
+            })
         },
     )(input)
 }
@@ -98,13 +101,13 @@ mod test {
     fn test_parse_resource_def() {
         let rd = parse_resource_definition("gpu=indices(10-123)").unwrap();
         assert_eq!(rd.name, "gpu");
-        assert!(matches!(
-            rd.kind,
-            GenericResourceDescriptorKind::Indices(GenericResourceKindIndices {
-                start: 10,
-                end: 123
-            })
-        ));
+        match rd.kind {
+            GenericResourceDescriptorKind::Indices(indices) => {
+                assert_eq!(indices.start.as_num(), 10);
+                assert_eq!(indices.end.as_num(), 123);
+            }
+            _ => panic!("Wrong result"),
+        }
 
         let rd = parse_resource_definition("mem=sum(1000_3000_2000)").unwrap();
         assert_eq!(rd.name, "mem");

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -181,7 +181,7 @@ async fn launcher_main(
             let resource_names = &state.resource_names;
 
             for rq in task_ref.get().configuration.resources.generic_requests() {
-                let resource_name = &resource_names[rq.resource as usize];
+                let resource_name = &resource_names[rq.resource.as_num() as usize];
                 program.env.insert(
                     format!("HQ_RESOURCE_REQUEST_{}", resource_name).into(),
                     rq.amount.to_string().into(),
@@ -189,7 +189,7 @@ async fn launcher_main(
             }
 
             for alloc in &allocation.generic_allocations {
-                let resource_name = &resource_names[alloc.resource as usize];
+                let resource_name = &resource_names[alloc.resource.as_num() as usize];
                 if let Some(indices) = alloc.value.to_comma_delimited_list() {
                     if resource_name == "gpus" {
                         /* Extra hack for GPUS */

--- a/crates/tako/src/common/macros.rs
+++ b/crates/tako/src/common/macros.rs
@@ -25,16 +25,6 @@ macro_rules! define_id_type {
             }
 
             #[inline]
-            pub fn as_u32(&self) -> u32 {
-                self.0 as u32
-            }
-
-            #[inline]
-            pub fn as_u64(&self) -> u64 {
-                self.0 as u64
-            }
-
-            #[inline]
             pub fn as_num(&self) -> $type {
                 self.0 as $type
             }

--- a/crates/tako/src/common/macros.rs
+++ b/crates/tako/src/common/macros.rs
@@ -68,7 +68,19 @@ macro_rules! define_id_type {
                 Ok($name(s.parse::<$type>()?))
             }
         }
+
+        impl $crate::common::macros::AsIdVec<$name> for ::std::vec::Vec<$type> {
+            #[inline]
+            fn to_ids(self) -> ::std::vec::Vec<$name> {
+                self.into_iter().map(|id| id.into()).collect()
+            }
+        }
     };
+}
+
+/// Converts a vector of integers into a vector of a corresponding newtype index
+pub trait AsIdVec<IdType> {
+    fn to_ids(self) -> Vec<IdType>;
 }
 
 /// Create a newtype that will contain a type wrapped inside [`WrappedRcRefCell`].

--- a/crates/tako/src/common/macros.rs
+++ b/crates/tako/src/common/macros.rs
@@ -33,6 +33,11 @@ macro_rules! define_id_type {
             pub fn as_u64(&self) -> u64 {
                 self.0 as u64
             }
+
+            #[inline]
+            pub fn as_num(&self) -> $type {
+                self.0 as $type
+            }
         }
 
         impl ::std::convert::From<$type> for $name {

--- a/crates/tako/src/common/resources/descriptor.rs
+++ b/crates/tako/src/common/resources/descriptor.rs
@@ -24,7 +24,7 @@ impl GenericResourceDescriptorKind {
     pub fn size(&self) -> GenericResourceAmount {
         match self {
             GenericResourceDescriptorKind::Indices(idx) if idx.end >= idx.start => {
-                (idx.end + 1 - idx.start) as u64
+                (idx.end.as_num() + 1 - idx.start.as_num()) as u64
             }
             GenericResourceDescriptorKind::Indices(_) => 0,
             GenericResourceDescriptorKind::Sum(x) => x.size,
@@ -170,12 +170,16 @@ mod tests {
     }
 
     impl GenericResourceDescriptor {
-        pub fn indices(name: &str, start: GenericResourceIndex, end: GenericResourceIndex) -> Self {
+        pub fn indices<Index: Into<GenericResourceIndex>>(
+            name: &str,
+            start: Index,
+            end: Index,
+        ) -> Self {
             GenericResourceDescriptor {
                 name: name.to_string(),
                 kind: GenericResourceDescriptorKind::Indices(GenericResourceKindIndices {
-                    start,
-                    end,
+                    start: start.into(),
+                    end: end.into(),
                 }),
             }
         }

--- a/crates/tako/src/common/resources/descriptor.rs
+++ b/crates/tako/src/common/resources/descriptor.rs
@@ -62,7 +62,7 @@ pub fn cpu_descriptor_from_socket_size(
                 .map(|_| {
                     let id = cpu_id_counter;
                     cpu_id_counter += 1;
-                    id
+                    id.into()
                 })
                 .collect::<Vec<CpuId>>()
         })
@@ -159,6 +159,7 @@ impl ResourceDescriptor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::macros::AsIdVec;
 
     impl ResourceDescriptor {
         pub fn simple(n_cpus: NumOfCpus) -> Self {
@@ -193,23 +194,26 @@ mod tests {
 
     #[test]
     fn test_resources_to_summary() {
-        let d = ResourceDescriptor::new(vec![vec![0]], Vec::new());
+        let d = ResourceDescriptor::new(vec![vec![0].to_ids()], Vec::new());
         assert_eq!(&d.summary(false), "1x1 cpus");
 
-        let d = ResourceDescriptor::new(vec![vec![0, 1, 2]], Vec::new());
+        let d = ResourceDescriptor::new(vec![vec![0, 1, 2].to_ids()], Vec::new());
         assert_eq!(&d.summary(true), "1x3 cpus");
 
-        let d = ResourceDescriptor::new(vec![vec![0, 1, 2, 4], vec![10, 11, 12, 14]], Vec::new());
+        let d = ResourceDescriptor::new(
+            vec![vec![0, 1, 2, 4].to_ids(), vec![10, 11, 12, 14].to_ids()],
+            Vec::new(),
+        );
         assert_eq!(&d.summary(true), "2x4 cpus");
 
         let d = ResourceDescriptor::new(
             vec![
-                vec![0, 1],
-                vec![10, 11],
-                vec![20, 21],
-                vec![30, 31],
-                vec![40, 41],
-                vec![50, 51, 52, 53, 54, 55],
+                vec![0, 1].to_ids(),
+                vec![10, 11].to_ids(),
+                vec![20, 21].to_ids(),
+                vec![30, 31].to_ids(),
+                vec![40, 41].to_ids(),
+                vec![50, 51, 52, 53, 54, 55].to_ids(),
             ],
             Vec::new(),
         );
@@ -220,7 +224,7 @@ mod tests {
             GenericResourceDescriptor::indices("Ccc", 1, 132),
             GenericResourceDescriptor::sum("Bbb", 100_000_000),
         ];
-        let d = ResourceDescriptor::new(vec![vec![0, 1]], generic);
+        let d = ResourceDescriptor::new(vec![vec![0, 1].to_ids()], generic);
         assert_eq!(
             &d.summary(true),
             "1x2 cpus\nAaa: Indices(0-9)\nBbb: Sum(100000000)\nCcc: Indices(1-132)"
@@ -229,10 +233,13 @@ mod tests {
 
     #[test]
     fn test_resources_to_describe() {
-        let d = ResourceDescriptor::new(vec![vec![0]], Vec::new());
+        let d = ResourceDescriptor::new(vec![vec![0].to_ids()], Vec::new());
         assert_eq!(&d.full_describe(), "[0]");
 
-        let d = ResourceDescriptor::new(vec![vec![0, 1, 2, 4], vec![10, 11, 12, 14]], Vec::new());
+        let d = ResourceDescriptor::new(
+            vec![vec![0, 1, 2, 4].to_ids(), vec![10, 11, 12, 14].to_ids()],
+            Vec::new(),
+        );
         assert_eq!(&d.full_describe(), "[0, 1, 2, 4], [10, 11, 12, 14]");
     }
 }

--- a/crates/tako/src/common/resources/mod.rs
+++ b/crates/tako/src/common/resources/mod.rs
@@ -2,14 +2,7 @@ pub mod allocation;
 pub mod descriptor;
 pub mod request;
 
-pub type NumOfCpus = u32;
-pub type CpuId = u32;
-
-/// Resource identification wrt. global resource list (stored in Core)
-pub type GenericResourceId = u32;
-pub type GenericResourceAmount = u64;
-pub type GenericResourceIndex = u32;
-
+use crate::define_id_type;
 pub use allocation::{
     GenericResourceAllocation, GenericResourceAllocationValue, GenericResourceAllocations,
     ResourceAllocation,
@@ -18,3 +11,15 @@ pub use descriptor::{
     CpusDescriptor, GenericResourceDescriptor, GenericResourceDescriptorKind, ResourceDescriptor,
 };
 pub use request::{CpuRequest, GenericResourceRequest, ResourceRequest, TimeRequest};
+
+pub type NumOfCpus = u32;
+pub type CpuId = u32;
+
+// Identifies a globally unique Resource request stored in Core.
+define_id_type!(GenericResourceId, u32);
+
+/// Represents some amount within a single generic resource (e.g. 100 MiB of memory).
+pub type GenericResourceAmount = u64;
+
+/// Represents an index within a single generic resource (e.g. GPU with ID 1).
+pub type GenericResourceIndex = u32;

--- a/crates/tako/src/common/resources/mod.rs
+++ b/crates/tako/src/common/resources/mod.rs
@@ -21,5 +21,5 @@ define_id_type!(GenericResourceId, u32);
 /// Represents some amount within a single generic resource (e.g. 100 MiB of memory).
 pub type GenericResourceAmount = u64;
 
-/// Represents an index within a single generic resource (e.g. GPU with ID 1).
-pub type GenericResourceIndex = u32;
+// Represents an index within a single generic resource (e.g. GPU with ID 1).
+define_id_type!(GenericResourceIndex, u32);

--- a/crates/tako/src/common/resources/mod.rs
+++ b/crates/tako/src/common/resources/mod.rs
@@ -13,7 +13,8 @@ pub use descriptor::{
 pub use request::{CpuRequest, GenericResourceRequest, ResourceRequest, TimeRequest};
 
 pub type NumOfCpus = u32;
-pub type CpuId = u32;
+define_id_type!(CpuId, u32);
+define_id_type!(SocketId, u32);
 
 // Identifies a globally unique Resource request stored in Core.
 define_id_type!(GenericResourceId, u32);

--- a/crates/tako/src/common/resources/request.rs
+++ b/crates/tako/src/common/resources/request.rs
@@ -156,15 +156,15 @@ mod tests {
     fn test_resource_request_validate() {
         let mut rq: ResourceRequest = CpuRequest::All.into();
         rq.add_generic_request(GenericResourceRequest {
-            resource: 10,
+            resource: 10.into(),
             amount: 4,
         });
         rq.add_generic_request(GenericResourceRequest {
-            resource: 7,
+            resource: 7.into(),
             amount: 6,
         });
         rq.add_generic_request(GenericResourceRequest {
-            resource: 10,
+            resource: 10.into(),
             amount: 6,
         });
         assert!(rq.validate().is_err())

--- a/crates/tako/src/common/trace.rs
+++ b/crates/tako/src/common/trace.rs
@@ -61,7 +61,7 @@ pub fn trace_task_new(task_id: TaskId, inputs: impl Iterator<Item = u64>) {
     tracing::info!(
         action = "task",
         event = "create",
-        task = task_id.as_u64(),
+        task = task_id.as_num(),
         inputs = make_inputs().as_str()
     );
 }
@@ -70,8 +70,8 @@ pub fn trace_task_new_finished(task_id: TaskId, size: u64, worker_id: WorkerId) 
     tracing::info!(
         action = "task",
         event = "create",
-        task = task_id.as_u64(),
-        worker = worker_id.as_u32(),
+        task = task_id.as_num(),
+        worker = worker_id.as_num(),
         size = size
     );
 }
@@ -80,8 +80,8 @@ pub fn trace_task_assign(task_id: TaskId, worker_id: WorkerId) {
     tracing::info!(
         action = "task",
         event = "assign",
-        worker = worker_id.as_u32(),
-        task = task_id.as_u64()
+        worker = worker_id.as_num(),
+        task = task_id.as_num()
     );
 }
 #[inline(always)]
@@ -89,8 +89,8 @@ pub fn trace_task_send(task_id: TaskId, worker_id: WorkerId) {
     tracing::info!(
         action = "task",
         event = "send",
-        task = task_id.as_u64(),
-        worker = worker_id.as_u32(),
+        task = task_id.as_num(),
+        worker = worker_id.as_num(),
     );
 }
 #[inline(always)]
@@ -98,8 +98,8 @@ pub fn trace_task_place(task_id: TaskId, worker_id: WorkerId) {
     tracing::info!(
         action = "task",
         event = "place",
-        task = task_id.as_u64(),
-        worker = worker_id.as_u32(),
+        task = task_id.as_num(),
+        worker = worker_id.as_num(),
     );
 }
 #[inline(always)]
@@ -107,8 +107,8 @@ pub fn trace_task_finish(task_id: TaskId, worker_id: WorkerId, size: u64, durati
     tracing::info!(
         action = "task",
         event = "finish",
-        task = task_id.as_u64(),
-        worker = worker_id.as_u32(),
+        task = task_id.as_num(),
+        worker = worker_id.as_num(),
         start = duration.0,
         stop = duration.1,
         size = size
@@ -116,13 +116,13 @@ pub fn trace_task_finish(task_id: TaskId, worker_id: WorkerId, size: u64, durati
 }
 #[inline(always)]
 pub fn trace_task_remove(task_id: TaskId) {
-    tracing::info!(action = "task", event = "remove", task = task_id.as_u64(),);
+    tracing::info!(action = "task", event = "remove", task = task_id.as_num(),);
 }
 #[inline(always)]
 pub fn trace_worker_new(worker_id: WorkerId, configuration: &WorkerConfiguration) {
     tracing::info!(
         action = "new-worker",
-        worker_id = worker_id.as_u32(),
+        worker_id = worker_id.as_num(),
         resources = format!("{:?}", &configuration.resources).as_str(),
         address = configuration.listen_address.as_str(),
     );
@@ -131,18 +131,18 @@ pub fn trace_worker_new(worker_id: WorkerId, configuration: &WorkerConfiguration
 pub fn trace_worker_steal(task_id: TaskId, from: WorkerId, to: WorkerId) {
     tracing::info!(
         action = "steal",
-        task = task_id.as_u64(),
-        from = from.as_u32(),
-        to = to.as_u32()
+        task = task_id.as_num(),
+        from = from.as_num(),
+        to = to.as_num()
     );
 }
 #[inline(always)]
 pub fn trace_worker_steal_response(task_id: TaskId, from: WorkerId, to: WorkerId, result: &str) {
     tracing::info!(
         action = "steal-response",
-        task = task_id.as_u64(),
-        from = from.as_u32(),
-        to = to.as_u32(),
+        task = task_id.as_num(),
+        from = from.as_num(),
+        to = to.as_num(),
         result = result
     );
 }
@@ -150,8 +150,8 @@ pub fn trace_worker_steal_response(task_id: TaskId, from: WorkerId, to: WorkerId
 pub fn trace_worker_steal_response_missing(task_id: TaskId, from: WorkerId) {
     tracing::info!(
         action = "steal-response",
-        task = task_id.as_u64(),
-        from = from.as_u32(),
+        task = task_id.as_num(),
+        from = from.as_num(),
         to = 0,
         result = "missing"
     );

--- a/crates/tako/src/server/core.rs
+++ b/crates/tako/src/server/core.rs
@@ -348,12 +348,12 @@ impl Core {
 
     pub fn get_or_create_generic_resource_id(&mut self, name: &str) -> GenericResourceId {
         if let Some(p) = self.resource_names.iter().position(|n| name == n) {
-            p as GenericResourceId
+            GenericResourceId::new(p as u32)
         } else {
             let p = self.resource_names.len();
             log::debug!("New generic resource registered '{}' as {}", name, p);
             self.resource_names.push(name.to_string());
-            p as GenericResourceId
+            GenericResourceId::new(p as u32)
         }
     }
 

--- a/crates/tako/src/server/reactor.rs
+++ b/crates/tako/src/server/reactor.rs
@@ -710,7 +710,7 @@ mod tests {
 
         let new_w = comm.take_new_workers();
         assert_eq!(new_w.len(), 1);
-        assert_eq!(new_w[0].0.as_u32(), 402);
+        assert_eq!(new_w[0].0.as_num(), 402);
         assert_eq!(new_w[0].1.resources.cpus, as_cpus(vec![vec![0, 1, 2, 3]]));
 
         assert!(
@@ -744,7 +744,7 @@ mod tests {
 
         let new_w = comm.take_new_workers();
         assert_eq!(new_w.len(), 1);
-        assert_eq!(new_w[0].0.as_u32(), 502);
+        assert_eq!(new_w[0].0.as_num(), 502);
         assert_eq!(
             new_w[0].1.resources.cpus,
             as_cpus(vec![vec![2, 3, 4], vec![100, 150]])
@@ -1070,7 +1070,7 @@ mod tests {
         ));
         let mut msgs = comm.take_client_task_errors(1);
         let (id, cs, _) = msgs.pop().unwrap();
-        assert_eq!(id.as_u64(), 13);
+        assert_eq!(id.as_num(), 13);
         assert_eq!(sorted_vec(cs), vec![15, 16, 17].to_ids());
         comm.emptiness_check();
 

--- a/crates/tako/src/server/task.rs
+++ b/crates/tako/src/server/task.rs
@@ -198,7 +198,7 @@ impl Task {
     }
 
     pub fn increment_instance_id(&mut self) {
-        self.instance_id = InstanceId(self.instance_id.as_u32() + 1);
+        self.instance_id = InstanceId(self.instance_id.as_num() + 1);
     }
 
     pub fn make_compute_message(&self) -> ToWorkerMessage {

--- a/crates/tako/src/server/worker_load.rs
+++ b/crates/tako/src/server/worker_load.rs
@@ -65,7 +65,7 @@ impl WorkerResources {
                 r.amount
                     <= *self
                         .n_generic_resources
-                        .get(r.resource as usize)
+                        .get(r.resource.as_num() as usize)
                         .unwrap_or(&0)
             })
     }
@@ -151,7 +151,7 @@ impl WorkerLoad {
                 r.amount
                     <= *self
                         .n_generic_resources
-                        .get(r.resource as usize)
+                        .get(r.resource.as_num() as usize)
                         .unwrap_or(&0)
             })
     }
@@ -240,7 +240,7 @@ impl ResourceRequestLowerBound {
         }
         if self.empty {
             for gr in request.generic_requests() {
-                self.n_generic_resources[gr.resource as usize] = gr.amount;
+                self.n_generic_resources[gr.resource.as_num() as usize] = gr.amount;
             }
             self.empty = false;
         } else {
@@ -251,7 +251,7 @@ impl ResourceRequestLowerBound {
                 if let Some(gr) = request
                     .generic_requests()
                     .iter()
-                    .find(|gr| gr.resource as usize == i)
+                    .find(|gr| gr.resource.as_num() as usize == i)
                 {
                     *n = (*n).min(gr.amount);
                 } else {
@@ -304,7 +304,7 @@ mod tests {
         let mut lb = ResourceRequestLowerBound::new(3);
         let mut rq: ResourceRequest = CpuRequest::Compact(2).into();
         rq.add_generic_request(GenericResourceRequest {
-            resource: 1,
+            resource: 1.into(),
             amount: 10,
         });
         lb.include(&rq);
@@ -313,7 +313,7 @@ mod tests {
 
         let mut rq: ResourceRequest = CpuRequest::Compact(3).into();
         rq.add_generic_request(GenericResourceRequest {
-            resource: 1,
+            resource: 1.into(),
             amount: 5,
         });
         lb.include(&rq);
@@ -321,7 +321,7 @@ mod tests {
         assert_eq!(lb.n_generic_resources, vec![0, 5, 0]);
 
         rq.add_generic_request(GenericResourceRequest {
-            resource: 2,
+            resource: 2.into(),
             amount: 100,
         });
         lb.include(&rq);
@@ -336,11 +336,11 @@ mod tests {
         let mut lb = ResourceRequestLowerBound::new(3);
         let mut rq: ResourceRequest = CpuRequest::Compact(2).into();
         rq.add_generic_request(GenericResourceRequest {
-            resource: 0,
+            resource: 0.into(),
             amount: 10,
         });
         rq.add_generic_request(GenericResourceRequest {
-            resource: 1,
+            resource: 1.into(),
             amount: 20,
         });
         lb.include(&rq);
@@ -349,7 +349,7 @@ mod tests {
 
         let mut rq: ResourceRequest = CpuRequest::Compact(3).into();
         rq.add_generic_request(GenericResourceRequest {
-            resource: 1,
+            resource: 1.into(),
             amount: 25,
         });
         lb.include(&rq);

--- a/crates/tako/src/tests/integration/test_basic.rs
+++ b/crates/tako/src/tests/integration/test_basic.rs
@@ -1,3 +1,4 @@
+use crate::common::macros::AsIdVec;
 use crate::messages::common::StdioDef;
 use crate::tests::integration::utils::api::cancel;
 use crate::tests::integration::utils::check_file_contents;
@@ -74,7 +75,7 @@ async fn test_cancel_immediately() {
 
         let ids = handle.submit(vec![simple_task(&["sleep", "1"], 1)]).await;
         let response = cancel(&mut handle, &ids).await;
-        assert_eq!(response.cancelled_tasks, vec![1.into()]);
+        assert_eq!(response.cancelled_tasks, vec![1].to_ids());
     })
     .await;
 }
@@ -109,7 +110,7 @@ async fn test_cancel_error_task() {
         sleep(Duration::from_millis(300)).await;
 
         let response = cancel(&mut handle, &[1]).await;
-        assert_eq!(response.already_finished, vec![1.into()]);
+        assert_eq!(response.already_finished, vec![1].to_ids());
 
         assert!(handle.wait(&[1]).await.get(1).is_invalid());
     })

--- a/crates/tako/src/tests/integration/utils/worker.rs
+++ b/crates/tako/src/tests/integration/utils/worker.rs
@@ -37,7 +37,7 @@ impl Default for WorkerSecretKey {
 #[derive(Builder, Default)]
 #[builder(pattern = "owned")]
 pub struct ResourceConfig {
-    #[builder(default = "vec![vec![1]]")]
+    #[builder(default = "vec![vec![1.into()]]")]
     cpus: CpusDescriptor,
     #[builder(default)]
     generic: Vec<GenericResourceDescriptor>,
@@ -284,7 +284,7 @@ fn launcher(
 
 // Resource helpers
 pub fn cpus(count: u32) -> ResourceConfigBuilder {
-    ResourceConfigBuilder::default().cpus(vec![(0..count).collect()])
+    ResourceConfigBuilder::default().cpus(vec![(0..count).map(|id| id.into()).collect()])
 }
 pub fn numa_cpus(cpu_per_socket: u32, sockets: u32) -> ResourceConfigBuilder {
     let descriptor = cpu_descriptor_from_socket_size(sockets, cpu_per_socket);

--- a/crates/tako/src/tests/test_scheduler.rs
+++ b/crates/tako/src/tests/test_scheduler.rs
@@ -556,7 +556,7 @@ fn test_generic_resource_assign2() {
         .unwrap()
         .tasks()
         .iter()
-        .all(|t| t.get().id.as_u64() < 50));
+        .all(|t| t.get().id.as_num() < 50));
 
     assert!(!rt.worker(100).is_parked());
     assert!(rt.worker(101).is_parked());

--- a/crates/tako/src/tests/utils.rs
+++ b/crates/tako/src/tests/utils.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::common::resources::descriptor::cpu_descriptor_from_socket_size;
 use crate::common::resources::{
-    CpuRequest, GenericResourceAmount, GenericResourceDescriptor, GenericResourceId,
+    CpuId, CpuRequest, GenericResourceAmount, GenericResourceDescriptor, GenericResourceId,
     GenericResourceRequest, NumOfCpus, ResourceDescriptor, ResourceRequest,
 };
 use crate::common::{Map, WrappedRcRefCell};
@@ -692,6 +692,12 @@ pub fn submit_example_2(core: &mut Core) {
 pub fn sorted_vec<T: Ord>(mut vec: Vec<T>) -> Vec<T> {
     vec.sort();
     vec
+}
+
+pub fn as_cpus(ids: Vec<Vec<u32>>) -> Vec<Vec<CpuId>> {
+    ids.into_iter()
+        .map(|v| v.into_iter().map(|id| id.into()).collect())
+        .collect()
 }
 
 #[allow(unused)]

--- a/crates/tako/src/tests/utils.rs
+++ b/crates/tako/src/tests/utils.rs
@@ -294,13 +294,13 @@ impl TaskBuilder {
         self
     }
 
-    pub fn generic_res(
+    pub fn generic_res<Id: Into<GenericResourceId>>(
         mut self,
-        idx: GenericResourceId,
+        idx: Id,
         amount: GenericResourceAmount,
     ) -> TaskBuilder {
         self.resources.add_generic_request(GenericResourceRequest {
-            resource: idx,
+            resource: idx.into(),
             amount,
         });
         self

--- a/crates/tako/src/worker/pool.rs
+++ b/crates/tako/src/worker/pool.rs
@@ -95,9 +95,11 @@ impl ResourcePool {
                 .position(|name| name == &descriptor.name)
                 .expect("Internal error, resource name not received");
             generic_resources[idx] = match &descriptor.kind {
-                GenericResourceDescriptorKind::Indices(idx) => {
-                    GenericResourcePool::Indices((idx.start..=idx.end).collect())
-                }
+                GenericResourceDescriptorKind::Indices(idx) => GenericResourcePool::Indices(
+                    (idx.start.as_num()..=idx.end.as_num())
+                        .map(|id| id.into())
+                        .collect(),
+                ),
                 GenericResourceDescriptorKind::Sum(v) => GenericResourcePool::Sum(v.size),
             }
         }

--- a/crates/tako/src/worker/rqueue.rs
+++ b/crates/tako/src/worker/rqueue.rs
@@ -113,7 +113,7 @@ mod tests {
     fn start_tasks_map(rq: &mut ResourceWaitQueue) -> Map<u64, ResourceAllocation> {
         rq.try_start_tasks(None)
             .into_iter()
-            .map(|(t, a)| (t.get().id.as_u64(), a))
+            .map(|(t, a)| (t.get().id.as_num(), a))
             .collect()
     }
 
@@ -123,7 +123,7 @@ mod tests {
     ) -> Map<u64, ResourceAllocation> {
         rq.try_start_tasks(Some(remaining_time))
             .into_iter()
-            .map(|(t, a)| (t.get().id.as_u64(), a))
+            .map(|(t, a)| (t.get().id.as_num(), a))
             .collect()
     }
 

--- a/crates/tako/src/worker/rqueue.rs
+++ b/crates/tako/src/worker/rqueue.rs
@@ -358,7 +358,7 @@ mod tests {
         let mut request: ResourceRequest = CpuRequest::Compact(2).into();
 
         request.add_generic_request(GenericResourceRequest {
-            resource: 0,
+            resource: 0.into(),
             amount: 2,
         });
 
@@ -387,7 +387,7 @@ mod tests {
 
         let mut request: ResourceRequest = CpuRequest::Compact(2).into();
         request.add_generic_request(GenericResourceRequest {
-            resource: 0,
+            resource: 0.into(),
             amount: 8,
         });
         let t = worker_task(10, request, 1);
@@ -395,7 +395,7 @@ mod tests {
 
         let mut request: ResourceRequest = CpuRequest::Compact(2).into();
         request.add_generic_request(GenericResourceRequest {
-            resource: 0,
+            resource: 0.into(),
             amount: 12,
         });
         let t = worker_task(11, request, 1);
@@ -403,7 +403,7 @@ mod tests {
 
         let mut request: ResourceRequest = CpuRequest::Compact(2).into();
         request.add_generic_request(GenericResourceRequest {
-            resource: 1,
+            resource: 1.into(),
             amount: 50_000_000,
         });
         let t = worker_task(12, request, 1);
@@ -430,7 +430,7 @@ mod tests {
 
         let mut request: ResourceRequest = CpuRequest::Compact(2).into();
         request.add_generic_request(GenericResourceRequest {
-            resource: 0,
+            resource: 0.into(),
             amount: 18,
         });
         let t = worker_task(10, request, 1);
@@ -438,11 +438,11 @@ mod tests {
 
         let mut request: ResourceRequest = CpuRequest::Compact(2).into();
         request.add_generic_request(GenericResourceRequest {
-            resource: 0,
+            resource: 0.into(),
             amount: 10,
         });
         request.add_generic_request(GenericResourceRequest {
-            resource: 1,
+            resource: 1.into(),
             amount: 60_000_000,
         });
         let t = worker_task(11, request, 1);
@@ -450,7 +450,7 @@ mod tests {
 
         let mut request: ResourceRequest = CpuRequest::Compact(2).into();
         request.add_generic_request(GenericResourceRequest {
-            resource: 1,
+            resource: 1.into(),
             amount: 99_000_000,
         });
         let t = worker_task(12, request, 1);


### PR DESCRIPTION
`as_num()` was added so that the code wouldn't have to change if some index changes e.g. from `u32` to `u64`.