### PR TITLE
Require the `--time-limit` parameter in `hq alloc add`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Changes
 
+  * The `--time-limit` parameter of `hq alloc add` command is now required.
   * `hq alloc remove` will no longer let you remove an allocation queue that contains running
     allocations by default. If you want to force its removal and cancel the running allocations
     immediately, use the `--force` flag. 

--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -71,7 +71,7 @@ pub struct SharedQueueOpts {
 
     /// Time limit (walltime) of PBS/Slurm allocations
     #[clap(long, short('t'))]
-    time_limit: Option<ExtendedArgDuration>,
+    time_limit: ExtendedArgDuration,
 
     /// How many workers (nodes) should be spawned in each allocation
     #[clap(long, short, default_value = "1")]
@@ -173,7 +173,7 @@ fn args_to_params(args: SharedQueueOpts) -> AllocationQueueParams {
     AllocationQueueParams {
         workers_per_alloc: args.workers_per_alloc,
         backlog: args.backlog,
-        timelimit: args.time_limit.map(|v| v.unpack()),
+        timelimit: Some(args.time_limit.unpack()),
         name: args.name,
         additional_args: args.additional_args,
     }

--- a/docs/deployment/allocation.md
+++ b/docs/deployment/allocation.md
@@ -26,13 +26,13 @@ account ID, etc.) after `--`. These trailing arguments will then be passed direc
 === "PBS"
 
     ```bash
-    $ hq alloc add pbs -- -qqprod -AAccount1
+    $ hq alloc add pbs --time-limit 1h -- -qqprod -AAccount1
     ```
 
 === "Slurm"
 
     ``` bash
-    $ hq alloc add slurm -- --partition=p1
+    $ hq alloc add slurm --time-limit 1h -- --partition=p1
     ```
 
 !!! tip
@@ -53,10 +53,15 @@ create multiple allocation queues, and you can even combine PBS queues with Slur
 In addition to arguments that are passed to `qsub`/`sbatch`, you can also use several other command line options when
 creating a new allocation queue:
 
+- **`--time-limit <duration>`** Sets the walltime of created allocations[^1].
+  
+    This parameter is required, as HyperQueue must know the duration of the individual allocations.
+    Make sure that you pass a  time limit that does not exceed the limit of the PBS/Slurm queue
+    that you intend to use, otherwise the allocation submissions will fail. You can use the
+    [`dry-run` command](#dry-run-command) to debug this.
+
 - `--backlog <count>` How many allocations should be queued (waiting to be started) in PBS/Slurm at any given time.
 - `--workers-per-alloc <count>` How many nodes should be requested in each allocation.
-- `--time-limit <duration>` Sets the walltime of created allocations[^1]. If unset, the default walltime of the selected
-PBS queue or Slurm partition will be used.
 - `--name <name>` Name of the allocation queue. Will be used to name allocations. Serves for debug purposes only.
 
 [^1]: You can use various [shortcuts](../tips/cli-shortcuts.md#duration) for the duration value.

--- a/tests/autoalloc/test_autoalloc.py
+++ b/tests/autoalloc/test_autoalloc.py
@@ -19,7 +19,7 @@ def test_autoalloc_descriptor_list(hq_env: HqEnv):
             "Name",
         ),
         0,
-        ("1", "5", "1", "N/A", "PBS", ""),
+        ("1", "5", "1", "1h", "PBS", ""),
     )
 
     add_queue(
@@ -64,6 +64,17 @@ def test_timelimit_human_format(hq_env: HqEnv, manager: str):
 
     info = hq_env.command(["alloc", "list"], as_table=True)
     info.check_column_value("Timelimit", 0, "3h 15m 10s")
+
+
+@pytest.mark.parametrize("manager", ("pbs", "slurm"))
+def test_require_timelimit(hq_env: HqEnv, manager: str):
+    hq_env.start_server()
+    add_queue(
+        hq_env,
+        manager=manager,
+        time_limit=None,
+        expect_fail="--time-limit <TIME_LIMIT>",
+    )
 
 
 def test_remove_descriptor(hq_env: HqEnv):

--- a/tests/autoalloc/utils.py
+++ b/tests/autoalloc/utils.py
@@ -32,7 +32,8 @@ def add_queue(
     backlog=1,
     workers_per_alloc=1,
     additional_args=None,
-    time_limit=None,
+    time_limit="1h",
+    **kwargs,
 ) -> str:
     args = ["alloc", "add", manager]
     if name is not None:
@@ -51,7 +52,7 @@ def add_queue(
         args.append("--")
         args.extend(additional_args.split(" "))
 
-    return hq_env.command(args)
+    return hq_env.command(args, **kwargs)
 
 
 def prepare_tasks(hq_env: HqEnv, count=1000):


### PR DESCRIPTION
In order to solve https://github.com/It4innovations/hyperqueue/issues/248 (and to provide better auto alloc behaviour in the future), we need to find the walltime of allocations created by auto alloc. However, currently the user does not have to provide this information.

There are two approaches to resolve this:
1) Parse the limit from PBS/Slurm if the user does not enter the time limit. This is tedious to implement and we would need to make queue name in `hq alloc add` a required parameter (or parse the queue name from the trailing arguments, but that is messy). This is probably a better solution in the long run, as it would allow us to also check things like the validity of the queue name. Although this could also be solved by using the dry run functionality in `hq alloc add`.
2) Make the timelimit a required parameter (this PR).