### PR TITLE
Add auto allocation dry run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## New features
 
+  * You can now test auto allocation parameters using a dry-run command:
+    ```bash
+    $ hq alloc dry-run pbs --time-limit 2h -- -q qexp -A Project1
+    ```
+    Using this command you can quickly test if PBS/Slurm will accept allocations created with
+    the provided parameters.
   * You can now specify the timelimit of PBS/Slurm allocations using the `HH:MM:SS` format:
     `hq alloc add pbs --time-limit 01:10:30`.
   * Improve error messages printed when an invalid CLI parameter is entered.

--- a/crates/hyperqueue/src/server/autoalloc/descriptor/common.rs
+++ b/crates/hyperqueue/src/server/autoalloc/descriptor/common.rs
@@ -10,7 +10,7 @@ use crate::server::autoalloc::state::AllocationId;
 use crate::server::autoalloc::{AutoAllocResult, DescriptorId};
 
 /// Name of a script that will be submitted to Slurm/PBS.
-const SUBMIT_SCRIPT_NAME: &str = "hq_submit.sh";
+const SUBMIT_SCRIPT_NAME: &str = "hq-submit.sh";
 
 /// Name of a file that will store the job id of a submitted Slurm/PBS allocation.
 const JOBID_FILE_NAME: &str = "jobid";

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -110,7 +110,10 @@ pub enum AutoAllocRequest {
     Info {
         descriptor: DescriptorId,
     },
-    AddQueue(AddQueueRequest),
+    AddQueue {
+        manager: ManagerType,
+        parameters: AllocationQueueParams,
+    },
     RemoveQueue {
         descriptor: DescriptorId,
         force: bool,
@@ -118,13 +121,7 @@ pub enum AutoAllocRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub enum AddQueueRequest {
-    Pbs(AddQueueParams),
-    Slurm(AddQueueParams),
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct AddQueueParams {
+pub struct AllocationQueueParams {
     pub workers_per_alloc: u32,
     pub backlog: u32,
     pub timelimit: Option<Duration>,

--- a/docs/deployment/allocation.md
+++ b/docs/deployment/allocation.md
@@ -103,12 +103,25 @@ allocations.
 
 ## Debugging automatic allocation
 Since the automatic allocator is a "background" process that interacts with an external job manager, it can be challenging
-to debug its behavior. To aid with this process, HyperQueue provides various sources of information that can help you
+to debug its behavior. To aid with this process, HyperQueue provides a "dry-run" command that you can
+use to test allocation parameters. HyperQueue also provides various sources of information that can help you
 find out what is going on.
 
-- [`Basic queue information`](#display-information-about-an-allocation-queue) This command will show you details about
+### Dry-run command
+To test whether PBS/Slurm will accept the submit parameters that you provide to the auto allocator,
+you can use the `dry-run` command. It accepts the same parameters as `hq alloc add`, which it will use
+to immediately submit an allocation and print any encountered errors.
+
+```bash
+$ hq alloc dry-run pbs --timelimit 2h -- q qexp -A Project1
+```
+
+If the allocation was submitted successfully, it will be canceled immediately to avoid wasting resources.
+
+### Finding information about allocations
+- **[`Basic queue information`](#display-information-about-an-allocation-queue)** This command will show you details about
 allocations created by the automatic allocator.
-- [`Allocator events`](#display-events-of-an-allocation-queue) Each time the allocator performs some action or notices
+- **[`Allocator events`](#display-events-of-an-allocation-queue)** Each time the allocator performs some action or notices
 that a status of some allocation was changed, it will create a corresponding event. You can use this command to list
 most recent events to see what was the allocator doing.
 - **Extended logging** To get more information about what is happening inside the allocator, start the HyperQueue
@@ -129,7 +142,7 @@ server directory:
     stderr
     stdout
     job-id
-    hq_submit.sh
+    hq-submit.sh
     ```
 
 ## Useful autoalloc commands

--- a/tests/autoalloc/pbs_mock.py
+++ b/tests/autoalloc/pbs_mock.py
@@ -33,7 +33,12 @@ class NewJobFailed(NewJobResponse):
 
 
 class PbsMock:
-    def __init__(self, hq_env: HqEnv, new_job_responses: List[NewJobResponse] = None):
+    def __init__(
+        self,
+        hq_env: HqEnv,
+        new_job_responses: List[NewJobResponse] = None,
+        qdel_code: Optional[str] = None,
+    ):
         if new_job_responses is None:
             new_job_responses = list(NewJobId(id=str(i)) for i in range(1000))
         self.new_job_responses = new_job_responses
@@ -91,7 +96,9 @@ data = dict(
 )
 print(json.dumps(data))
 """
-        self.qdel_code = f"""
+        self.qdel_code = (
+            qdel_code
+            or f"""
 import sys
 import json
 import os
@@ -101,6 +108,7 @@ jobid = sys.argv[1]
 with open(os.path.join("{self.qdel_dir}", jobid), "w") as f:
     f.write(jobid)
 """
+        )
 
         self.jobs: Dict[str, JobState] = {}
 


### PR DESCRIPTION
This command will synchronously try to submit an allocation and print the result. If it succeeds, the allocation will be canceled immediately.

This command is implemented entirely in the client and does not require a running instance of HyperQueue.

Fixes: https://github.com/It4innovations/hyperqueue/issues/253