### PR TITLE
Use `FxHasher` for hash maps and sets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,7 +655,6 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
  "serde",
 ]
 
@@ -711,7 +708,6 @@ dependencies = [
  "env_logger",
  "futures",
  "gethostname",
- "hashbrown",
  "hex",
  "humantime",
  "indicatif",
@@ -1572,6 +1568,7 @@ dependencies = [
  "derive_builder",
  "env_logger",
  "futures",
+ "fxhash",
  "gethostname",
  "hashbrown",
  "hex",

--- a/crates/hyperqueue/Cargo.toml
+++ b/crates/hyperqueue/Cargo.toml
@@ -23,7 +23,6 @@ serde-tuple-vec-map = "1"
 bytes = "1.0.1"
 atty = "0.2"
 cli-table = { version = "0.4.6", default-features = false }
-hashbrown = { version = "0.11", features = ["serde"] }
 thiserror = "1"
 anyhow = "1"
 dirs = "4.0"

--- a/crates/hyperqueue/src/lib.rs
+++ b/crates/hyperqueue/src/lib.rs
@@ -11,8 +11,7 @@ pub mod worker;
 #[cfg(test)]
 pub(crate) mod tests;
 
-pub type Map<K, V> = hashbrown::HashMap<K, V>;
-pub type Set<T> = hashbrown::HashSet<T>;
+pub use tako::common::{Map, Set};
 
 pub type Error = crate::common::error::HqError;
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -272,9 +272,9 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
     use std::time::{Duration, SystemTime};
+    use tako::common::Map;
 
     use crate::common::arraydef::IntArray;
-    use hashbrown::HashMap;
     use tako::common::resources::TimeRequest;
     use tako::messages::common::ProgramDefinition;
     use tako::messages::gateway::ResourceRequest;
@@ -354,7 +354,7 @@ mod tests {
     async fn test_keep_backlog_filled() {
         let state = create_state(1000);
 
-        let mut queue = HashMap::<AllocationId, isize>::new();
+        let mut queue = Map::<AllocationId, isize>::new();
         queue.insert("0".to_string(), 0); // run immediately
         queue.insert("1".to_string(), 2); // run after two checks
         queue.insert("2".to_string(), 3); // run after three checks
@@ -603,7 +603,7 @@ mod tests {
 
     #[derive(Default)]
     struct AllocationState {
-        state: HashMap<AllocationId, AllocationStatus>,
+        state: Map<AllocationId, AllocationStatus>,
         spawned_allocations: usize,
     }
 

--- a/crates/tako/Cargo.toml
+++ b/crates/tako/Cargo.toml
@@ -19,7 +19,7 @@ serde_bytes = "0.11"
 serde_json = "1.0"
 thiserror = "1"
 rand = { version = "0.8", features = ["small_rng"] }
-hashbrown = { version = "0.11", features = ["serde"] }
+hashbrown = { version = "0.11", features = ["serde", "inline-more"], default-features = false }
 gethostname = "0.2"
 log = "0.4"
 tracing = "0.1"
@@ -31,6 +31,7 @@ hex = "0.4"
 bincode = "1.3.3"
 bstr = { version = "0.2", features = ["serde1"] }
 psutil = "3.2.1"
+fxhash = "0.2.1"
 
 [dev-dependencies]
 derive_builder = "0.10.2"

--- a/crates/tako/src/common/data_structures.rs
+++ b/crates/tako/src/common/data_structures.rs
@@ -1,0 +1,152 @@
+use fxhash::FxBuildHasher;
+use serde::{Deserialize, Serialize};
+use std::hash::Hash;
+use std::ops::{Deref, DerefMut};
+
+// Map
+type InnerMap<K, V> = hashbrown::HashMap<K, V, FxBuildHasher>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Map<K: Eq + Hash, V>(InnerMap<K, V>);
+
+impl<K: Eq + Hash, V> Map<K, V> {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Map(InnerMap::with_capacity_and_hasher(
+            capacity,
+            FxBuildHasher::default(),
+        ))
+    }
+}
+
+impl<K: Eq + Hash, V> Default for Map<K, V> {
+    #[inline]
+    fn default() -> Self {
+        Self(InnerMap::default())
+    }
+}
+
+impl<K: Eq + Hash, V> Deref for Map<K, V> {
+    type Target = InnerMap<K, V>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<K: Eq + Hash, V> DerefMut for Map<K, V> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<K: Eq + Hash, V> FromIterator<(K, V)> for Map<K, V>
+where
+    K: Eq + Hash,
+{
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Self(InnerMap::from_iter(iter))
+    }
+}
+
+impl<K: Eq + Hash, V> IntoIterator for Map<K, V> {
+    type Item = (K, V);
+    type IntoIter = <InnerMap<K, V> as IntoIterator>::IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, K: Eq + Hash, V> IntoIterator for &'a Map<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = <&'a InnerMap<K, V> as IntoIterator>::IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+// Set
+type InnerSet<T> = hashbrown::HashSet<T, FxBuildHasher>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Set<T: Eq + Hash>(InnerSet<T>);
+
+impl<T: Eq + Hash> Set<T> {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Set(InnerSet::with_capacity_and_hasher(
+            capacity,
+            FxBuildHasher::default(),
+        ))
+    }
+}
+
+impl<T: Eq + Hash> Default for Set<T> {
+    #[inline]
+    fn default() -> Self {
+        Self(InnerSet::default())
+    }
+}
+
+impl<T: Eq + Hash> Deref for Set<T> {
+    type Target = InnerSet<T>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Eq + Hash> DerefMut for Set<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Eq + Hash> FromIterator<T> for Set<T>
+where
+    T: Eq + Hash,
+{
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(InnerSet::from_iter(iter))
+    }
+}
+
+impl<T: Eq + Hash> IntoIterator for Set<T> {
+    type Item = T;
+    type IntoIter = <InnerSet<T> as IntoIterator>::IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T: Eq + Hash> IntoIterator for &'a Set<T> {
+    type Item = &'a T;
+    type IntoIter = <&'a InnerSet<T> as IntoIterator>::IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}

--- a/crates/tako/src/common/mod.rs
+++ b/crates/tako/src/common/mod.rs
@@ -1,7 +1,6 @@
 pub use wrapped::WrappedRcRefCell;
 
-pub type Map<K, V> = hashbrown::HashMap<K, V>;
-pub type Set<T> = hashbrown::HashSet<T>;
+pub use data_structures::{Map, Set};
 
 pub mod data;
 pub mod error;
@@ -10,6 +9,7 @@ pub mod rpc;
 mod wrapped;
 #[macro_use]
 pub mod trace;
+pub mod data_structures;
 pub mod index;
 pub mod secret;
 pub mod stablemap;

--- a/crates/tako/src/common/resources/descriptor.rs
+++ b/crates/tako/src/common/resources/descriptor.rs
@@ -124,7 +124,7 @@ impl ResourceDescriptor {
         let mut result = if self.cpus.len() == 1 {
             format!("1x{} cpus", self.cpus[0].len())
         } else {
-            let mut counts = Map::<usize, usize>::new();
+            let mut counts = Map::<usize, usize>::default();
             for group in &self.cpus {
                 *counts.entry(group.len()).or_default() += 1;
             }

--- a/crates/tako/src/common/stablemap.rs
+++ b/crates/tako/src/common/stablemap.rs
@@ -41,12 +41,12 @@ impl<V> StableVec<V> {
 }
 
 #[derive(Debug)]
-pub struct StableMap<K, V> {
+pub struct StableMap<K: Eq + Hash, V> {
     map: Map<K, StableVecIndex>,
     storage: StableVec<V>,
 }
 
-impl<K, V> Default for StableMap<K, V> {
+impl<K: Eq + Hash, V> Default for StableMap<K, V> {
     #[inline]
     fn default() -> Self {
         Self {

--- a/crates/tako/src/server/reactor.rs
+++ b/crates/tako/src/server/reactor.rs
@@ -217,7 +217,7 @@ pub fn on_task_finished(
                 }
             }
 
-            let mut placement = Set::new();
+            let mut placement = Set::default();
 
             if task.configuration.n_outputs > 0 {
                 placement.insert(worker_id);
@@ -430,7 +430,7 @@ pub fn on_cancel_tasks(
     task_ids: &[TaskId],
 ) -> (Vec<TaskId>, Vec<TaskId>) {
     let mut to_unregister = Set::with_capacity(task_ids.len());
-    let mut running_ids: Map<WorkerId, Vec<TaskId>> = Map::new();
+    let mut running_ids: Map<WorkerId, Vec<TaskId>> = Map::default();
     let mut already_finished: Vec<TaskId> = Vec::new();
 
     log::debug!("Canceling {} tasks", task_ids.len());

--- a/crates/tako/src/worker/data.rs
+++ b/crates/tako/src/worker/data.rs
@@ -2,10 +2,9 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 
 use bytes::Bytes;
-use hashbrown::HashSet;
 
 use crate::common::data::SerializationType;
-use crate::common::WrappedRcRefCell;
+use crate::common::{Set, WrappedRcRefCell};
 use crate::worker::task::TaskRef;
 use crate::{TaskId, WorkerId};
 
@@ -40,7 +39,7 @@ pub enum DataObjectState {
 pub struct DataObject {
     pub id: TaskId,
     pub state: DataObjectState,
-    pub consumers: HashSet<TaskRef>,
+    pub consumers: Set<TaskRef>,
     pub size: u64,
 }
 

--- a/crates/tako/src/worker/state.rs
+++ b/crates/tako/src/worker/state.rs
@@ -2,7 +2,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use bytes::{Bytes, BytesMut};
-use hashbrown::HashMap;
 use orion::aead::SecretKey;
 use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
@@ -34,7 +33,7 @@ pub struct WorkerState {
     pub sender: UnboundedSender<Bytes>,
     tasks: TaskMap,
     pub ready_task_queue: ResourceWaitQueue,
-    pub data_objects: HashMap<TaskId, DataObjectRef>,
+    pub data_objects: Map<TaskId, DataObjectRef>,
     pub running_tasks: Set<TaskId>,
     pub start_task_scheduled: bool,
     pub start_task_notify: Rc<Notify>,


### PR DESCRIPTION
This reduces the size of hash maps and sets from `64` to `32` bytes. Size of server `Task` is reduced from `288` to `192` bytes. These two data structures will now also use a slightly faster hash function.

<details>
<summary>Micro-benchmark results</summary>

```
Gnuplot not found, using plotters backend
Benchmarking core/remove a single task/10
Benchmarking core/remove a single task/10: Analyzing
core/remove a single task/10
                        time:   [61.787 ns 63.781 ns 65.832 ns]
                        change: [-58.583% -56.372% -54.001%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking core/remove a single task/1000
Benchmarking core/remove a single task/1000: Analyzing
core/remove a single task/1000
                        time:   [270.43 ns 299.51 ns 334.85 ns]
                        change: [-33.746% -23.758% -12.314%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
Benchmarking core/remove a single task/100000
Benchmarking core/remove a single task/100000: Analyzing
core/remove a single task/100000
                        time:   [2.0099 us 2.0774 us 2.1581 us]
                        change: [-18.400% -12.926% -7.6336%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
Benchmarking core/remove all tasks/10
Benchmarking core/remove all tasks/10: Analyzing
core/remove all tasks/10
                        time:   [864.28 ns 893.80 ns 922.27 ns]
                        change: [-22.180% -18.580% -14.768%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking core/remove all tasks/1000
Benchmarking core/remove all tasks/1000: Analyzing
core/remove all tasks/1000
                        time:   [96.012 us 99.398 us 102.50 us]
                        change: [-27.339% -23.630% -19.751%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking core/remove all tasks/100000
Benchmarking core/remove all tasks/100000: Analyzing
core/remove all tasks/100000
                        time:   [18.285 ms 18.432 ms 18.578 ms]
                        change: [-43.733% -43.094% -42.489%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking core/add task/10
Benchmarking core/add task/10: Analyzing
core/add task/10        time:   [55.152 ns 58.463 ns 61.647 ns]
                        change: [-36.172% -31.266% -26.114%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking core/add task/1000
Benchmarking core/add task/1000: Analyzing
core/add task/1000      time:   [165.73 ns 181.07 ns 196.80 ns]
                        change: [-37.639% -24.590% -8.2922%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
Benchmarking core/add task/100000
Benchmarking core/add task/100000: Analyzing
core/add task/100000    time:   [1.5577 us 1.6045 us 1.6543 us]
                        change: [+0.6213% +9.1881% +16.767%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
Benchmarking core/add tasks/10
Benchmarking core/add tasks/10: Analyzing
core/add tasks/10       time:   [968.91 ns 990.90 ns 1.0100 us]
                        change: [-16.812% -14.019% -11.355%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking core/add tasks/1000
Benchmarking core/add tasks/1000: Analyzing
core/add tasks/1000     time:   [46.701 us 47.191 us 47.657 us]
                        change: [-31.461% -30.178% -28.938%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
Benchmarking core/add tasks/100000
Benchmarking core/add tasks/100000: Analyzing
core/add tasks/100000   time:   [12.716 ms 12.774 ms 12.832 ms]
                        change: [-30.471% -30.036% -29.645%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
Benchmarking core/iterate tasks/10
Benchmarking core/iterate tasks/10: Analyzing
core/iterate tasks/10   time:   [26.969 ns 28.753 ns 30.514 ns]
                        change: [-7.0072% +2.8899% +13.093%] (p = 0.57 > 0.05)
                        No change in performance detected.
Benchmarking core/iterate tasks/1000
Benchmarking core/iterate tasks/1000: Analyzing
core/iterate tasks/1000 time:   [2.5081 us 2.7272 us 2.9374 us]
                        change: [-20.424% -10.365% +0.4334%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking core/iterate tasks/100000
Benchmarking core/iterate tasks/100000: Analyzing
core/iterate tasks/100000
                        time:   [411.91 us 431.15 us 452.35 us]
                        change: [-23.866% -18.921% -14.348%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) high mild
  13 (13.00%) high severe

Benchmarking scheduler/compute b-level/10
Benchmarking scheduler/compute b-level/10: Analyzing
scheduler/compute b-level/10
                        time:   [480.81 ns 501.13 ns 519.80 ns]
                        change: [-11.158% -6.2334% -0.6997%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Benchmarking scheduler/compute b-level/1000
Benchmarking scheduler/compute b-level/1000: Analyzing
scheduler/compute b-level/1000
                        time:   [22.118 us 23.177 us 24.127 us]
                        change: [-26.702% -21.701% -16.730%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking scheduler/compute b-level/100000
Benchmarking scheduler/compute b-level/100000: Analyzing
scheduler/compute b-level/100000
                        time:   [2.7337 ms 2.7766 ms 2.8197 ms]
                        change: [-43.699% -42.474% -41.298%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking scheduler/schedule/tasks=10, workers=1
Benchmarking scheduler/schedule/tasks=10, workers=1: Analyzing
scheduler/schedule/tasks=10, workers=1
                        time:   [4.3451 us 4.4029 us 4.4561 us]
                        change: [-15.017% -13.202% -11.275%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking scheduler/schedule/tasks=10, workers=8
Benchmarking scheduler/schedule/tasks=10, workers=8: Analyzing
scheduler/schedule/tasks=10, workers=8
                        time:   [7.8769 us 7.9698 us 8.0666 us]
                        change: [-14.792% -13.629% -12.383%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
Benchmarking scheduler/schedule/tasks=10, workers=16
Benchmarking scheduler/schedule/tasks=10, workers=16: Analyzing
scheduler/schedule/tasks=10, workers=16
                        time:   [11.711 us 11.773 us 11.831 us]
                        change: [-13.343% -12.546% -11.717%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking scheduler/schedule/tasks=10, workers=32
Benchmarking scheduler/schedule/tasks=10, workers=32: Analyzing
scheduler/schedule/tasks=10, workers=32
                        time:   [15.329 us 15.399 us 15.466 us]
                        change: [-13.164% -12.463% -11.732%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking scheduler/schedule/tasks=1000, workers=1
Benchmarking scheduler/schedule/tasks=1000, workers=1: Analyzing
scheduler/schedule/tasks=1000, workers=1
                        time:   [217.66 us 219.03 us 220.27 us]
                        change: [-30.678% -29.604% -28.549%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking scheduler/schedule/tasks=1000, workers=8
Benchmarking scheduler/schedule/tasks=1000, workers=8: Analyzing
scheduler/schedule/tasks=1000, workers=8
                        time:   [303.49 us 305.02 us 306.40 us]
                        change: [-25.817% -24.650% -23.449%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking scheduler/schedule/tasks=1000, workers=16
Benchmarking scheduler/schedule/tasks=1000, workers=16: Analyzing
scheduler/schedule/tasks=1000, workers=16
                        time:   [371.31 us 372.96 us 374.54 us]
                        change: [-26.072% -22.992% -20.990%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking scheduler/schedule/tasks=1000, workers=32
Benchmarking scheduler/schedule/tasks=1000, workers=32: Analyzing
scheduler/schedule/tasks=1000, workers=32
                        time:   [508.28 us 509.96 us 511.53 us]
                        change: [-19.039% -18.438% -17.845%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
Benchmarking scheduler/schedule/tasks=100000, workers=1
Benchmarking scheduler/schedule/tasks=100000, workers=1: Analyzing
scheduler/schedule/tasks=100000, workers=1
                        time:   [41.740 ms 41.916 ms 42.102 ms]
                        change: [-55.312% -54.844% -54.327%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
Benchmarking scheduler/schedule/tasks=100000, workers=8
Benchmarking scheduler/schedule/tasks=100000, workers=8: Analyzing
scheduler/schedule/tasks=100000, workers=8
                        time:   [50.769 ms 51.019 ms 51.277 ms]
                        change: [-40.773% -39.940% -39.143%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Benchmarking scheduler/schedule/tasks=100000, workers=16
Benchmarking scheduler/schedule/tasks=100000, workers=16: Analyzing
scheduler/schedule/tasks=100000, workers=16
                        time:   [59.114 ms 59.395 ms 59.678 ms]
                        change: [-33.105% -32.698% -32.293%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
Benchmarking scheduler/schedule/tasks=100000, workers=32
Benchmarking scheduler/schedule/tasks=100000, workers=32: Analyzing
scheduler/schedule/tasks=100000, workers=32
                        time:   [71.808 ms 72.021 ms 72.241 ms]
                        change: [-28.663% -28.353% -28.068%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking worker/add task/10
Benchmarking worker/add task/10: Analyzing
worker/add task/10      time:   [1.1998 us 1.2006 us 1.2014 us]
                        change: [-1.6815% -1.5285% -1.3725%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe
Benchmarking worker/add task/1000
Benchmarking worker/add task/1000: Analyzing
worker/add task/1000    time:   [1.2478 us 1.2507 us 1.2535 us]
                        change: [-4.4164% -3.7820% -3.1868%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
Benchmarking worker/add task/100000
Benchmarking worker/add task/100000: Analyzing
worker/add task/100000  time:   [1.7104 us 1.7845 us 1.8778 us]
                        change: [-4.4542% +0.6483% +6.9401%] (p = 0.83 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking worker/add tasks/10
Benchmarking worker/add tasks/10: Analyzing
worker/add tasks/10     time:   [2.7533 us 2.7757 us 2.7959 us]
                        change: [-38.973% -20.565% -5.9040%] (p = 0.13 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking worker/add tasks/1000
Benchmarking worker/add tasks/1000: Analyzing
worker/add tasks/1000   time:   [144.86 us 145.31 us 145.74 us]
                        change: [-10.573% -9.9109% -9.3264%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Benchmarking worker/add tasks/100000
Benchmarking worker/add tasks/100000: Analyzing
worker/add tasks/100000 time:   [31.170 ms 31.300 ms 31.435 ms]
                        change: [+18.741% +21.922% +25.131%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Benchmarking worker/cancel waiting task/10
Benchmarking worker/cancel waiting task/10: Analyzing
worker/cancel waiting task/10
                        time:   [322.15 ns 338.15 ns 353.12 ns]
                        change: [-11.976% -5.5328% +1.4355%] (p = 0.11 > 0.05)
                        No change in performance detected.
Benchmarking worker/cancel waiting task/1000
Benchmarking worker/cancel waiting task/1000: Analyzing
worker/cancel waiting task/1000
                        time:   [834.35 ns 907.64 ns 986.20 ns]
                        change: [-14.416% -4.8259% +6.2297%] (p = 0.38 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
Benchmarking worker/cancel waiting task/100000
Benchmarking worker/cancel waiting task/100000: Analyzing
worker/cancel waiting task/100000
                        time:   [2.4598 us 2.5527 us 2.6686 us]
                        change: [-4.9421% -0.1098% +5.4143%] (p = 0.97 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
Benchmarking worker/add task to resource queue
Benchmarking worker/add task to resource queue: Analyzing
worker/add task to resource queue
                        time:   [261.97 ns 264.28 ns 267.09 ns]
                        change: [-24.089% -21.787% -19.486%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
Benchmarking worker/release allocation from resource queue
Benchmarking worker/release allocation from resource queue: Analyzing
worker/release allocation from resource queue
                        time:   [768.00 ns 791.52 ns 813.58 ns]
                        change: [-6.2732% -1.3793% +3.8795%] (p = 0.61 > 0.05)
                        No change in performance detected.
Benchmarking worker/start tasks in resource queue/1
Benchmarking worker/start tasks in resource queue/1: Analyzing
worker/start tasks in resource queue/1
                        time:   [392.49 ns 402.14 ns 411.41 ns]
                        change: [-7.0210% -2.7338% +1.2255%] (p = 0.22 > 0.05)
                        No change in performance detected.
Benchmarking worker/start tasks in resource queue/10
Benchmarking worker/start tasks in resource queue/10: Analyzing
worker/start tasks in resource queue/10
                        time:   [574.07 ns 591.21 ns 607.51 ns]
                        change: [-11.515% -6.3902% -1.3004%] (p = 0.02 < 0.05)
                        Performance has improved.
Benchmarking worker/start tasks in resource queue/1000
Benchmarking worker/start tasks in resource queue/1000: Analyzing
worker/start tasks in resource queue/1000
                        time:   [1.1904 us 1.2731 us 1.3633 us]
                        change: [-10.199% -2.4720% +6.3617%] (p = 0.57 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Benchmarking worker/start tasks in resource queue/100000
Benchmarking worker/start tasks in resource queue/100000: Analyzing
worker/start tasks in resource queue/100000
                        time:   [3.6205 us 3.8591 us 4.1441 us]
                        change: [-3.8296% +3.8156% +12.407%] (p = 0.36 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
```
</details>

Macro-benchmarks weren't affected (as usually, since we only have `sleep` currently).