### PR TITLE
Improve parser error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
   * You can now specify the timelimit of PBS/Slurm allocations using the `HH:MM:SS` format:
     `hq alloc add pbs --time-limit 01:10:30`.
+  * Improve error messages printed when an invalid CLI parameter is entered.
 
 # v0.6.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +74,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "brownstone"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83b83224877479161e925498306710f448b13a7f6fdcf69022a60dad1fe3d1bd"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "bstr"
@@ -703,6 +718,7 @@ dependencies = [
  "jemallocator",
  "log",
  "nom",
+ "nom-supreme",
  "num_cpus",
  "orion",
  "rmp-serde",
@@ -727,6 +743,12 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indent_write"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
 
 [[package]]
 name = "indexmap"
@@ -794,6 +816,12 @@ dependencies = [
  "jemalloc-sys",
  "libc",
 ]
+
+[[package]]
+name = "joinery"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
@@ -917,6 +945,19 @@ dependencies = [
  "memchr",
  "minimal-lexical",
  "version_check",
+]
+
+[[package]]
+name = "nom-supreme"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aadc66631948f6b65da03be4c4cd8bd104d481697ecbb9bbd65719b1ec60bc9f"
+dependencies = [
+ "brownstone",
+ "indent_write",
+ "joinery",
+ "memchr",
+ "nom",
 ]
 
 [[package]]

--- a/crates/hyperqueue/Cargo.toml
+++ b/crates/hyperqueue/Cargo.toml
@@ -36,6 +36,7 @@ humantime = "2.1.0"
 num_cpus = "1.13.0"
 bincode = "1.3.3"
 nom = "7.0"
+nom-supreme = "0.6.0"
 bstr = { version = "0.2", features = ["serde1"] }
 colored = "2"
 byteorder = "1.4"

--- a/crates/hyperqueue/src/client/status.rs
+++ b/crates/hyperqueue/src/client/status.rs
@@ -1,11 +1,11 @@
 use std::str::FromStr;
 
 use nom::branch::alt;
-use nom::bytes::complete::tag;
 use nom::character::complete::space0;
 use nom::combinator::map;
 use nom::multi::separated_list1;
 use nom::sequence::tuple;
+use nom_supreme::tag::complete::tag;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -99,7 +99,7 @@ fn p_status_list(input: &str) -> NomResult<Vec<Status>> {
     separated_list1(tuple((tag(","), space0)), p_status)(input)
 }
 
-fn parse_status_list(input: &str) -> anyhow::Result<Vec<Status>> {
+pub fn parse_status_list(input: &str) -> anyhow::Result<Vec<Status>> {
     consume_all(p_status_list, input)
 }
 

--- a/crates/hyperqueue/src/common/arrayparser.rs
+++ b/crates/hyperqueue/src/common/arrayparser.rs
@@ -3,6 +3,8 @@ use nom::character::complete::char;
 use nom::combinator::{map_res, opt};
 use nom::multi::separated_list1;
 use nom::sequence::{preceded, tuple};
+use nom::Parser;
+use nom_supreme::ParserExt;
 
 use crate::common::arraydef::{IntArray, IntRange};
 use crate::common::parser::{consume_all, p_u32, NomResult};
@@ -23,7 +25,9 @@ fn p_range(input: &str) -> NomResult<IntRange> {
             }
             _ => Err(anyhow!("Invalid range")),
         },
-    )(input)
+    )
+    .context("Integer range")
+    .parse(input)
 }
 
 fn p_ranges(input: &str) -> NomResult<Vec<IntRange>> {

--- a/crates/hyperqueue/src/lib.rs
+++ b/crates/hyperqueue/src/lib.rs
@@ -8,6 +8,9 @@ pub mod stream;
 pub mod transfer;
 pub mod worker;
 
+#[cfg(test)]
+pub(crate) mod tests;
+
 pub type Map<K, V> = hashbrown::HashMap<K, V>;
 pub type Set<T> = hashbrown::HashSet<T>;
 

--- a/crates/hyperqueue/src/tests/mod.rs
+++ b/crates/hyperqueue/src/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/crates/hyperqueue/src/tests/utils.rs
+++ b/crates/hyperqueue/src/tests/utils.rs
@@ -1,0 +1,15 @@
+use crate::common::parser::{consume_all, NomResult};
+
+pub fn check_parse_error<F: FnMut(&str) -> NomResult<O>, O>(
+    parser: F,
+    input: &str,
+    expected_error: &str,
+) {
+    match consume_all(parser, input) {
+        Err(e) => {
+            let output = format!("{:?}", e);
+            assert_eq!(output, expected_error);
+        }
+        _ => panic!("The parser should have failed"),
+    }
+}

--- a/crates/hyperqueue/src/worker/hwdetect.rs
+++ b/crates/hyperqueue/src/worker/hwdetect.rs
@@ -5,11 +5,12 @@ use tako::common::resources::{
     GenericResourceIndex, NumOfCpus,
 };
 
-use nom::bytes::complete::tag;
 use nom::character::complete::{newline, space0};
 use nom::combinator::{map_res, opt};
 use nom::multi::separated_list1;
 use nom::sequence::{preceded, terminated, tuple};
+use nom::Parser;
+use nom_supreme::tag::complete::tag;
 use tako::common::resources::descriptor::{
     cpu_descriptor_from_socket_size, GenericResourceKindIndices,
 };
@@ -73,7 +74,8 @@ fn p_cpu_range(input: &str) -> NomResult<Vec<CpuId>> {
             )),
         )),
         |(u, v)| crate::Result::Ok((u..=v.unwrap_or(u)).map(|id| id.into()).collect()),
-    )(input)
+    )
+    .parse(input)
 }
 
 fn p_cpu_ranges(input: &str) -> NomResult<Vec<CpuId>> {

--- a/crates/hyperqueue/src/worker/parser.rs
+++ b/crates/hyperqueue/src/worker/parser.rs
@@ -1,10 +1,12 @@
 use crate::arg_wrapper;
 use crate::common::parser::{consume_all, p_u32, p_u64, NomResult};
 use nom::branch::alt;
-use nom::bytes::complete::tag;
 use nom::character::complete::{alphanumeric1, char, multispace0};
 use nom::combinator::{map, opt};
 use nom::sequence::{delimited, preceded, separated_pair, tuple};
+use nom::Parser;
+use nom_supreme::tag::complete::tag;
+use nom_supreme::ParserExt;
 use tako::common::resources::descriptor::{
     cpu_descriptor_from_socket_size, GenericResourceDescriptorKind, GenericResourceKindIndices,
     GenericResourceKindSum,
@@ -56,18 +58,22 @@ fn p_kind_sum(input: &str) -> NomResult<GenericResourceDescriptorKind> {
             tuple((multispace0, char(')'), multispace0)),
         ),
         |size| GenericResourceDescriptorKind::Sum(GenericResourceKindSum { size }),
-    )(input)
+    )
+    .parse(input)
 }
 
 fn p_resource_kind(input: &str) -> NomResult<GenericResourceDescriptorKind> {
-    alt((p_kind_indices, p_kind_sum))(input)
+    alt((
+        p_kind_indices.context("Index resource"),
+        p_kind_sum.context("Sum resource"),
+    ))(input)
 }
 
-fn p_resource_definition(input: &str) -> NomResult<GenericResourceDescriptor> {
+pub fn p_resource_definition(input: &str) -> NomResult<GenericResourceDescriptor> {
     let parser = separated_pair(
-        alphanumeric1,
+        alphanumeric1.context("Resource identifier"),
         tuple((multispace0, char('='), multispace0)),
-        p_resource_kind,
+        p_resource_kind.context("Resource kind (sum or indices)"),
     );
     map(parser, |(name, kind)| GenericResourceDescriptor {
         name: name.to_string(),
@@ -82,6 +88,7 @@ fn parse_resource_definition(input: &str) -> anyhow::Result<GenericResourceDescr
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::tests::utils::check_parse_error;
     use tako::common::index::AsIdVec;
 
     #[test]
@@ -93,6 +100,16 @@ mod test {
         assert_eq!(
             parse_cpu_definition("2x3").unwrap(),
             vec![vec![0, 1, 2].to_ids(), vec![3, 4, 5].to_ids()]
+        );
+    }
+
+    #[test]
+    fn test_parse_cpu_def_error() {
+        check_parse_error(
+            p_cpu_definition,
+            "x",
+            r#"Parse error
+expected integer at character 0: "x""#,
         );
     }
 
@@ -116,5 +133,106 @@ mod test {
                 size: 1000_3000_2000
             })
         ));
+    }
+
+    #[test]
+    fn test_parse_resource_def_empty() {
+        check_parse_error(
+            p_resource_definition,
+            "",
+            r#"Parse error
+expected Resource identifier at the end of input
+  expected alphanumeric character at the end of input"#,
+        );
+    }
+
+    #[test]
+    fn test_parse_resource_def_number() {
+        check_parse_error(
+            p_resource_definition,
+            "1",
+            r#"Parse error
+expected "=" at the end of input"#,
+        );
+    }
+
+    #[test]
+    fn test_parse_resource_def_missing_value() {
+        check_parse_error(
+            p_resource_definition,
+            "x=",
+            r#"Parse error
+expected Resource kind (sum or indices) at the end of input
+  expected one of the following 2 variants:
+    expected Index resource at the end of input
+      expected "indices" at the end of input
+    or
+    expected Sum resource at the end of input
+      expected "sum" at the end of input"#,
+        );
+    }
+
+    #[test]
+    fn test_parse_resource_def_numeric_value() {
+        check_parse_error(
+            p_resource_definition,
+            "x=1",
+            r#"Parse error
+expected Resource kind (sum or indices) at character 2: "1"
+  expected one of the following 2 variants:
+    expected Index resource at character 2: "1"
+      expected "indices" at character 2: "1"
+    or
+    expected Sum resource at character 2: "1"
+      expected "sum" at character 2: "1""#,
+        );
+    }
+
+    #[test]
+    fn test_parse_resource_def_only_sum() {
+        check_parse_error(
+            p_resource_definition,
+            "x=sum",
+            r#"Parse error
+expected Resource kind (sum or indices) at character 2: "sum"
+  expected one of the following 2 variants:
+    expected Index resource at character 2: "sum"
+      expected "indices" at character 2: "sum"
+    or
+    expected Sum resource at character 2: "sum"
+      expected "(" at the end of input"#,
+        );
+    }
+
+    #[test]
+    fn test_parse_resource_def_missing_value_in_parentheses() {
+        check_parse_error(
+            p_resource_definition,
+            "x=sum()",
+            r#"Parse error
+expected Resource kind (sum or indices) at character 2: "sum()"
+  expected one of the following 2 variants:
+    expected Index resource at character 2: "sum()"
+      expected "indices" at character 2: "sum()"
+    or
+    expected Sum resource at character 2: "sum()"
+    expected integer at character 6: ")""#,
+        );
+    }
+
+    #[test]
+    fn test_parse_resource_def_invalid_value_in_parentheses() {
+        check_parse_error(
+            p_resource_definition,
+            "x=sum(x)",
+            r#"Parse error
+expected Resource kind (sum or indices) at character 2: "sum(x)"
+  expected one of the following 2 variants:
+    expected Index resource at character 2: "sum(x)"
+      expected "indices" at character 2: "sum(x)"
+    or
+    expected Sum resource at character 2: "sum(x)"
+    expected integer at character 6: "x)""#,
+        );
     }
 }


### PR DESCRIPTION
Improves the error messages produced by parsers, using the `nom-supreme` crate.

Before:
```
 ./hq worker start --resource x
error: Invalid value for '--resource <RESOURCE>...': Parser error at '""': expecting Char

 ./hq worker start --resource x=
error: Invalid value for '--resource <RESOURCE>...': Parser error at '""': expecting Tag
```

After:
```
 ./hq worker start --resource x
error: Invalid value for '--resource <RESOURCE>...': Parse error
expected "=" at the end of input

./hq worker start --resource x=
error: Invalid value for '--resource <RESOURCE>...': Parse error
expected Resource kind (sum or indices) at the end of input
  expected one of the following 2 variants:
    expected Index resource at the end of input
      expected "indices" at the end of input
    or
    expected Sum resource at the end of input
      expected "sum" at the end of input
```