### PR TITLE
Gradual placeholder resolving

### DIFF
--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -10,6 +10,7 @@ use crate::transfer::messages::{
 };
 use crate::worker::parser::{ArgCpuDefinition, ArgGenericResourceDef};
 use crate::worker::start;
+use crate::worker::start::HqTaskLauncher;
 use crate::worker::streamer::StreamerRef;
 use crate::WorkerId;
 use anyhow::Context;
@@ -117,9 +118,7 @@ pub async fn start_hq_worker(
         server_addr,
         configuration,
         Some(record.tako_secret_key().clone()),
-        Box::new(move |state, task_id, end_receiver| {
-            start::worker_launcher(&state, &streamer_ref, task_id, end_receiver)
-        }),
+        Box::new(HqTaskLauncher::new(streamer_ref)),
     )
     .await?;
 

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -13,7 +13,7 @@ use crate::common::serverdir::AccessRecord;
 use crate::server::autoalloc::{
     Allocation, AllocationEvent, AllocationEventHolder, AllocationStatus,
 };
-use crate::server::job::{JobTaskCounters, JobTaskInfo, JobTaskState};
+use crate::server::job::{JobTaskCounters, JobTaskInfo, JobTaskState, StartedTaskData};
 use crate::stream::reader::logfile::Summary;
 use crate::transfer::messages::{
     AutoAllocListResponse, JobDetail, JobInfo, JobType, StatsResponse, WaitForJobsResponse,
@@ -76,9 +76,13 @@ impl CliOutput {
     ) {
         tasks.sort_unstable_by_key(|t| t.task_id);
         let make_error_row = |t: &JobTaskInfo| match &t.state {
-            JobTaskState::Failed { worker, error, .. } => Some(vec![
+            JobTaskState::Failed {
+                started_data: StartedTaskData { worker_id, .. },
+                error,
+                ..
+            } => Some(vec![
                 t.task_id.cell(),
-                format_worker(*worker, worker_map).cell(),
+                format_worker(*worker_id, worker_map).cell(),
                 error.to_owned().cell().foreground_color(Some(Color::Red)),
             ]),
             _ => None,

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -878,17 +878,17 @@ fn format_worker(id: WorkerId, worker_map: &WorkerMap) -> &str {
 pub fn get_task_time(state: &JobTaskState) -> (Option<DateTime<Utc>>, Option<DateTime<Utc>>) {
     match state {
         JobTaskState::Canceled | JobTaskState::Waiting => (None, None),
-        JobTaskState::Running { start_date, .. } => (Some(*start_date), None),
+        JobTaskState::Running { started_data, .. } => (Some(started_data.start_date), None),
         JobTaskState::Finished {
-            start_date,
+            started_data,
             end_date,
             ..
         }
         | JobTaskState::Failed {
-            start_date,
+            started_data,
             end_date,
             ..
-        } => (Some(*start_date), Some(*end_date)),
+        } => (Some(started_data.start_date), Some(*end_date)),
     }
 }
 

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -877,7 +877,9 @@ fn format_worker(id: WorkerId, worker_map: &WorkerMap) -> &str {
 
 pub fn get_task_time(state: &JobTaskState) -> (Option<DateTime<Utc>>, Option<DateTime<Utc>>) {
     match state {
-        JobTaskState::Canceled | JobTaskState::Waiting => (None, None),
+        JobTaskState::Canceled {
+            started_data: Some(started_data),
+        } => (Some(started_data.start_date), None),
         JobTaskState::Running { started_data, .. } => (Some(started_data.start_date), None),
         JobTaskState::Finished {
             started_data,
@@ -889,6 +891,7 @@ pub fn get_task_time(state: &JobTaskState) -> (Option<DateTime<Utc>>, Option<Dat
             end_date,
             ..
         } => (Some(started_data.start_date), Some(*end_date)),
+        JobTaskState::Canceled { started_data: None } | JobTaskState::Waiting => (None, None),
     }
 }
 

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -131,27 +131,30 @@ impl Output for JsonOutput {
                         "state": state,
                     });
                     match task.state {
-                        JobTaskState::Running { start_date, worker } => {
+                        JobTaskState::Running {
+                            started_data,
+                            worker,
+                        } => {
                             data["worker"] = worker.as_num().into();
-                            data["started_at"] = format_datetime(start_date)
+                            data["started_at"] = format_datetime(started_data.start_date)
                         }
                         JobTaskState::Finished {
-                            start_date,
+                            started_data,
                             worker,
                             end_date,
                         } => {
                             data["worker"] = worker.as_num().into();
-                            data["started_at"] = format_datetime(start_date);
+                            data["started_at"] = format_datetime(started_data.start_date);
                             data["finished_at"] = format_datetime(end_date);
                         }
                         JobTaskState::Failed {
-                            start_date,
+                            started_data,
                             end_date,
                             worker,
                             error,
                         } => {
                             data["worker"] = worker.as_num().into();
-                            data["started_at"] = format_datetime(start_date);
+                            data["started_at"] = format_datetime(started_data.start_date);
                             data["finished_at"] = format_datetime(end_date);
                             data["error"] = error.into();
                         }

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -124,7 +124,7 @@ impl Output for JsonOutput {
                         JobTaskState::Running { .. } => "running",
                         JobTaskState::Finished { .. } => "finished",
                         JobTaskState::Failed { .. } => "failed",
-                        JobTaskState::Canceled => "canceled",
+                        JobTaskState::Canceled { .. } => "canceled",
                     };
                     let mut data = json!({
                         "id": task.task_id,

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -131,29 +131,24 @@ impl Output for JsonOutput {
                         "state": state,
                     });
                     match task.state {
-                        JobTaskState::Running {
-                            started_data,
-                            worker,
-                        } => {
-                            data["worker"] = worker.as_num().into();
+                        JobTaskState::Running { started_data } => {
+                            // data["worker"] = worker.as_num().into();
                             data["started_at"] = format_datetime(started_data.start_date)
                         }
                         JobTaskState::Finished {
                             started_data,
-                            worker,
                             end_date,
                         } => {
-                            data["worker"] = worker.as_num().into();
+                            // data["worker"] = worker.as_num().into();
                             data["started_at"] = format_datetime(started_data.start_date);
                             data["finished_at"] = format_datetime(end_date);
                         }
                         JobTaskState::Failed {
                             started_data,
                             end_date,
-                            worker,
                             error,
                         } => {
-                            data["worker"] = worker.as_num().into();
+                            // data["worker"] = worker.as_num().into();
                             data["started_at"] = format_datetime(started_data.start_date);
                             data["finished_at"] = format_datetime(end_date);
                             data["error"] = error.into();

--- a/crates/hyperqueue/src/client/status.rs
+++ b/crates/hyperqueue/src/client/status.rs
@@ -81,7 +81,7 @@ pub fn task_status(status: &JobTaskState) -> Status {
         JobTaskState::Running { .. } => Status::Running,
         JobTaskState::Finished { .. } => Status::Finished,
         JobTaskState::Failed { .. } => Status::Failed,
-        JobTaskState::Canceled => Status::Canceled,
+        JobTaskState::Canceled { .. } => Status::Canceled,
     }
 }
 

--- a/crates/hyperqueue/src/common/placeholders.rs
+++ b/crates/hyperqueue/src/common/placeholders.rs
@@ -3,14 +3,14 @@ use std::fmt::Write;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use bstr::BString;
+use bstr::BStr;
 use nom::bytes::complete::take_until;
 use nom::sequence::delimited;
 use nom_supreme::tag::complete::tag;
 
 use tako::messages::common::ProgramDefinition;
 
-use crate::common::env::{HQ_INSTANCE_ID, HQ_JOB_ID, HQ_SUBMIT_DIR, HQ_TASK_ID};
+use crate::common::env::{HQ_INSTANCE_ID, HQ_SUBMIT_DIR, HQ_TASK_ID};
 use crate::common::parser::NomResult;
 use crate::{JobId, Map};
 
@@ -22,51 +22,73 @@ pub const SUBMIT_DIR_PLACEHOLDER: &str = "SUBMIT_DIR";
 
 type PlaceholderMap<'a> = Map<&'static str, Cow<'a, str>>;
 
+fn env_key(key: &str) -> &BStr {
+    key.into()
+}
+
+/// Fills placeholder values known on the worker.
 pub fn fill_placeholders_worker(program: &mut ProgramDefinition) {
     let mut placeholders = PlaceholderMap::new();
-    let job_id = program.env[&BString::from(HQ_JOB_ID)].to_string();
-    let task_id = program.env[&BString::from(HQ_TASK_ID)].to_string();
-    let instance_id = program.env[&BString::from(HQ_INSTANCE_ID)].to_string();
-    let submit_dir = program.env[&BString::from(HQ_SUBMIT_DIR)].to_string();
 
-    placeholders.insert(JOB_ID_PLACEHOLDER, job_id.into());
+    let task_id = program.env[env_key(HQ_TASK_ID)].to_string();
     placeholders.insert(TASK_ID_PLACEHOLDER, task_id.into());
+
+    let instance_id = program.env[env_key(HQ_INSTANCE_ID)].to_string();
     placeholders.insert(INSTANCE_ID_PLACEHOLDER, instance_id.into());
-    placeholders.insert(SUBMIT_DIR_PLACEHOLDER, submit_dir.clone().into());
 
-    let replace_path = |map: &PlaceholderMap, path: &PathBuf, base_dir: &Path| -> PathBuf {
-        let path: PathBuf = replace_placeholders(map, path.to_str().unwrap()).into();
-        normalize_path(&path, base_dir)
-    };
+    let submit_dir: PathBuf = program.env[env_key(HQ_SUBMIT_DIR)].to_string().into();
+    resolve_program_paths(placeholders, program, &submit_dir, true);
+}
 
-    // Replace CWD
-    let submit_dir = PathBuf::from(submit_dir);
-    program.cwd = program
-        .cwd
-        .as_ref()
-        .map(|cwd| replace_path(&placeholders, cwd, &submit_dir))
-        .or_else(|| Some(std::env::current_dir().unwrap()));
-
-    // Replace STDOUT and STDERR
-    placeholders.insert(
-        CWD_PLACEHOLDER,
-        program.cwd.as_ref().unwrap().to_str().unwrap().into(),
-    );
-
-    program.stdout = std::mem::take(&mut program.stdout)
-        .map_filename(|path| replace_path(&placeholders, &path, &submit_dir));
-    program.stderr = std::mem::take(&mut program.stderr)
-        .map_filename(|path| replace_path(&placeholders, &path, &submit_dir));
+/// Fills placeholder values that are known immediately after a job is submitted.
+pub fn fill_placeholders_after_submit(
+    program: &mut ProgramDefinition,
+    job_id: JobId,
+    submit_dir: &Path,
+) {
+    let mut placeholders = PlaceholderMap::new();
+    insert_submit_data(&mut placeholders, job_id, submit_dir);
+    resolve_program_paths(placeholders, program, submit_dir, false);
 }
 
 pub fn fill_placeholders_log(value: &mut PathBuf, job_id: JobId, submit_dir: &Path) {
-    let mut map = PlaceholderMap::new();
-    map.insert(JOB_ID_PLACEHOLDER, job_id.to_string().into());
-    map.insert(SUBMIT_DIR_PLACEHOLDER, submit_dir.to_str().unwrap().into());
-    *value = replace_placeholders(&map, value.to_str().unwrap()).into();
+    let mut placeholders = PlaceholderMap::new();
+    insert_submit_data(&mut placeholders, job_id, submit_dir);
+    *value = resolve(&placeholders, value.to_str().unwrap()).into();
 }
 
-fn replace_placeholders(map: &PlaceholderMap, input: &str) -> String {
+fn insert_submit_data<'a>(map: &mut PlaceholderMap<'a>, job_id: JobId, submit_dir: &'a Path) {
+    map.insert(JOB_ID_PLACEHOLDER, job_id.to_string().into());
+    map.insert(SUBMIT_DIR_PLACEHOLDER, submit_dir.to_str().unwrap().into());
+}
+
+fn resolve_program_paths<'a>(
+    mut placeholders: PlaceholderMap<'a>,
+    program: &'a mut ProgramDefinition,
+    submit_dir: &Path,
+    normalize_paths: bool,
+) {
+    // Replace CWD
+    program.cwd = program
+        .cwd
+        .as_ref()
+        .map(|cwd| resolve_path(&placeholders, cwd, submit_dir, normalize_paths))
+        .or_else(|| Some(std::env::current_dir().unwrap()));
+
+    if normalize_paths {
+        placeholders.insert(
+            CWD_PLACEHOLDER,
+            program.cwd.as_ref().unwrap().to_str().unwrap().into(),
+        );
+    }
+
+    program.stdout = std::mem::take(&mut program.stdout)
+        .map_filename(|path| resolve_path(&placeholders, &path, submit_dir, normalize_paths));
+    program.stderr = std::mem::take(&mut program.stderr)
+        .map_filename(|path| resolve_path(&placeholders, &path, submit_dir, normalize_paths));
+}
+
+fn resolve(map: &PlaceholderMap, input: &str) -> String {
     let mut buffer = String::with_capacity(input.len());
     for placeholder in parse_resolvable_string(input) {
         match placeholder {
@@ -86,6 +108,15 @@ fn replace_placeholders(map: &PlaceholderMap, input: &str) -> String {
         .unwrap();
     }
     buffer
+}
+
+fn resolve_path(map: &PlaceholderMap, path: &Path, base_dir: &Path, normalize: bool) -> PathBuf {
+    let path: PathBuf = resolve(map, path.to_str().unwrap()).into();
+    if normalize {
+        normalize_path(&path, base_dir)
+    } else {
+        path
+    }
 }
 
 /// Adds the given base `directory` to the `path`, if it's not already absolute.
@@ -146,11 +177,13 @@ pub fn parse_resolvable_string(data: &str) -> Vec<StringPart> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use tako::messages::common::{ProgramDefinition, StdioDef};
 
     use crate::common::env::{HQ_INSTANCE_ID, HQ_JOB_ID, HQ_SUBMIT_DIR, HQ_TASK_ID};
     use crate::common::placeholders::{
-        fill_placeholders_worker, parse_resolvable_string, StringPart,
+        fill_placeholders_after_submit, fill_placeholders_worker, parse_resolvable_string,
+        StringPart,
     };
     use crate::Map;
 
@@ -226,68 +259,51 @@ mod tests {
     }
 
     #[test]
-    fn test_replace_task_id() {
+    fn test_replace_after_submit() {
         let mut program = program_def(
-            "dir-%{TASK_ID}",
-            Some("%{TASK_ID}.out"),
-            Some("%{TASK_ID}.err"),
-            "",
-            0,
-            1,
-        );
-        fill_placeholders_worker(&mut program);
-        assert_eq!(program.cwd, Some("dir-1".into()));
-        assert_eq!(program.stdout, StdioDef::File("1.out".into()));
-        assert_eq!(program.stderr, StdioDef::File("1.err".into()));
-    }
-
-    #[test]
-    fn test_replace_job_id() {
-        let mut program = program_def(
-            "dir-%{JOB_ID}-%{TASK_ID}",
-            Some("%{JOB_ID}-%{TASK_ID}.out"),
-            Some("%{JOB_ID}-%{TASK_ID}.err"),
-            "",
-            5,
-            1,
-        );
-        fill_placeholders_worker(&mut program);
-        assert_eq!(program.cwd, Some("dir-5-1".into()));
-        assert_eq!(program.stdout, StdioDef::File("5-1.out".into()));
-        assert_eq!(program.stderr, StdioDef::File("5-1.err".into()));
-    }
-
-    #[test]
-    fn test_replace_submit_dir() {
-        let mut program = program_def(
-            "%{SUBMIT_DIR}",
-            Some("%{SUBMIT_DIR}/out"),
-            Some("%{SUBMIT_DIR}/err"),
-            "/submit-dir",
-            5,
-            1,
-        );
-        fill_placeholders_worker(&mut program);
-
-        assert_eq!(program.cwd, Some("/submit-dir".into()));
-        assert_eq!(program.stdout, StdioDef::File("/submit-dir/out".into()));
-        assert_eq!(program.stderr, StdioDef::File("/submit-dir/err".into()));
-    }
-
-    #[test]
-    fn test_replace_cwd() {
-        let mut program = program_def(
-            "dir-%{JOB_ID}-%{TASK_ID}",
+            "%{SUBMIT_DIR}/%{JOB_ID}-%{TASK_ID}",
             Some("%{CWD}.out"),
             Some("%{CWD}.err"),
-            "",
+            "/foo",
+            99,
+            99,
+        );
+        fill_placeholders_after_submit(&mut program, 5.into(), &PathBuf::from("/foo"));
+        assert_eq!(program.cwd, Some("/foo/5-%{TASK_ID}".into()));
+        assert_eq!(program.stdout, StdioDef::File("%{CWD}.out".into()));
+        assert_eq!(program.stderr, StdioDef::File("%{CWD}.err".into()));
+    }
+
+    #[test]
+    fn test_replace_worker() {
+        let mut program = program_def(
+            "%{TASK_ID}-%{INSTANCE_ID}",
+            Some("%{CWD}/stdout"),
+            Some("%{CWD}/stderr"),
+            "/foo",
+            5,
+            10,
+        );
+        fill_placeholders_worker(&mut program);
+        assert_eq!(program.cwd, Some("/foo/10-0".into()));
+        assert_eq!(program.stdout, StdioDef::File("/foo/10-0/stdout".into()));
+        assert_eq!(program.stderr, StdioDef::File("/foo/10-0/stderr".into()));
+    }
+
+    #[test]
+    fn test_fill_cwd_into_output_paths() {
+        let mut program = program_def(
+            "bar/%{TASK_ID}",
+            Some("%{CWD}/%{TASK_ID}.out"),
+            Some("%{CWD}/%{TASK_ID}.err"),
+            "/foo",
             5,
             1,
         );
         fill_placeholders_worker(&mut program);
-        assert_eq!(program.cwd, Some("dir-5-1".into()));
-        assert_eq!(program.stdout, StdioDef::File("dir-5-1.out".into()));
-        assert_eq!(program.stderr, StdioDef::File("dir-5-1.err".into()));
+        assert_eq!(program.cwd, Some("/foo/bar/1".into()));
+        assert_eq!(program.stdout, StdioDef::File("/foo/bar/1/1.out".into()));
+        assert_eq!(program.stderr, StdioDef::File("/foo/bar/1/1.err".into()));
     }
 
     fn program_def(

--- a/crates/hyperqueue/src/server/client/mod.rs
+++ b/crates/hyperqueue/src/server/client/mod.rs
@@ -1,21 +1,18 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use bstr::BString;
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use orion::kdf::SecretKey;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{oneshot, Notify};
 
-use tako::messages::common::ProgramDefinition;
 use tako::messages::gateway::{
     CancelTasks, FromGatewayMessage, MonitoringEventRequest, StopWorkerRequest, ToGatewayMessage,
 };
 
 use crate::client::status::{job_status, task_status, Status};
 use crate::common::arraydef::IntArray;
-use crate::common::env::{HQ_JOB_ID, HQ_SUBMIT_DIR, HQ_TASK_ID};
 use crate::common::manager::info::ManagerType;
 use crate::common::serverdir::ServerDir;
 use crate::server::autoalloc::{
@@ -33,7 +30,7 @@ use crate::transfer::messages::{
     Selector, StatsResponse, StopWorkerResponse, SubmitRequest, ToClientMessage,
     WorkerListResponse,
 };
-use crate::{JobId, JobTaskCount, JobTaskId, WorkerId};
+use crate::{JobId, JobTaskCount, WorkerId};
 
 mod submit;
 
@@ -569,23 +566,6 @@ async fn handle_job_cancel(
     }
 
     ToClientMessage::CancelJobResponse(responses)
-}
-
-fn make_program_def_for_task(
-    program_def: &ProgramDefinition,
-    job_id: JobId,
-    task_id: JobTaskId,
-    submit_dir: &Path,
-) -> ProgramDefinition {
-    let mut def = program_def.clone();
-    def.env.insert(HQ_JOB_ID.into(), job_id.to_string().into());
-    def.env
-        .insert(HQ_TASK_ID.into(), task_id.to_string().into());
-    def.env.insert(
-        HQ_SUBMIT_DIR.into(),
-        BString::from(submit_dir.to_string_lossy().as_bytes()),
-    );
-    def
 }
 
 async fn handle_resubmit(

--- a/crates/hyperqueue/src/server/state.rs
+++ b/crates/hyperqueue/src/server/state.rs
@@ -172,9 +172,9 @@ impl State {
     pub fn process_task_update(&mut self, msg: TaskUpdate, backend: &Backend) {
         log::debug!("Task id={} updated {:?}", msg.id, msg.state);
         match msg.state {
-            TaskState::Running(worker_id) => {
+            TaskState::Running { worker_id, context } => {
                 let job = self.get_job_mut_by_tako_task_id(msg.id).unwrap();
-                job.set_running_state(msg.id, worker_id)
+                job.set_running_state(msg.id, worker_id, context)
             }
             TaskState::Finished => {
                 let job = self.get_job_mut_by_tako_task_id(msg.id).unwrap();

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 
 /// Data created when a task is started on a worker.
 /// It can be accessed through the state of a running task.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunningTaskContext {
     cwd: PathBuf,
     stdout: StdioDef,

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -15,7 +15,7 @@ use tako::common::error::DsError;
 use tako::common::resources::{ResourceAllocation, ResourceDescriptor};
 use tako::messages::common::WorkerConfiguration;
 use tako::messages::common::{ProgramDefinition, StdioDef};
-use tako::worker::launcher::{command_from_definitions, pin_program};
+use tako::worker::launcher::command_from_definitions;
 use tako::worker::state::{WorkerState, WorkerStateRef};
 use tako::worker::task::Task;
 use tako::worker::taskenv::{StopReason, TaskResult};
@@ -167,6 +167,14 @@ fn insert_resources_into_env(
             );
         }
     }
+}
+
+fn pin_program(program: &mut ProgramDefinition, allocation: &ResourceAllocation) {
+    program.args.insert(0, "taskset".into());
+    program.args.insert(1, "-c".into());
+    program
+        .args
+        .insert(2, allocation.comma_delimited_cpu_ids().into());
 }
 
 /// Zero-worker mode measures pure overhead of HyperQueue.

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -1,6 +1,4 @@
-use std::future::Future;
 use std::io;
-use std::pin::Pin;
 use std::process::ExitStatus;
 use std::rc::Rc;
 use std::time::Duration;
@@ -16,7 +14,7 @@ use tako::common::error::DsError;
 use tako::common::resources::{ResourceAllocation, ResourceDescriptor};
 use tako::messages::common::WorkerConfiguration;
 use tako::messages::common::{ProgramDefinition, StdioDef};
-use tako::worker::launcher::{command_from_definitions, TaskLauncher};
+use tako::worker::launcher::{command_from_definitions, TaskLaunchData, TaskLauncher};
 use tako::worker::state::{WorkerState, WorkerStateRef};
 use tako::worker::task::Task;
 use tako::worker::taskenv::{StopReason, TaskResult};
@@ -52,13 +50,13 @@ impl TaskLauncher for HqTaskLauncher {
         state_ref: WorkerStateRef,
         task_id: TaskId,
         stop_receiver: Receiver<StopReason>,
-    ) -> Pin<Box<dyn Future<Output = tako::Result<TaskResult>>>> {
-        Box::pin(launcher_main(
+    ) -> TaskLaunchData {
+        TaskLaunchData::from_future(Box::pin(launcher_main(
             state_ref,
             self.streamer_ref.clone(),
             task_id,
             stop_receiver,
-        ))
+        )))
     }
 }
 

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -41,9 +41,9 @@ use serde::{Deserialize, Serialize};
 /// It can be accessed through the state of a running task.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunningTaskContext {
-    cwd: PathBuf,
-    stdout: StdioDef,
-    stderr: StdioDef,
+    pub cwd: PathBuf,
+    pub stdout: StdioDef,
+    pub stderr: StdioDef,
 }
 
 pub struct HqTaskLauncher {

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::rc::Rc;
 use std::time::Duration;
@@ -14,8 +15,9 @@ use tako::common::error::DsError;
 use tako::common::resources::{ResourceAllocation, ResourceDescriptor};
 use tako::messages::common::WorkerConfiguration;
 use tako::messages::common::{ProgramDefinition, StdioDef};
+use tako::transfer::auth::serialize;
 use tako::worker::launcher::{command_from_definitions, TaskLaunchData, TaskLauncher};
-use tako::worker::state::{WorkerState, WorkerStateRef};
+use tako::worker::state::WorkerState;
 use tako::worker::task::Task;
 use tako::worker::taskenv::{StopReason, TaskResult};
 use tako::{InstanceId, TaskId};
@@ -33,6 +35,16 @@ use crate::worker::streamer::StreamSender;
 use crate::worker::streamer::StreamerRef;
 use crate::Map;
 use crate::{JobId, JobTaskId};
+use serde::{Deserialize, Serialize};
+
+/// Data created when a task is started on a worker.
+/// It can be accessed through the state of a running task.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RunningTaskContext {
+    cwd: PathBuf,
+    stdout: StdioDef,
+    stderr: StdioDef,
+}
 
 pub struct HqTaskLauncher {
     streamer_ref: StreamerRef,
@@ -45,18 +57,73 @@ impl HqTaskLauncher {
 }
 
 impl TaskLauncher for HqTaskLauncher {
-    fn start_task(
+    fn build_task(
         &self,
-        state_ref: WorkerStateRef,
+        state: &WorkerState,
         task_id: TaskId,
         stop_receiver: Receiver<StopReason>,
-    ) -> TaskLaunchData {
-        TaskLaunchData::from_future(Box::pin(launcher_main(
-            state_ref,
+    ) -> tako::Result<TaskLaunchData> {
+        let (program, job_id, job_task_id, instance_id): (
+            ProgramDefinition,
+            JobId,
+            JobTaskId,
+            InstanceId,
+        ) = {
+            let task = state.get_task(task_id);
+            let allocation = task
+                .resource_allocation()
+                .expect("Missing resource allocation for running task");
+
+            log::debug!(
+                "Starting program launcher task_id={} res={:?} alloc={:?} body_len={}",
+                task.id,
+                &task.resources,
+                allocation,
+                task.body.len(),
+            );
+
+            let body: TaskBody = tako::transfer::auth::deserialize(&task.body)?;
+            let mut program = body.program;
+
+            if body.pin {
+                pin_program(&mut program, allocation);
+                program.env.insert(HQ_PIN.into(), "1".into());
+            }
+
+            insert_resources_into_env(state, task, allocation, &mut program);
+
+            program
+                .env
+                .insert(HQ_INSTANCE_ID.into(), task.instance_id.to_string().into());
+
+            fill_placeholders_worker(&mut program);
+
+            create_directory_if_needed(&program.stdout)?;
+            create_directory_if_needed(&program.stderr)?;
+
+            (program, body.job_id, body.task_id, task.instance_id)
+        };
+
+        let context = RunningTaskContext {
+            cwd: program.cwd.clone().unwrap(),
+            stdout: program.stdout.clone(),
+            stderr: program.stderr.clone(),
+        };
+        let serialized_context = serialize(&context)?;
+
+        let task_future = run_task(
             self.streamer_ref.clone(),
-            task_id,
+            program,
+            job_id,
+            job_task_id,
+            instance_id,
             stop_receiver,
-        )))
+        );
+
+        Ok(TaskLaunchData::new(
+            Box::pin(task_future),
+            serialized_context,
+        ))
     }
 }
 
@@ -93,65 +160,6 @@ fn create_directory_if_needed(file: &StdioDef) -> io::Result<()> {
         }
     }
     Ok(())
-}
-
-async fn launcher_main(
-    state_ref: WorkerStateRef,
-    streamer_ref: StreamerRef,
-    task_id: TaskId,
-    end_receiver: tokio::sync::oneshot::Receiver<StopReason>,
-) -> tako::Result<TaskResult> {
-    let (program, job_id, job_task_id, instance_id): (
-        ProgramDefinition,
-        JobId,
-        JobTaskId,
-        InstanceId,
-    ) = {
-        let state = state_ref.get();
-        let task = state.get_task(task_id);
-        let allocation = task
-            .resource_allocation()
-            .expect("Missing resource allocation for running task");
-
-        log::debug!(
-            "Starting program launcher task_id={} res={:?} alloc={:?} body_len={}",
-            task.id,
-            &task.resources,
-            allocation,
-            task.body.len(),
-        );
-
-        let body: TaskBody = tako::transfer::auth::deserialize(&task.body)?;
-        let mut program = body.program;
-
-        if body.pin {
-            pin_program(&mut program, allocation);
-            program.env.insert(HQ_PIN.into(), "1".into());
-        }
-
-        insert_resources_into_env(&state_ref.get(), task, allocation, &mut program);
-
-        program
-            .env
-            .insert(HQ_INSTANCE_ID.into(), task.instance_id.to_string().into());
-
-        fill_placeholders_worker(&mut program);
-
-        create_directory_if_needed(&program.stdout)?;
-        create_directory_if_needed(&program.stderr)?;
-
-        (program, body.job_id, body.task_id, task.instance_id)
-    };
-
-    run_task(
-        streamer_ref,
-        &program,
-        job_id,
-        job_task_id,
-        instance_id,
-        end_receiver,
-    )
-    .await
 }
 
 fn insert_resources_into_env(
@@ -207,7 +215,7 @@ fn pin_program(program: &mut ProgramDefinition, allocation: &ResourceAllocation)
 #[cfg(feature = "zero-worker")]
 async fn run_task(
     _streamer_ref: StreamerRef,
-    _program: &ProgramDefinition,
+    _program: ProgramDefinition,
     _job_id: JobId,
     _job_task_id: JobTaskId,
     _instance_id: InstanceId,
@@ -219,13 +227,13 @@ async fn run_task(
 #[cfg(not(feature = "zero-worker"))]
 async fn run_task(
     streamer_ref: StreamerRef,
-    program: &ProgramDefinition,
+    program: ProgramDefinition,
     job_id: JobId,
     job_task_id: JobTaskId,
     instance_id: InstanceId,
     end_receiver: tokio::sync::oneshot::Receiver<StopReason>,
 ) -> tako::Result<TaskResult> {
-    let mut command = command_from_definitions(program)?;
+    let mut command = command_from_definitions(&program)?;
 
     let status_to_result = |status: ExitStatus| {
         if !status.success() {

--- a/crates/tako/benches/benchmarks/scheduler.rs
+++ b/crates/tako/benches/benchmarks/scheduler.rs
@@ -8,6 +8,7 @@ use tako::scheduler::metrics::compute_b_level_metric;
 use tako::scheduler::state::SchedulerState;
 use tako::server::comm::Comm;
 use tako::server::core::Core;
+use tako::server::task::SerializedTaskContext;
 use tako::{TaskId, WorkerId};
 
 use crate::{add_tasks, create_worker};
@@ -86,7 +87,13 @@ impl Comm for NullComm {
 
     fn send_client_task_finished(&mut self, _task_id: TaskId) {}
 
-    fn send_client_task_started(&mut self, _task_id: TaskId, _worker_id: WorkerId) {}
+    fn send_client_task_started(
+        &mut self,
+        _task_id: TaskId,
+        _worker_id: WorkerId,
+        _context: SerializedTaskContext,
+    ) {
+    }
 
     fn send_client_task_error(
         &mut self,

--- a/crates/tako/benches/benchmarks/worker.rs
+++ b/crates/tako/benches/benchmarks/worker.rs
@@ -1,5 +1,3 @@
-use std::future::Future;
-use std::pin::Pin;
 use std::time::Duration;
 
 use criterion::measurement::WallTime;
@@ -15,7 +13,7 @@ use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::oneshot::Receiver;
 
 use tako::messages::worker::ComputeTaskMsg;
-use tako::worker::launcher::TaskLauncher;
+use tako::worker::launcher::{TaskLaunchData, TaskLauncher};
 use tako::worker::rqueue::ResourceWaitQueue;
 use tako::worker::state::{TaskMap, WorkerStateRef};
 use tako::worker::task::Task;
@@ -32,8 +30,8 @@ impl TaskLauncher for BenchmarkTaskLauncher {
         _state_ref: WorkerStateRef,
         _task_id: TaskId,
         _stop_receiver: Receiver<StopReason>,
-    ) -> Pin<Box<dyn Future<Output = tako::Result<TaskResult>>>> {
-        Box::pin(async move { Ok(TaskResult::Finished) })
+    ) -> TaskLaunchData {
+        TaskLaunchData::from_future(Box::pin(async move { Ok(TaskResult::Finished) }))
     }
 }
 

--- a/crates/tako/benches/benchmarks/worker.rs
+++ b/crates/tako/benches/benchmarks/worker.rs
@@ -15,7 +15,7 @@ use tokio::sync::oneshot::Receiver;
 use tako::messages::worker::ComputeTaskMsg;
 use tako::worker::launcher::{TaskLaunchData, TaskLauncher};
 use tako::worker::rqueue::ResourceWaitQueue;
-use tako::worker::state::{TaskMap, WorkerStateRef};
+use tako::worker::state::{TaskMap, WorkerState, WorkerStateRef};
 use tako::worker::task::Task;
 use tako::worker::taskenv::{StopReason, TaskResult};
 use tako::TaskId;
@@ -25,13 +25,15 @@ use crate::create_worker;
 struct BenchmarkTaskLauncher;
 
 impl TaskLauncher for BenchmarkTaskLauncher {
-    fn start_task(
+    fn build_task(
         &self,
-        _state_ref: WorkerStateRef,
+        _state: &WorkerState,
         _task_id: TaskId,
         _stop_receiver: Receiver<StopReason>,
-    ) -> TaskLaunchData {
-        TaskLaunchData::from_future(Box::pin(async move { Ok(TaskResult::Finished) }))
+    ) -> tako::Result<TaskLaunchData> {
+        Ok(TaskLaunchData::from_future(Box::pin(async move {
+            Ok(TaskResult::Finished)
+        })))
     }
 }
 

--- a/crates/tako/src/common/wrapped.rs
+++ b/crates/tako/src/common/wrapped.rs
@@ -39,12 +39,14 @@ impl<T: ?Sized> WrappedRcRefCell<T> {
 
     /// Return a immutable reference to contents. Panics whenever `RefCell::borrow()` would.
     #[inline]
+    #[track_caller]
     pub fn get(&self) -> Ref<T> {
         self.inner.deref().borrow()
     }
 
     /// Return a mutable reference to contents. Panics whenever `RefCell::borrow_mut()` would.
     #[inline]
+    #[track_caller]
     pub fn get_mut(&self) -> RefMut<T> {
         self.inner.deref().borrow_mut()
     }

--- a/crates/tako/src/messages/gateway.rs
+++ b/crates/tako/src/messages/gateway.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use crate::common::resources::CpuRequest;
 use crate::messages::common::{TaskFailInfo, WorkerConfiguration};
 use crate::server::monitoring::MonitoringEvent;
+use crate::server::task::SerializedTaskContext;
 use crate::{Priority, TaskId, WorkerId};
 use std::time::Duration;
 
@@ -114,7 +115,10 @@ pub struct ErrorResponse {
 pub enum TaskState {
     Invalid,
     Waiting,
-    Running(WorkerId),
+    Running {
+        worker_id: WorkerId,
+        context: SerializedTaskContext,
+    },
     Finished,
 }
 
@@ -127,7 +131,7 @@ impl Serialize for TaskState {
             TaskState::Invalid => "Invalid",
             TaskState::Waiting => "Waiting",
             TaskState::Finished => "Finished",
-            TaskState::Running(_) => "Running",
+            TaskState::Running { .. } => "Running",
         })
     }
 }

--- a/crates/tako/src/messages/worker.rs
+++ b/crates/tako/src/messages/worker.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use crate::common::resources::{CpuId, GenericResourceAmount, GenericResourceIndex};
 use crate::common::Map;
 use crate::messages::common::{TaskFailInfo, WorkerConfiguration};
+use crate::server::task::SerializedTaskContext;
 use crate::worker::hwmonitor::WorkerHwState;
 use crate::{InstanceId, Priority};
 use crate::{TaskId, WorkerId};
@@ -90,6 +91,7 @@ pub struct TaskFailedMsg {
 #[derive(Deserialize, Serialize, Debug)]
 pub struct TaskRunningMsg {
     pub id: TaskId,
+    pub context: SerializedTaskContext,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/crates/tako/src/scheduler/state.rs
+++ b/crates/tako/src/scheduler/state.rs
@@ -214,7 +214,7 @@ impl SchedulerState {
             TaskRuntimeState::Stealing(from_w, _) => {
                 TaskRuntimeState::Stealing(from_w, Some(worker_id))
             }
-            TaskRuntimeState::Running(_) | TaskRuntimeState::Finished(_) => {
+            TaskRuntimeState::Running { .. } | TaskRuntimeState::Finished(_) => {
                 panic!("Invalid state {:?}", task.state);
             }
         };

--- a/crates/tako/src/server/client.rs
+++ b/crates/tako/src/server/client.rs
@@ -154,7 +154,7 @@ pub async fn process_client_message(
                             TaskRuntimeState::Waiting(_) => TaskState::Waiting,
                             TaskRuntimeState::Assigned(_) => TaskState::Waiting,
                             TaskRuntimeState::Stealing(_, _) => TaskState::Waiting,
-                            TaskRuntimeState::Running(_) => TaskState::Waiting,
+                            TaskRuntimeState::Running { .. } => TaskState::Waiting,
                             TaskRuntimeState::Finished(_) => TaskState::Finished,
                         },
                     }

--- a/crates/tako/src/server/core.rs
+++ b/crates/tako/src/server/core.rs
@@ -356,7 +356,8 @@ impl Core {
                     assert!(task.is_fresh());
                 }
 
-                TaskRuntimeState::Assigned(wid) | TaskRuntimeState::Running(wid) => {
+                TaskRuntimeState::Assigned(wid)
+                | TaskRuntimeState::Running { worker_id: wid, .. } => {
                     assert!(!task.is_fresh());
                     fw_check(task);
                     worker_check(self, task.id, *wid);

--- a/crates/tako/src/server/rpc.rs
+++ b/crates/tako/src/server/rpc.rs
@@ -259,7 +259,7 @@ pub async fn worker_receive_loop<
                 on_task_finished(&mut core, &mut *comm, worker_id, msg);
             }
             FromWorkerMessage::TaskRunning(msg) => {
-                on_task_running(&mut core, &mut *comm, worker_id, msg.id);
+                on_task_running(&mut core, &mut *comm, worker_id, msg);
             }
             FromWorkerMessage::TaskFailed(msg) => {
                 on_task_error(&mut core, &mut *comm, worker_id, msg.id, msg.info);

--- a/crates/tako/src/tests/integration/utils/api.rs
+++ b/crates/tako/src/tests/integration/utils/api.rs
@@ -71,7 +71,7 @@ pub async fn wait_for_task_start<T: Into<TaskId>>(
 ) -> WorkerId {
     let task_id: TaskId = task_id.into();
     wait_for_msg!(handler, ToGatewayMessage::TaskUpdate(TaskUpdate {
-        state: TaskState::Running(worker_id),
+        state: TaskState::Running { worker_id, .. },
         id,
     }) if id == task_id => worker_id)
 }

--- a/crates/tako/src/tests/integration/utils/worker.rs
+++ b/crates/tako/src/tests/integration/utils/worker.rs
@@ -17,7 +17,7 @@ use orion::auth::SecretKey;
 use tokio::sync::oneshot::Receiver;
 use tokio::task::LocalSet;
 
-use crate::worker::launcher::{command_from_definitions, TaskLauncher};
+use crate::worker::launcher::{command_from_definitions, TaskLaunchData, TaskLauncher};
 use crate::worker::rpc::run_worker;
 use crate::worker::state::WorkerStateRef;
 use crate::worker::taskenv::{StopReason, TaskResult};
@@ -270,8 +270,8 @@ impl TaskLauncher for TestTaskLauncher {
         state_ref: WorkerStateRef,
         task_id: TaskId,
         stop_receiver: Receiver<StopReason>,
-    ) -> Pin<Box<dyn Future<Output = crate::Result<TaskResult>>>> {
-        Box::pin(async move {
+    ) -> TaskLaunchData {
+        TaskLaunchData::from_future(Box::pin(async move {
             tokio::select! {
                 biased;
                 r = stop_receiver => {
@@ -282,7 +282,7 @@ impl TaskLauncher for TestTaskLauncher {
                     Ok(TaskResult::Finished)
                 }
             }
-        })
+        }))
     }
 }
 

--- a/crates/tako/src/tests/test_reactor.rs
+++ b/crates/tako/src/tests/test_reactor.rs
@@ -24,7 +24,7 @@ use crate::tests::utils::schedule::{
     start_and_finish_on_worker, start_on_worker, submit_test_tasks,
 };
 use crate::tests::utils::sorted_vec;
-use crate::tests::utils::task::{task, task_with_deps, TaskBuilder};
+use crate::tests::utils::task::{task, task_running_msg, task_with_deps, TaskBuilder};
 use crate::tests::utils::workflows::{submit_example_1, submit_example_3};
 use crate::tests::utils::{env, schedule};
 use crate::{TaskId, WorkerId};
@@ -621,20 +621,26 @@ fn test_running_task() {
     on_set_observe_flag(&mut core, &mut comm, 1.into(), true);
     comm.emptiness_check();
 
-    on_task_running(&mut core, &mut comm, 101.into(), 1.into());
+    on_task_running(&mut core, &mut comm, 101.into(), task_running_msg(1));
     assert_eq!(comm.take_client_task_running(1), vec![1].to_ids());
     comm.emptiness_check();
 
-    on_task_running(&mut core, &mut comm, 101.into(), 2.into());
+    on_task_running(&mut core, &mut comm, 101.into(), task_running_msg(2));
     comm.emptiness_check();
 
     assert!(matches!(
         core.task(1).state,
-        TaskRuntimeState::Running(WorkerId(101))
+        TaskRuntimeState::Running {
+            worker_id: WorkerId(101),
+            ..
+        }
     ));
     assert!(matches!(
         core.task(2).state,
-        TaskRuntimeState::Running(WorkerId(101))
+        TaskRuntimeState::Running {
+            worker_id: WorkerId(101),
+            ..
+        }
     ));
 
     on_remove_worker(
@@ -710,7 +716,7 @@ fn test_running_before_steal_response() {
     assert!(worker_has_task(&core, 102, 1));
 
     let mut comm = create_test_comm();
-    on_task_running(&mut core, &mut comm, 101.into(), 1.into());
+    on_task_running(&mut core, &mut comm, 101.into(), task_running_msg(1));
     comm.check_need_scheduling();
     comm.emptiness_check();
 
@@ -801,7 +807,7 @@ fn test_after_cancel_messages() {
     );
     comm.emptiness_check();
 
-    on_task_running(&mut core, &mut comm, 101.into(), 4.into());
+    on_task_running(&mut core, &mut comm, 101.into(), task_running_msg(4));
     comm.emptiness_check();
 }
 

--- a/crates/tako/src/tests/utils/env.rs
+++ b/crates/tako/src/tests/utils/env.rs
@@ -9,7 +9,7 @@ use crate::scheduler::state::SchedulerState;
 use crate::server::comm::Comm;
 use crate::server::core::Core;
 use crate::server::reactor::on_new_worker;
-use crate::server::task::Task;
+use crate::server::task::{SerializedTaskContext, Task};
 use crate::server::worker::Worker;
 use crate::server::worker_load::WorkerLoad;
 use crate::tests::utils;
@@ -327,7 +327,12 @@ impl Comm for TestComm {
         self.client_task_finished.push(task_id);
     }
 
-    fn send_client_task_started(&mut self, task_id: TaskId, _worker_id: WorkerId) {
+    fn send_client_task_started(
+        &mut self,
+        task_id: TaskId,
+        _worker_id: WorkerId,
+        _context: SerializedTaskContext,
+    ) {
         self.client_task_running.push(task_id);
     }
 

--- a/crates/tako/src/tests/utils/schedule.rs
+++ b/crates/tako/src/tests/utils/schedule.rs
@@ -7,6 +7,7 @@ use crate::server::reactor::{on_new_tasks, on_new_worker, on_task_finished, on_t
 use crate::server::task::Task;
 use crate::server::worker::Worker;
 use crate::tests::utils::env::TestComm;
+use crate::tests::utils::task::task_running_msg;
 use crate::{TaskId, WorkerId};
 use std::time::Duration;
 
@@ -70,7 +71,7 @@ pub fn start_on_worker_running<W: Into<WorkerId>, T: Into<TaskId>>(
     let mut comm = TestComm::default();
     force_assign(core, &mut scheduler, task_id, worker_id);
     scheduler.finish_scheduling(core, &mut comm);
-    on_task_running(core, &mut comm, worker_id, task_id);
+    on_task_running(core, &mut comm, worker_id, task_running_msg(task_id));
 }
 
 pub fn finish_on_worker<W: Into<WorkerId>, T: Into<TaskId>>(

--- a/crates/tako/src/tests/utils/task.rs
+++ b/crates/tako/src/tests/utils/task.rs
@@ -1,5 +1,6 @@
 use super::resources::ResBuilder;
 use crate::common::resources::{CpuRequest, GenericResourceAmount, GenericResourceId, NumOfCpus};
+use crate::messages::worker::TaskRunningMsg;
 use crate::server::task::{Task, TaskConfiguration, TaskInput};
 use crate::{Priority, TaskId};
 use std::rc::Rc;
@@ -99,4 +100,11 @@ pub fn task_with_deps<T: Into<TaskId>>(id: T, deps: &[&Task], n_outputs: u32) ->
         .simple_deps(deps)
         .outputs(n_outputs)
         .build()
+}
+
+pub fn task_running_msg<T: Into<TaskId>>(task_id: T) -> TaskRunningMsg {
+    TaskRunningMsg {
+        id: task_id.into(),
+        context: Default::default(),
+    }
 }

--- a/crates/tako/src/worker/launcher.rs
+++ b/crates/tako/src/worker/launcher.rs
@@ -8,6 +8,7 @@ use bstr::ByteSlice;
 use tokio::process::Command;
 
 use crate::messages::common::{ProgramDefinition, StdioDef};
+use crate::server::task::SerializedTaskContext;
 use crate::worker::state::WorkerState;
 use crate::worker::taskenv::{StopReason, TaskResult};
 use crate::TaskId;
@@ -19,15 +20,15 @@ pub struct TaskLaunchData {
     pub task_future: TaskFuture,
 
     /// Opaque data that will be sent back to the server
-    pub running_data: Vec<u8>,
+    pub task_context: SerializedTaskContext,
 }
 
 impl TaskLaunchData {
     #[inline]
-    pub fn new(task_future: TaskFuture, running_data: Vec<u8>) -> Self {
+    pub fn new(task_future: TaskFuture, task_context: SerializedTaskContext) -> Self {
         Self {
             task_future,
-            running_data,
+            task_context,
         }
     }
 
@@ -35,7 +36,7 @@ impl TaskLaunchData {
     pub fn from_future(task_future: TaskFuture) -> Self {
         Self {
             task_future,
-            running_data: Vec::new(),
+            task_context: Default::default(),
         }
     }
 }

--- a/crates/tako/src/worker/launcher.rs
+++ b/crates/tako/src/worker/launcher.rs
@@ -8,11 +8,11 @@ use bstr::ByteSlice;
 use tokio::process::Command;
 
 use crate::messages::common::{ProgramDefinition, StdioDef};
-use crate::worker::state::WorkerStateRef;
+use crate::worker::state::WorkerState;
 use crate::worker::taskenv::{StopReason, TaskResult};
 use crate::TaskId;
 
-type TaskFuture = Pin<Box<dyn Future<Output = crate::Result<TaskResult>>>>;
+pub type TaskFuture = Pin<Box<dyn Future<Output = crate::Result<TaskResult>>>>;
 
 pub struct TaskLaunchData {
     /// Future that represents the execution of the task
@@ -41,12 +41,14 @@ impl TaskLaunchData {
 }
 
 pub trait TaskLauncher {
-    fn start_task(
+    /// Creates data required to execute a task.
+    /// `state_ref` must not be borrowed when this function is called.  
+    fn build_task(
         &self,
-        state_ref: WorkerStateRef,
+        state: &WorkerState,
         task_id: TaskId,
         stop_receiver: tokio::sync::oneshot::Receiver<StopReason>,
-    ) -> TaskLaunchData;
+    ) -> crate::Result<TaskLaunchData>;
 }
 
 /// Create an output stream file on the given path.

--- a/crates/tako/src/worker/reactor.rs
+++ b/crates/tako/src/worker/reactor.rs
@@ -1,28 +1,100 @@
 use crate::common::resources::ResourceAllocation;
+use crate::messages::common::TaskFailInfo;
 use crate::messages::worker::{FromWorkerMessage, TaskRunningMsg};
+use crate::worker::launcher::{TaskFuture, TaskLaunchData};
 use crate::worker::state::{WorkerState, WorkerStateRef};
-use crate::worker::task::TaskState;
-use crate::worker::taskenv::TaskEnv;
+use crate::worker::taskenv::{StopReason, TaskEnv, TaskResult};
 use crate::TaskId;
+use futures::future::Either;
+use tokio::sync::oneshot;
 
 pub fn run_task(
     state: &mut WorkerState,
-    state_ref: WorkerStateRef,
+    state_ref: &WorkerStateRef,
     task_id: TaskId,
     allocation: ResourceAllocation,
 ) {
-    {
-        log::debug!("Task={} assigned", task_id);
+    log::debug!("Task={} assigned", task_id);
 
-        state.send_message_to_server(FromWorkerMessage::TaskRunning(TaskRunningMsg {
-            id: task_id,
-        }));
+    assert_eq!(state.get_task(task_id).n_outputs, 0);
+    let (end_sender, end_receiver) = oneshot::channel();
+    let task_env = TaskEnv::new(end_sender);
 
-        let mut task_env = TaskEnv::new();
-        task_env.start_task(state, state_ref, task_id);
+    state.start_task(task_id, task_env, allocation);
 
-        let mut task = state.get_task_mut(task_id);
-        task.state = TaskState::Running(task_env, allocation);
+    match state.task_launcher.build_task(state, task_id, end_receiver) {
+        Ok(task_launch_data) => {
+            let TaskLaunchData {
+                task_future,
+                running_data: _,
+            } = task_launch_data;
+
+            state.send_message_to_server(FromWorkerMessage::TaskRunning(TaskRunningMsg {
+                id: task_id,
+            }));
+
+            tokio::task::spawn_local(execute_task(task_future, state_ref.clone(), task_id));
+        }
+        Err(error) => {
+            log::debug!(
+                "Task initialization failed id={}, error={:?}",
+                task_id,
+                error
+            );
+            state.finish_task_failed(task_id, TaskFailInfo::from_string(error.to_string()));
+        }
+    };
+}
+
+async fn execute_task(task_future: TaskFuture, state_ref: WorkerStateRef, task_id: TaskId) {
+    let time_limit = {
+        let state = state_ref.get();
+        if let Some(task) = state.find_task(task_id) {
+            task.time_limit
+        } else {
+            // Task was removed before spawn took place
+            return;
+        }
+    };
+
+    let result = if let Some(duration) = time_limit {
+        let sleep = tokio::time::sleep(duration);
+        tokio::pin!(sleep);
+        match futures::future::select(task_future, sleep).await {
+            Either::Left((r, _)) => r,
+            Either::Right((_, task_future)) => {
+                {
+                    let mut state = state_ref.get_mut();
+                    let task = state.get_task_mut(task_id);
+                    log::debug!("Task {} timeouted", task.id);
+                    task.task_env_mut().unwrap().send_stop(StopReason::Timeout)
+                }
+                task_future.await
+            }
+        }
+    } else {
+        task_future.await
+    };
+    let mut state = state_ref.get_mut();
+    match result {
+        Ok(TaskResult::Finished) => {
+            log::debug!("Inner task finished id={}", task_id);
+            state.finish_task(task_id, 0);
+        }
+        Ok(TaskResult::Canceled) => {
+            log::debug!("Inner task canceled id={}", task_id);
+            state.finish_task_cancel(task_id);
+        }
+        Ok(TaskResult::Timeouted) => {
+            log::debug!("Inner task timeouted id={}", task_id);
+            state.finish_task_failed(
+                task_id,
+                TaskFailInfo::from_string("Time limit reached".to_string()),
+            );
+        }
+        Err(e) => {
+            log::debug!("Inner task failed id={}, error={:?}", task_id, e);
+            state.finish_task_failed(task_id, TaskFailInfo::from_string(e.to_string()));
+        }
     }
-    state.running_tasks.insert(task_id);
 }

--- a/crates/tako/src/worker/reactor.rs
+++ b/crates/tako/src/worker/reactor.rs
@@ -5,7 +5,7 @@ use crate::worker::task::TaskState;
 use crate::worker::taskenv::TaskEnv;
 use crate::TaskId;
 
-pub fn assign_task(
+pub fn run_task(
     state: &mut WorkerState,
     state_ref: WorkerStateRef,
     task_id: TaskId,

--- a/crates/tako/src/worker/reactor.rs
+++ b/crates/tako/src/worker/reactor.rs
@@ -26,11 +26,12 @@ pub fn run_task(
         Ok(task_launch_data) => {
             let TaskLaunchData {
                 task_future,
-                running_data: _,
+                task_context,
             } = task_launch_data;
 
             state.send_message_to_server(FromWorkerMessage::TaskRunning(TaskRunningMsg {
                 id: task_id,
+                context: task_context,
             }));
 
             tokio::task::spawn_local(execute_task(task_future, state_ref.clone(), task_id));

--- a/crates/tako/src/worker/rpc.rs
+++ b/crates/tako/src/worker/rpc.rs
@@ -219,7 +219,7 @@ async fn task_starter_process(state_ref: WrappedRcRefCell<WorkerState>) {
             }
 
             for (task_id, allocation) in allocations {
-                run_task(&mut state, state_ref.clone(), task_id, allocation);
+                run_task(&mut state, &state_ref, task_id, allocation);
             }
         }
     }

--- a/crates/tako/src/worker/rpc.rs
+++ b/crates/tako/src/worker/rpc.rs
@@ -156,7 +156,7 @@ pub async fn run_worker(
     let try_start_tasks = task_starter_process(state.clone());
 
     let heartbeat = heartbeat_process(heartbeat_interval, state.clone());
-    let hw_polling_process = match send_overview_interval {
+    let overview_loop = match send_overview_interval {
         None => Either::Left(futures::future::pending()),
         Some(interval) => Either::Right(send_overview_loop(state.clone(), interval)),
     };

--- a/crates/tako/src/worker/rpc.rs
+++ b/crates/tako/src/worker/rpc.rs
@@ -103,7 +103,7 @@ pub async fn run_worker(
     scheduler_address: SocketAddr,
     mut configuration: WorkerConfiguration,
     secret_key: Option<Arc<SecretKey>>,
-    launcher_setup: TaskLauncher,
+    launcher_setup: Box<dyn TaskLauncher>,
 ) -> crate::Result<((WorkerId, WorkerConfiguration), impl Future<Output = ()>)> {
     let (listener, address) = start_listener().await?;
     configuration.listen_address = address;

--- a/crates/tako/src/worker/state.rs
+++ b/crates/tako/src/worker/state.rs
@@ -11,6 +11,7 @@ use tokio::sync::Notify;
 
 use crate::common::data::SerializationType;
 use crate::common::resources::map::ResourceMap;
+use crate::common::resources::ResourceAllocation;
 use crate::common::stablemap::StableMap;
 use crate::common::{Map, Set, WrappedRcRefCell};
 use crate::messages::common::{TaskFailInfo, WorkerConfiguration};
@@ -21,6 +22,7 @@ use crate::worker::data::{DataObject, DataObjectRef, DataObjectState};
 use crate::worker::launcher::TaskLauncher;
 use crate::worker::rqueue::ResourceWaitQueue;
 use crate::worker::task::{Task, TaskState};
+use crate::worker::taskenv::TaskEnv;
 use crate::TaskId;
 use crate::{PriorityTuple, WorkerId};
 
@@ -335,6 +337,17 @@ impl WorkerState {
         }
         self.start_task_scheduled = true;
         self.start_task_notify.notify_one();
+    }
+
+    pub fn start_task(
+        &mut self,
+        task_id: TaskId,
+        task_env: TaskEnv,
+        allocation: ResourceAllocation,
+    ) {
+        let mut task = self.get_task_mut(task_id);
+        task.state = TaskState::Running(task_env, allocation);
+        self.running_tasks.insert(task_id);
     }
 
     pub fn finish_task(&mut self, task_id: TaskId, size: u64) {

--- a/crates/tako/src/worker/state.rs
+++ b/crates/tako/src/worker/state.rs
@@ -44,7 +44,7 @@ pub struct WorkerState {
     pub random: SmallRng,
 
     pub configuration: WorkerConfiguration,
-    pub task_launcher: TaskLauncher,
+    pub task_launcher: Box<dyn TaskLauncher>,
     pub secret_key: Option<Arc<SecretKey>>,
 
     pub start_time: std::time::Instant,
@@ -368,7 +368,7 @@ impl WorkerStateRef {
         download_sender: tokio::sync::mpsc::UnboundedSender<(DataObjectRef, PriorityTuple)>,
         worker_addresses: Map<WorkerId, String>,
         resource_map: ResourceMap,
-        task_launcher: TaskLauncher,
+        task_launcher: Box<dyn TaskLauncher>,
     ) -> Self {
         let ready_task_queue = ResourceWaitQueue::new(&configuration.resources, &resource_map);
         Self::wrap(WorkerState {

--- a/crates/tako/src/worker/taskenv.rs
+++ b/crates/tako/src/worker/taskenv.rs
@@ -62,6 +62,7 @@ impl TaskEnv {
             state
                 .task_launcher
                 .start_task(state_ref.clone(), task_id, end_receiver)
+                .task_future
         };
 
         tokio::task::spawn_local(async move {

--- a/crates/tako/src/worker/taskenv.rs
+++ b/crates/tako/src/worker/taskenv.rs
@@ -1,10 +1,4 @@
-use futures::future::Either;
-use tokio::sync::oneshot;
 use tokio::sync::oneshot::Sender;
-
-use crate::messages::common::TaskFailInfo;
-use crate::worker::state::{WorkerState, WorkerStateRef};
-use crate::TaskId;
 
 pub enum TaskResult {
     Finished,
@@ -31,12 +25,13 @@ pub struct TaskEnv {
 }
 
 impl TaskEnv {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        TaskEnv { stop_sender: None }
+    pub fn new(stop_sender: Sender<StopReason>) -> Self {
+        Self {
+            stop_sender: Some(stop_sender),
+        }
     }
 
-    fn send_stop(&mut self, reason: StopReason) {
+    pub fn send_stop(&mut self, reason: StopReason) {
         if let Some(sender) = std::mem::take(&mut self.stop_sender) {
             assert!(sender.send(reason).is_ok());
         } else {
@@ -46,75 +41,5 @@ impl TaskEnv {
 
     pub fn cancel_task(&mut self) {
         self.send_stop(StopReason::Cancel);
-    }
-
-    pub fn start_task(
-        &mut self,
-        state: &mut WorkerState,
-        state_ref: WorkerStateRef,
-        task_id: TaskId,
-    ) {
-        let task_fut = {
-            assert_eq!(state.get_task(task_id).n_outputs, 0);
-            assert!(self.stop_sender.is_none());
-            let (end_sender, end_receiver) = oneshot::channel();
-            self.stop_sender = Some(end_sender);
-            state
-                .task_launcher
-                .start_task(state_ref.clone(), task_id, end_receiver)
-                .task_future
-        };
-
-        tokio::task::spawn_local(async move {
-            let time_limit = {
-                let state = state_ref.get();
-                if let Some(task) = state.find_task(task_id) {
-                    task.time_limit
-                } else {
-                    // Task were removed before spawn take place
-                    return;
-                }
-            };
-            let result = if let Some(duration) = time_limit {
-                let sleep = tokio::time::sleep(duration);
-                tokio::pin!(sleep);
-                match futures::future::select(task_fut, sleep).await {
-                    Either::Left((r, _)) => r,
-                    Either::Right((_, task_fut)) => {
-                        {
-                            let mut state = state_ref.get_mut();
-                            let task = state.get_task_mut(task_id);
-                            log::debug!("Task {} timeouted", task.id);
-                            task.task_env_mut().unwrap().send_stop(StopReason::Timeout)
-                        }
-                        task_fut.await
-                    }
-                }
-            } else {
-                task_fut.await
-            };
-            let mut state = state_ref.get_mut();
-            match result {
-                Ok(TaskResult::Finished) => {
-                    log::debug!("Inner task finished id={}", task_id);
-                    state.finish_task(task_id, 0);
-                }
-                Ok(TaskResult::Canceled) => {
-                    log::debug!("Inner task canceled id={}", task_id);
-                    state.finish_task_cancel(task_id);
-                }
-                Ok(TaskResult::Timeouted) => {
-                    log::debug!("Inner task timeouted id={}", task_id);
-                    state.finish_task_failed(
-                        task_id,
-                        TaskFailInfo::from_string("Time limit reached".to_string()),
-                    );
-                }
-                Err(e) => {
-                    log::debug!("Inner task failed id={}, error={:?}", task_id, e);
-                    state.finish_task_failed(task_id, TaskFailInfo::from_string(e.to_string()));
-                }
-            }
-        });
     }
 }

--- a/crates/tako/src/worker/taskenv.rs
+++ b/crates/tako/src/worker/taskenv.rs
@@ -59,7 +59,9 @@ impl TaskEnv {
             assert!(self.stop_sender.is_none());
             let (end_sender, end_receiver) = oneshot::channel();
             self.stop_sender = Some(end_sender);
-            (*state.task_launcher)(state_ref.clone(), task_id, end_receiver)
+            state
+                .task_launcher
+                .start_task(state_ref.clone(), task_id, end_receiver)
         };
 
         tokio::task::spawn_local(async move {

--- a/docs/cli/output-mode.md
+++ b/docs/cli/output-mode.md
@@ -199,7 +199,14 @@ Time-based items are formatted in the following way:
             "id": 0,
             "started_at": "2021-12-20T08:56:16.437123396Z",
             "state": "finished",
-            "worker": 1
+            "worker": 1,
+            "cwd": "/tmp/foo",
+            "stderr": {
+              "File": "job-1/0.stderr"
+            },
+            "stdout": {
+              "File": "job-1/0.stdout"
+            }
           }],
           "time_limit": null
         }

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -126,22 +126,19 @@ def test_job_array_error_all(hq_env: HqEnv):
     states = table.get_row_value("State").split("\n")
     assert "FAILED (10)" in states
 
-    offset = JOB_TABLE_ROWS + 1
-
-    for i in range(5):
-        assert table[offset + i][0] == str(i)
-        assert "No such file or directory" in table[offset + i][2]
-    table.print()
-    assert table[offset + 5] == []
+    errors = table[JOB_TABLE_ROWS:].get_column_value("Error")
+    for error in errors:
+        assert "No such file or directory" in error
 
     table = hq_env.command(["job", "1", "--tasks"], as_table=True)
     states = table.get_row_value("State").split("\n")
     assert "FAILED (10)" in states
 
+    task_table = table[JOB_TABLE_ROWS:]
     for i in range(10):
-        assert table[offset + i][0] == str(i)
-        assert table[offset + i][1] == "FAILED"
-        assert "No such file or directory" in table[offset + i][6]
+        assert task_table.get_column_value("Task Id")[i] == str(i)
+        assert task_table.get_column_value("State")[i] == "FAILED"
+        assert "No such file or directory" in task_table.get_column_value("Error")[i]
 
 
 def test_job_array_cancel(hq_env: HqEnv):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -154,7 +154,7 @@ def test_job_output_default(hq_env: HqEnv, tmp_path):
         assert f.read() == ""
 
 
-def test_cwd_recursive_placeholder(hq_env: HqEnv, tmp_path):
+def test_cwd_recursive_placeholder(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.command(
         ["submit", "--cwd", "%{CWD}/foo", "--", "bash", "-c", "echo 'hello'"],
@@ -219,6 +219,18 @@ def test_job_output_absolute_path(hq_env: HqEnv, tmp_path):
         assert f.read() == "hello\n"
     with open(os.path.join(tmp_path, "xyz")) as f:
         assert f.read() == ""
+
+
+def test_job_paths_prefilled_placeholders(hq_env: HqEnv):
+    """
+    Checks that job paths are partially resolved after submit.
+    """
+    hq_env.start_server()
+    hq_env.command(["submit", "hostname"])
+    wait_for_job_state(hq_env, 1, "WAITING")
+
+    table = hq_env.command(["job", "1"], as_table=True)
+    assert table.get_row_value("Stdout") == default_task_output(task_id="%{TASK_ID}")
 
 
 def test_job_output_none(hq_env: HqEnv, tmp_path):

--- a/tests/utils/table.py
+++ b/tests/utils/table.py
@@ -80,6 +80,9 @@ def parse_table(table_string: str) -> Table:
     result = []
     new_row = True
     for line in lines:
+        # Log output
+        if line.startswith("["):
+            continue
         if line.startswith("+-"):
             new_row = True
             continue


### PR DESCRIPTION
This PR refactors worker starting to enable attaching a task context to running tasks. This is then used to display resolved paths (cwd, stdout, stderr) of tasks in CLI/JSON output.

The last commit introduces gradual resolving (see commit message).
Best reviewed commit-by-commit.

Fixes: https://github.com/It4innovations/hyperqueue/issues/186