### PR TITLE
Simplify storage of items in StableMap

### DIFF
--- a/crates/tako/benches/benchmarks/worker.rs
+++ b/crates/tako/benches/benchmarks/worker.rs
@@ -188,7 +188,7 @@ fn bench_resource_queue_release_allocation(c: &mut BenchmarkGroup<WallTime>) {
                 queue.add_task(&task);
 
                 let mut map = TaskMap::default();
-                map.insert(0.into(), task);
+                map.insert(task);
 
                 let mut started = queue.try_start_tasks(&map, None);
                 (queue, Some(started.pop().unwrap().1))
@@ -222,7 +222,7 @@ fn bench_resource_queue_start_tasks(c: &mut BenchmarkGroup<WallTime>) {
                                 .into(),
                             );
                             queue.add_task(&task);
-                            map.insert(id.into(), task);
+                            map.insert(task);
                         }
 
                         (queue, map)

--- a/crates/tako/src/common/stablemap.rs
+++ b/crates/tako/src/common/stablemap.rs
@@ -5,8 +5,7 @@ use std::hash::Hash;
 
 #[derive(Debug)]
 struct StableVec<V> {
-    items: Vec<Option<V>>,
-    free_indices: Vec<StableVecIndex>,
+    items: Vec<V>,
 }
 
 impl<V> Default for StableVec<V> {
@@ -14,7 +13,6 @@ impl<V> Default for StableVec<V> {
     fn default() -> Self {
         Self {
             items: Default::default(),
-            free_indices: Default::default(),
         }
     }
 }
@@ -24,43 +22,21 @@ define_id_type!(StableVecIndex, u64);
 impl<V> StableVec<V> {
     #[inline]
     fn get(&self, index: StableVecIndex) -> Option<&V> {
-        self.items
-            .get(index.as_num() as usize)
-            .and_then(|v| v.as_ref())
+        let index: usize = index.into();
+        self.items.get(index)
     }
 
     #[inline]
     fn get_mut(&mut self, index: StableVecIndex) -> Option<&mut V> {
-        self.items
-            .get_mut(index.as_num() as usize)
-            .and_then(|v| v.as_mut())
+        let index: usize = index.into();
+        self.items.get_mut(index)
     }
 
     #[inline]
     fn insert(&mut self, value: V) -> StableVecIndex {
-        match self.free_indices.pop() {
-            Some(index) => {
-                debug_assert!(self.items[index.as_num() as usize].is_none());
-                self.items[index.as_num() as usize] = Some(value);
-                index
-            }
-            None => {
-                self.items.push(Some(value));
-                StableVecIndex::new((self.items.len() - 1) as u64)
-            }
-        }
-    }
-
-    #[inline]
-    fn remove(&mut self, index: StableVecIndex) -> Option<V> {
-        match self.items.get_mut(index.as_num() as usize) {
-            Some(value) => {
-                debug_assert!(value.is_some());
-                self.free_indices.push(index);
-                value.take()
-            }
-            None => panic!("Attempted to remove invalid index {}", index),
-        }
+        let index = StableVecIndex::new(self.items.len() as u64);
+        self.items.push(value);
+        index
     }
 }
 
@@ -83,6 +59,7 @@ impl<K, V> Default for StableMap<K, V> {
 impl<K, V> StableMap<K, V>
 where
     K: Hash + Eq,
+    V: ExtractKey<K>,
 {
     #[inline]
     pub fn find<Q: ?Sized>(&self, key: &Q) -> Option<&V>
@@ -123,7 +100,8 @@ where
     }
 
     #[inline]
-    pub fn insert(&mut self, key: K, value: V) {
+    pub fn insert(&mut self, value: V) {
+        let key = value.extract_key();
         let index = self.storage.insert(value);
         self.map.insert(key, index);
     }
@@ -134,15 +112,34 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq,
     {
-        self.map
-            .remove(key)
-            .and_then(|index| self.storage.remove(index))
+        self.map.remove(key).and_then(|index| {
+            let idx: usize = index.into();
+            let length = self.storage.items.len();
+
+            // If we got here, the index must be valid
+            if idx == length - 1 {
+                self.storage.items.pop()
+            } else {
+                // Remember the key of the last element
+                let last_key = self.storage.items.last().unwrap().extract_key();
+                // Swap the removed element with the last element
+                let removed = self.storage.items.swap_remove(idx);
+                // Redirect the key of the swapped (previously last) element
+                self.map.insert(last_key, index);
+                Some(removed)
+            }
+        })
     }
+}
+
+/// This trait is needed to provide fast key inversion (value -> key) without auxiliary storage.
+pub trait ExtractKey<K> {
+    fn extract_key(&self) -> K;
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::common::stablemap::{StableMap, StableVec};
+    use crate::common::stablemap::{ExtractKey, StableMap, StableVec};
 
     #[test]
     fn vec_insert_empty() {
@@ -169,77 +166,73 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn vec_remove_missing_should_panic() {
-        let mut v: StableVec<u32> = Default::default();
-        v.remove(0.into());
-    }
-
-    #[test]
-    fn vec_remove_returns_existing() {
-        let mut v: StableVec<u32> = Default::default();
-        let i1 = v.insert(1);
-
-        assert_eq!(v.remove(i1), Some(1));
-    }
-
-    #[test]
-    fn vec_remove_get() {
-        let mut v: StableVec<u32> = Default::default();
-        let i1 = v.insert(1);
-        let i2 = v.insert(2);
-        let i3 = v.insert(3);
-
-        v.remove(i2);
-        assert_eq!(v.get(i1), Some(&1));
-        assert_eq!(v.get(i3), Some(&3));
-    }
-
-    #[test]
-    fn vec_insert_after_remove() {
-        let mut v: StableVec<u32> = Default::default();
-        v.insert(1);
-        let i2 = v.insert(2);
-        v.insert(3);
-
-        v.remove(i2);
-
-        let i4 = v.insert(4);
-        assert_eq!(i4, i2);
-
-        assert_eq!(v.items.len(), 3);
-    }
-
-    #[test]
-    fn vec_insert_after_multiple_remove() {
-        let mut v: StableVec<u32> = Default::default();
-        v.insert(1);
-        let i2 = v.insert(2);
-        let i3 = v.insert(3);
-
-        v.remove(i2);
-        v.remove(i3);
-
-        let i4 = v.insert(4);
-        assert_eq!(i4, i3);
-
-        assert_eq!(v.items.len(), 3);
-    }
-
-    #[test]
     fn map_insert_get() {
         let mut v: StableMap<u32, u64> = Default::default();
-        v.insert(1, 1);
+        v.insert(1);
 
         assert_eq!(v.get(&1), &1);
     }
 
     #[test]
-    fn map_remove_get() {
+    fn map_remove_only() {
         let mut v: StableMap<u32, u64> = Default::default();
-        v.insert(1, 1);
+        v.insert(1);
 
         assert_eq!(v.remove(&1), Some(1));
         assert_eq!(v.find(&1), None);
+    }
+
+    #[test]
+    fn map_remove_in_middle() {
+        let mut v: StableMap<u32, u64> = Default::default();
+        v.insert(1);
+        v.insert(2);
+        v.insert(3);
+
+        assert_eq!(v.remove(&2), Some(2));
+        assert_eq!(v.find(&1), Some(&1));
+        assert_eq!(v.find(&2), None);
+        assert_eq!(v.find(&3), Some(&3));
+    }
+
+    #[test]
+    fn map_remove_last() {
+        let mut v: StableMap<u32, u64> = Default::default();
+        v.insert(1);
+        v.insert(2);
+
+        assert_eq!(v.remove(&2), Some(2));
+        assert_eq!(v.find(&2), None);
+        assert_eq!(v.find(&1), Some(&1));
+    }
+
+    #[test]
+    fn map_remove_missing() {
+        let mut v: StableMap<u32, u64> = Default::default();
+        v.insert(1);
+
+        assert_eq!(v.remove(&2), None);
+        assert_eq!(v.find(&1), Some(&1));
+    }
+
+    #[test]
+    fn map_insert_after_remove() {
+        let mut v: StableMap<u32, u64> = Default::default();
+        v.insert(1);
+        v.insert(2);
+        v.insert(3);
+
+        assert_eq!(v.remove(&2), Some(2));
+        v.insert(2);
+        assert_eq!(v.find(&1), Some(&1));
+        assert_eq!(v.find(&2), Some(&2));
+        assert_eq!(v.find(&3), Some(&3));
+    }
+
+    impl ExtractKey<u32> for u64 {
+        #[inline]
+        fn extract_key(&self) -> u32 {
+            *self as u32
+        }
     }
 }

--- a/crates/tako/src/worker/state.rs
+++ b/crates/tako/src/worker/state.rs
@@ -200,7 +200,7 @@ impl WorkerState {
                 task.get_waiting()
             );
         }
-        self.tasks.insert(task.id, task);
+        self.tasks.insert(task);
     }
 
     pub fn remove_data_by_id(&mut self, task_id: TaskId) {

--- a/crates/tako/src/worker/task.rs
+++ b/crates/tako/src/worker/task.rs
@@ -1,4 +1,5 @@
 use crate::common::resources::ResourceAllocation;
+use crate::common::stablemap::ExtractKey;
 use crate::common::WrappedRcRefCell;
 use crate::messages::worker::ComputeTaskMsg;
 use crate::worker::data::DataObjectRef;
@@ -27,13 +28,12 @@ pub struct Task {
 
 impl Task {
     pub fn new(message: ComputeTaskMsg) -> Self {
-        Task {
+        Self {
             id: message.id,
             priority: (message.user_priority, message.scheduler_priority),
             state: TaskState::Waiting(0),
             deps: Default::default(),
             instance_id: message.instance_id,
-
             resources: message.resources,
             time_limit: message.time_limit,
             n_outputs: message.n_outputs,
@@ -118,5 +118,12 @@ impl TaskRef {
             n_outputs: message.n_outputs,
             body: message.body,
         })
+    }
+}
+
+impl ExtractKey<TaskId> for Task {
+    #[inline]
+    fn extract_key(&self) -> TaskId {
+        self.id
     }
 }

--- a/crates/tako/src/worker/test_util.rs
+++ b/crates/tako/src/worker/test_util.rs
@@ -40,8 +40,7 @@ impl ResourceQueueBuilder {
 
     pub fn add_task(&mut self, task: Task) {
         self.queue.add_task(&task);
-        let id = task.id;
-        self.task_map.insert(id, task);
+        self.task_map.insert(task);
     }
 
     pub fn start_tasks(&mut self) -> Map<u64, ResourceAllocation> {


### PR DESCRIPTION
I realized that we can simplify the storage if we just swap the last element with the removed element during item removal. To avoid a secondary map that would map items to their keys, the values now need to provide fast key lookup (but that is trivial for tasks and workers, which are the intended structures for this map).