### PR TITLE
Remove most trace events

### DIFF
--- a/crates/tako/src/common/trace.rs
+++ b/crates/tako/src/common/trace.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::fmt::{Arguments, Write};
+use std::fmt::Arguments;
 use std::fs::File;
 use std::io::BufWriter;
 use std::sync::{Arc, Mutex};
@@ -7,10 +7,6 @@ use std::time::SystemTime;
 
 use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::FmtSubscriber;
-
-use crate::messages::common::WorkerConfiguration;
-use crate::TaskId;
-use crate::WorkerId;
 
 pub struct ScopedTimer<'a> {
     process: &'a str,
@@ -45,124 +41,6 @@ macro_rules! trace_time {
         let _timer = $crate::common::trace::ScopedTimer::new($process, $method);
         $block
     }};
-}
-
-#[inline(always)]
-pub fn trace_task_new(task_id: TaskId, inputs: impl Iterator<Item = u64>) {
-    let make_inputs = || {
-        let (_, bound) = inputs.size_hint();
-        let mut input_str = String::with_capacity(5 * bound.unwrap());
-        for input in inputs {
-            write!(input_str, "{},", input).ok();
-        }
-        input_str
-    };
-
-    tracing::info!(
-        action = "task",
-        event = "create",
-        task = task_id.as_num(),
-        inputs = make_inputs().as_str()
-    );
-}
-#[inline(always)]
-pub fn trace_task_new_finished(task_id: TaskId, size: u64, worker_id: WorkerId) {
-    tracing::info!(
-        action = "task",
-        event = "create",
-        task = task_id.as_num(),
-        worker = worker_id.as_num(),
-        size = size
-    );
-}
-#[inline(always)]
-pub fn trace_task_assign(task_id: TaskId, worker_id: WorkerId) {
-    tracing::info!(
-        action = "task",
-        event = "assign",
-        worker = worker_id.as_num(),
-        task = task_id.as_num()
-    );
-}
-#[inline(always)]
-pub fn trace_task_send(task_id: TaskId, worker_id: WorkerId) {
-    tracing::info!(
-        action = "task",
-        event = "send",
-        task = task_id.as_num(),
-        worker = worker_id.as_num(),
-    );
-}
-#[inline(always)]
-pub fn trace_task_place(task_id: TaskId, worker_id: WorkerId) {
-    tracing::info!(
-        action = "task",
-        event = "place",
-        task = task_id.as_num(),
-        worker = worker_id.as_num(),
-    );
-}
-#[inline(always)]
-pub fn trace_task_finish(task_id: TaskId, worker_id: WorkerId, size: u64, duration: (u64, u64)) {
-    tracing::info!(
-        action = "task",
-        event = "finish",
-        task = task_id.as_num(),
-        worker = worker_id.as_num(),
-        start = duration.0,
-        stop = duration.1,
-        size = size
-    );
-}
-#[inline(always)]
-pub fn trace_task_remove(task_id: TaskId) {
-    tracing::info!(action = "task", event = "remove", task = task_id.as_num(),);
-}
-#[inline(always)]
-pub fn trace_worker_new(worker_id: WorkerId, configuration: &WorkerConfiguration) {
-    tracing::info!(
-        action = "new-worker",
-        worker_id = worker_id.as_num(),
-        resources = format!("{:?}", &configuration.resources).as_str(),
-        address = configuration.listen_address.as_str(),
-    );
-}
-#[inline(always)]
-pub fn trace_worker_steal(task_id: TaskId, from: WorkerId, to: WorkerId) {
-    tracing::info!(
-        action = "steal",
-        task = task_id.as_num(),
-        from = from.as_num(),
-        to = to.as_num()
-    );
-}
-#[inline(always)]
-pub fn trace_worker_steal_response(task_id: TaskId, from: WorkerId, to: WorkerId, result: &str) {
-    tracing::info!(
-        action = "steal-response",
-        task = task_id.as_num(),
-        from = from.as_num(),
-        to = to.as_num(),
-        result = result
-    );
-}
-#[inline(always)]
-pub fn trace_worker_steal_response_missing(task_id: TaskId, from: WorkerId) {
-    tracing::info!(
-        action = "steal-response",
-        task = task_id.as_num(),
-        from = from.as_num(),
-        to = 0,
-        result = "missing"
-    );
-}
-#[inline(always)]
-pub fn trace_packet_send(size: usize) {
-    tracing::info!(action = "packet-send", size = size);
-}
-#[inline(always)]
-pub fn trace_packet_receive(size: usize) {
-    tracing::info!(action = "packet-receive", size = size);
 }
 
 struct FileGuard(Arc<Mutex<BufWriter<std::fs::File>>>);

--- a/crates/tako/src/scheduler/state.rs
+++ b/crates/tako/src/scheduler/state.rs
@@ -8,7 +8,6 @@ use rand::SeedableRng;
 use tokio::sync::Notify;
 use tokio::time::sleep;
 
-use crate::common::trace::trace_task_assign;
 use crate::common::Map;
 use crate::messages::worker::{TaskIdsMsg, ToWorkerMessage};
 use crate::server::comm::{Comm, CommSenderRef};
@@ -163,7 +162,6 @@ impl SchedulerState {
                     task.set_fresh_flag(false);
                 }
                 let task = tasks.get_task(task_id);
-                trace_task_assign(task.id, worker_id);
                 comm.send_worker_message(worker_id, &task.make_compute_message(tasks));
             }
         }

--- a/crates/tako/src/server/core.rs
+++ b/crates/tako/src/server/core.rs
@@ -6,7 +6,6 @@ use tokio::task::JoinHandle;
 
 use crate::common::resources::map::{ResourceIdAllocator, ResourceMap};
 use crate::common::resources::{GenericResourceId, ResourceRequest};
-use crate::common::trace::trace_task_remove;
 use crate::common::{Map, Set, WrappedRcRefCell};
 use crate::messages::gateway::ServerInfo;
 use crate::server::monitoring::EventStorage;
@@ -260,8 +259,6 @@ impl Core {
     /// it up.
     #[must_use]
     pub fn remove_task(&mut self, task_id: TaskId) -> TaskRuntimeState {
-        trace_task_remove(task_id);
-
         let task = self
             .tasks
             .remove(task_id)


### PR DESCRIPTION
The tracing infrastructure is a left-over from RSDS. I removed most of the methods, since they will be stored inside the event log instead. I still kept some of the infrastructure because it might be useful for logging profiling information in the future.

@vyomkeshj The removed trace events should be eventually moved into monitoring events.