### PR TITLE
Fix worker selection with heterogenous tasks

### DIFF
--- a/crates/tako/src/tests/utils/env.rs
+++ b/crates/tako/src/tests/utils/env.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 pub struct TestEnv {
     core: Core,
     scheduler: SchedulerState,
-    task_id_counter: u64,
+    pub task_id_counter: u64,
     worker_id_counter: u32,
 }
 


### PR DESCRIPTION
The worker vector wasn't cleared, therefore workers could be left in the vector from a previous iteration. In the next iteration, there could be a task with different resource requirements.