### PR TITLE
Add option to configure the number of kept directories in autoallocation queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,18 @@
 ## Fixes
 
 ### Automatic allocation
-* [Issue #294](https://github.com/It4innovations/hyperqueue/issues/294): If the automatic allocator
-  fails to submit an allocation, it leaves behind a directory on the filesystem, which contains useful
-  debugging information. However, HyperQueue could create a lot these files and directories if
-  allocations were failing to be submitted repeatedly. To alleviate this, HyperQueue will now keep
-  only the last `16` directories of unsubmitted allocations. Older directories will be removed to
-  save space.
+* [Issue #294](https://github.com/It4innovations/hyperqueue/issues/294): The automatic allocator
+  leaves behind directories of inactive (failed or finished) allocations on the filesystem. Although
+  these directories contain useful debugging information, creating too many of them can needlessly
+  waste disk space. To alleviate this, HyperQueue will now keep only the last `20` directories of
+  inactive allocations per each allocation queue and remove the older directories to save space.
+  
+  You can change this parameter by using the `--max-kept-directories` flag when creating an allocation
+  queue:
+
+  ```bash
+  $ hq alloc add pbs --time-limit 1h --max-kept-directories 100
+  ```
 
 ## New features
 

--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -101,6 +101,15 @@ pub struct SharedQueueOpts {
     #[clap(long, default_value = "finish-running", possible_values = &["stop", "finish-running"])]
     on_server_lost: ArgServerLostPolicy,
 
+    /// Maximum number of directories of inactive (finished, failed, unsubmitted) allocations
+    /// that should be stored on the disk. When the number of inactive directories surpasses this
+    /// value, the least recent directories will be removed.
+    ///
+    /// If you do not need to access the directories (e.g. to debug automatic allocation), you can
+    /// set this to a smaller number to save disk space.
+    #[clap(long, default_value = "20")]
+    max_kept_directories: usize,
+
     /// Additional arguments passed to the submit command
     #[clap()]
     additional_args: Vec<String>,
@@ -200,6 +209,7 @@ fn args_to_params(args: SharedQueueOpts) -> AllocationQueueParams {
         resource,
         additional_args,
         on_server_lost,
+        max_kept_directories,
     } = args;
 
     AllocationQueueParams {
@@ -212,6 +222,7 @@ fn args_to_params(args: SharedQueueOpts) -> AllocationQueueParams {
         worker_resources_args: resource.into_iter().map(|v| v.into()).collect(),
         max_worker_count,
         on_server_lost: on_server_lost.unpack(),
+        max_kept_directories,
     }
 }
 

--- a/crates/hyperqueue/src/server/autoalloc/descriptor/mod.rs
+++ b/crates/hyperqueue/src/server/autoalloc/descriptor/mod.rs
@@ -19,6 +19,7 @@ pub struct QueueDescriptor {
     info: QueueInfo,
     name: Option<String>,
     handler: Box<dyn QueueHandler>,
+    max_kept_directories: usize,
 }
 
 impl QueueDescriptor {
@@ -27,29 +28,39 @@ impl QueueDescriptor {
         info: QueueInfo,
         name: Option<String>,
         handler: Box<dyn QueueHandler>,
+        max_kept_directories: usize,
     ) -> Self {
         Self {
             manager,
             info,
             name,
             handler,
+            max_kept_directories,
         }
     }
 
     pub fn manager(&self) -> &ManagerType {
         &self.manager
     }
+
     pub fn info(&self) -> &QueueInfo {
         &self.info
     }
+
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
     }
+
     pub fn handler(&self) -> &dyn QueueHandler {
         self.handler.as_ref()
     }
+
     pub fn handler_mut(&mut self) -> &mut dyn QueueHandler {
         self.handler.as_mut()
+    }
+
+    pub fn max_kept_directories(&self) -> usize {
+        self.max_kept_directories
     }
 }
 

--- a/crates/hyperqueue/src/server/client/mod.rs
+++ b/crates/hyperqueue/src/server/client/mod.rs
@@ -338,6 +338,7 @@ pub fn create_queue_info(params: AllocationQueueParams) -> QueueInfo {
         worker_resources_args,
         max_worker_count,
         on_server_lost,
+        max_kept_directories: _,
     } = params;
     QueueInfo::new(
         backlog,
@@ -359,12 +360,14 @@ fn create_queue(
 ) -> ToClientMessage {
     let server_directory = server_dir.directory().to_path_buf();
     let name = params.name.clone();
+    let max_kept_directories = params.max_kept_directories;
     let handler = create_allocation_handler(&manager, name.clone(), server_directory);
     let queue_info = create_queue_info(params);
 
     match handler {
         Ok(handler) => {
-            let descriptor = QueueDescriptor::new(manager, queue_info, name, handler);
+            let descriptor =
+                QueueDescriptor::new(manager, queue_info, name, handler, max_kept_directories);
             let id = state_ref.get_mut().get_autoalloc_state_mut().create_id();
             state_ref
                 .get_mut()

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -151,6 +151,7 @@ pub struct AllocationQueueParams {
     pub worker_cpu_arg: Option<String>,
     pub worker_resources_args: Vec<String>,
     pub max_worker_count: Option<u32>,
+    pub max_kept_directories: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/docs/deployment/allocation.md
+++ b/docs/deployment/allocation.md
@@ -87,6 +87,10 @@ creating a new allocation queue:
     `hq worker start`).
 
 - `--name <name>` Name of the allocation queue. Will be used to name allocations. Serves for debug purposes only.
+- `--max-kept-directories <number>` Each allocation that finishes (either successfully or unsuccessfully)
+will leave a directory containing debugging information on the filesystem. To avoid wasting disk space,
+HyperQueue will by default keep only the most recent `N` directories and remove the older ones. You
+can change the number of kept directories with this parameter.
 
 [^1]: You can use various [shortcuts](../cli/shortcuts.md#duration) for the duration value.
 
@@ -173,14 +177,6 @@ server directory:
     job-id
     hq-submit.sh
     ```
-
-    !!! tip
-
-        HyperQueue will store the `hq-submit.sh` file on disk even if the allocation fails to be queued.
-        You can use this file to debug the submission failure.
-
-        To avoid wasting disk space, HyperQueue will only keep a small number of most recent
-        directories of unqueued allocations, older ones will be deleted.
 
 ## Useful autoalloc commands
 Here is a list of useful commands to manage automatic allocation:


### PR DESCRIPTION
The autoallocator will now also remove directories of finished/failed allocations.

Fixes: https://github.com/It4innovations/hyperqueue/issues/294