### PR TITLE
(De)serialize objects directly on Python/Rust boundary instead of using Serialize/Deserialize

### DIFF
--- a/crates/pyhq/python/hyperqueue/client.py
+++ b/crates/pyhq/python/hyperqueue/client.py
@@ -1,14 +1,14 @@
-from .ffi.ffi import JobDescription, TaskDescription, connect_to_server, submit_job
-from .job import Job
+from pathlib import Path
+from typing import Optional
+
+from .ffi.ffi import connect_to_server, submit_job
+from .job import Job, JobId
 
 
 class Client:
-    def __init__(self, *args, **kwargs):
-        self.ctx = connect_to_server()
+    def __init__(self, path: Optional[Path] = None):
+        path = str(path) if path else None
+        self.ctx = connect_to_server(path)
 
-    def submit(self, job: Job):
-        configs = job.build()
-        job = JobDescription(
-            tasks=[TaskDescription(args=config.args) for config in configs]
-        )
+    def submit(self, job: Job) -> JobId:
         return submit_job(self.ctx, job)

--- a/crates/pyhq/python/hyperqueue/ffi/ffi.py
+++ b/crates/pyhq/python/hyperqueue/ffi/ffi.py
@@ -1,7 +1,9 @@
-import dataclasses
-from typing import List, Optional
+from typing import Optional
 
 from .. import hyperqueue as ffi
+from ..job import Job, JobId
+from .protocol import JobDescription
+from .utils import task_config_to_task_desc
 
 
 class HqContext:
@@ -9,19 +11,6 @@ class HqContext:
     Opaque class returned from `connect_to_server`.
     Should be passed to FFI methods that require it.
     """
-
-
-@dataclasses.dataclass()
-class TaskDescription:
-    args: List[str]
-
-
-@dataclasses.dataclass
-class JobDescription:
-    tasks: List[TaskDescription]
-
-
-JobId = int
 
 
 def connect_to_server(directory: Optional[str] = None) -> HqContext:
@@ -32,6 +21,7 @@ def stop_server(ctx: HqContext):
     return ffi.stop_server(ctx)
 
 
-def submit_job(ctx: HqContext, job: JobDescription) -> JobId:
-    job = dataclasses.asdict(job)
+def submit_job(ctx: HqContext, job: Job) -> JobId:
+    configs = job.build()
+    job = JobDescription(tasks=[task_config_to_task_desc(config) for config in configs])
     return ffi.submit_job(ctx, job)

--- a/crates/pyhq/python/hyperqueue/ffi/protocol.py
+++ b/crates/pyhq/python/hyperqueue/ffi/protocol.py
@@ -1,0 +1,13 @@
+import dataclasses
+from typing import List, Optional
+
+
+@dataclasses.dataclass()
+class TaskDescription:
+    args: List[str]
+    cwd: Optional[str]
+
+
+@dataclasses.dataclass
+class JobDescription:
+    tasks: List[TaskDescription]

--- a/crates/pyhq/python/hyperqueue/ffi/utils.py
+++ b/crates/pyhq/python/hyperqueue/ffi/utils.py
@@ -1,0 +1,6 @@
+from ..task import TaskConfig
+from .protocol import TaskDescription
+
+
+def task_config_to_task_desc(config: TaskConfig) -> TaskDescription:
+    return TaskDescription(args=config.args, cwd=config.cwd)

--- a/crates/pyhq/python/hyperqueue/job.py
+++ b/crates/pyhq/python/hyperqueue/job.py
@@ -2,6 +2,8 @@ from typing import List, Optional
 
 from .task import EnvType, ExternalProgram, ProgramArgs, Task, TaskConfig, build_tasks
 
+JobId = int
+
 
 class Job:
     def __init__(self, *args, **kwargs):

--- a/crates/pyhq/src/job.rs
+++ b/crates/pyhq/src/job.rs
@@ -1,5 +1,3 @@
-use crate::utils::error::ToPyResult;
-use crate::{borrow_mut, run_future, ContextPtr};
 use hyperqueue::common::arraydef::IntArray;
 use hyperqueue::common::fsutils::get_current_dir;
 use hyperqueue::rpc_call;
@@ -9,15 +7,18 @@ use hyperqueue::transfer::messages::{
     TaskDescription as HqTaskDescription, ToClientMessage,
 };
 use pyo3::{PyResult, Python};
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
-pub(crate) struct TaskDescription {
+use crate::utils::error::ToPyResult;
+use crate::{borrow_mut, run_future, ContextPtr, FromPyObject};
+
+#[derive(Debug, FromPyObject)]
+pub struct TaskDescription {
     args: Vec<String>,
+    cwd: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub(crate) struct JobDescription {
+#[derive(Debug, FromPyObject)]
+pub struct JobDescription {
     tasks: Vec<TaskDescription>,
 }
 
@@ -38,7 +39,7 @@ pub(crate) fn submit_job_impl(
                     env: Default::default(),
                     stdout: Default::default(),
                     stderr: Default::default(),
-                    cwd: None,
+                    cwd: task.cwd.map(|p| p.into()),
                 },
                 resources: Default::default(),
                 pin: false,

--- a/crates/pyhq/src/lib.rs
+++ b/crates/pyhq/src/lib.rs
@@ -1,12 +1,11 @@
 use pyo3::types::PyModule;
-use pyo3::{pyclass, pyfunction, pymodule};
+use pyo3::{pyclass, pyfunction, pymodule, FromPyObject};
 use pyo3::{wrap_pyfunction, Py, PyResult, Python};
 use tokio::runtime::Builder;
 
-use crate::job::{submit_job_impl, JobDescription};
-use crate::marshal::FromPy;
 use hyperqueue::transfer::connection::ClientConnection;
 
+use crate::job::{submit_job_impl, JobDescription};
 use crate::server::{connect_to_server_impl, stop_server_impl};
 use crate::utils::run_future;
 
@@ -35,8 +34,8 @@ fn stop_server(py: Python, ctx: ContextPtr) -> PyResult<()> {
 }
 
 #[pyfunction]
-fn submit_job(py: Python, ctx: ContextPtr, job: FromPy<JobDescription>) -> PyResult<u32> {
-    submit_job_impl(py, ctx, job.extract())
+fn submit_job(py: Python, ctx: ContextPtr, job: JobDescription) -> PyResult<u32> {
+    submit_job_impl(py, ctx, job)
 }
 
 #[pymodule]

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -1,0 +1,17 @@
+from hyperqueue.client import Client
+from hyperqueue.job import Job
+
+from ..conftest import HqEnv
+from ..utils import wait_for_job_state
+
+
+def test_submit_simple(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.start_worker()
+    client = Client(hq_env.server_dir)
+
+    job = Job()
+    job.program(args=["hostname"])
+    job_id = client.submit(job)
+
+    wait_for_job_state(hq_env, job_id, "FINISHED")


### PR DESCRIPTION
Serialize/Deserialize couldn't handle `Duration` and probably also some other types. We will need to write out the FFI boundary structs by hand.