### PR TITLE
Delete old directories of unsubmitted allocations in automatic allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # DEV
 
+## Fixes
+
+### Automatic allocation
+* [Issue #294](https://github.com/It4innovations/hyperqueue/issues/294): If the automatic allocator
+  fails to submit an allocation, it leaves behind a directory on the filesystem, which contains useful
+  debugging information. However, HyperQueue could create a lot these files and directories if
+  allocations were failing to be submitted repeatedly. To alleviate this, HyperQueue will now keep
+  only the last `16` directories of unsubmitted allocations. Older directories will be removed to
+  save space.
+
 ## New features
 
 ### Worker configuration

--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -228,16 +228,20 @@ async fn dry_run(opts: DryRunOpts) -> anyhow::Result<()> {
     let queue_info = create_queue_info(params);
 
     let allocation = handler
-        .schedule_allocation(0, &queue_info, worker_count as u64)
+        .submit_allocation(0, &queue_info, worker_count as u64)
         .await
         .map_err(|e| anyhow::anyhow!("Could not submit allocation: {:?}", e))?;
 
+    let working_dir = allocation.working_dir().to_path_buf();
+    let id = allocation
+        .into_id()
+        .map_err(|e| anyhow::anyhow!("Could not submit allocation: {:?}", e))?;
     let allocation = Allocation {
-        id: allocation.id().to_string(),
+        id: id.to_string(),
         worker_count: 1,
         queued_at: SystemTime::now(),
         status: AllocationStatus::Queued,
-        working_dir: allocation.working_dir().into(),
+        working_dir,
     };
     handler
         .remove_allocation(&allocation)

--- a/crates/hyperqueue/src/server/autoalloc/descriptor/pbs.rs
+++ b/crates/hyperqueue/src/server/autoalloc/descriptor/pbs.rs
@@ -12,7 +12,7 @@ use crate::server::autoalloc::descriptor::common::{
     build_worker_args, check_command_output, create_allocation_dir, create_command, submit_script,
     ExternalHandler,
 };
-use crate::server::autoalloc::descriptor::{CreatedAllocation, QueueHandler};
+use crate::server::autoalloc::descriptor::{AllocationSubmissionResult, QueueHandler};
 use crate::server::autoalloc::state::AllocationStatus;
 use crate::server::autoalloc::{Allocation, AutoAllocResult, DescriptorId, QueueInfo};
 
@@ -28,12 +28,12 @@ impl PbsHandler {
 }
 
 impl QueueHandler for PbsHandler {
-    fn schedule_allocation(
+    fn submit_allocation(
         &mut self,
         descriptor_id: DescriptorId,
         queue_info: &QueueInfo,
         worker_count: u64,
-    ) -> Pin<Box<dyn Future<Output = AutoAllocResult<CreatedAllocation>>>> {
+    ) -> Pin<Box<dyn Future<Output = AutoAllocResult<AllocationSubmissionResult>>>> {
         let queue_info = queue_info.clone();
         let timelimit = queue_info.timelimit;
         let hq_path = self.handler.hq_path.clone();
@@ -61,9 +61,9 @@ impl QueueHandler for PbsHandler {
                 &worker_args,
             );
             let job_id =
-                submit_script(script, "qsub", &directory, |output| Ok(output.to_string())).await?;
+                submit_script(script, "qsub", &directory, |output| Ok(output.to_string())).await;
 
-            Ok(CreatedAllocation {
+            Ok(AllocationSubmissionResult {
                 id: job_id,
                 working_dir: directory,
             })

--- a/crates/pyhq/python/pyhq/client.py
+++ b/crates/pyhq/python/pyhq/client.py
@@ -1,4 +1,4 @@
-from .ffi.ffi import TaskDescription, connect_to_server, JobDescription, submit_job
+from .ffi.ffi import JobDescription, TaskDescription, connect_to_server, submit_job
 from .job import Job
 
 
@@ -8,7 +8,7 @@ class Client:
 
     def submit(self, job: Job):
         configs = job.build()
-        job = JobDescription(tasks=[
-            TaskDescription(args=config.args) for config in configs
-        ])
+        job = JobDescription(
+            tasks=[TaskDescription(args=config.args) for config in configs]
+        )
         return submit_job(self.ctx, job)

--- a/crates/pyhq/python/pyhq/ffi/ffi.py
+++ b/crates/pyhq/python/pyhq/ffi/ffi.py
@@ -1,6 +1,5 @@
-from typing import List, Optional
-
 import dataclasses
+from typing import List, Optional
 
 from .. import pyhq as ffi
 

--- a/crates/pyhq/python/pyhq/task.py
+++ b/crates/pyhq/python/pyhq/task.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Union
 from .output import Output, gather_outputs
 from .validation import ValidationException, validate_args
 
-
 EnvType = Optional[Dict[str, str]]
 ProgramArgs = Union[List[str], str]
 

--- a/docs/deployment/allocation.md
+++ b/docs/deployment/allocation.md
@@ -174,6 +174,14 @@ server directory:
     hq-submit.sh
     ```
 
+    !!! tip
+
+        HyperQueue will store the `hq-submit.sh` file on disk even if the allocation fails to be queued.
+        You can use this file to debug the submission failure.
+
+        To avoid wasting disk space, HyperQueue will only keep a small number of most recent
+        directories of unqueued allocations, older ones will be deleted.
+
 ## Useful autoalloc commands
 Here is a list of useful commands to manage automatic allocation:
 

--- a/tests/pyapi/binding/test_server.py
+++ b/tests/pyapi/binding/test_server.py
@@ -1,5 +1,6 @@
-from ...conftest import HqEnv
 from pyhq.ffi.ffi import connect_to_server, stop_server
+
+from ...conftest import HqEnv
 
 
 def test_stop_server(hq_env: HqEnv):


### PR DESCRIPTION
If an allocation fails to be submitted, its working directory is put inside a queue. Once the queue is full, the overflowing directories will be removed (on a best-effort basis).