### PR TITLE
Reduce the flakiness of `test_max_fails_0`

### DIFF
--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -435,7 +435,7 @@ def test_max_fails_0(hq_env: HqEnv):
         [
             "submit",
             "--array",
-            "1-200",
+            "1-2",
             "--stdout",
             "none",
             "--stderr",
@@ -445,17 +445,16 @@ def test_max_fails_0(hq_env: HqEnv):
             "--",
             "bash",
             "-c",
-            "if [ $HQ_TASK_ID == 137 ]; then exit 1; fi",
+            "if [ $HQ_TASK_ID == 1 ]; then exit 1; fi; if [ $HQ_TASK_ID == 2 ]; then sleep 100; fi"
         ]
     )
-    hq_env.start_workers(1)
+    hq_env.start_workers(1, cpus=2)
 
     wait_for_job_state(hq_env, 1, "CANCELED")
 
     table = hq_env.command(["job", "1"], as_table=True)
     states = table.get_row_value("State").split("\n")
     assert "FAILED (1)" in states
-    assert any(s.startswith("FINISHED") for s in states)
     assert any(s.startswith("CANCELED") for s in states)
 
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -445,7 +445,7 @@ def test_max_fails_0(hq_env: HqEnv):
             "--",
             "bash",
             "-c",
-            "if [ $HQ_TASK_ID == 1 ]; then exit 1; fi; if [ $HQ_TASK_ID == 2 ]; then sleep 100; fi"
+            "if [ $HQ_TASK_ID == 1 ]; then exit 1; fi; if [ $HQ_TASK_ID == 2 ]; then sleep 100; fi",
         ]
     )
     hq_env.start_workers(1, cpus=2)


### PR DESCRIPTION
Before, the job could fail before it was canceled.