### PR TITLE
Disable `help` subcommand

### DIFF
--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -62,6 +62,7 @@ struct CommonOpts {
 // Root CLI options
 #[derive(Parser)]
 #[clap(author, about, version(option_env!("HQ_BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))))]
+#[clap(global_setting = clap::AppSettings::DisableHelpSubcommand)]
 struct Opts {
     #[clap(flatten)]
     common: CommonOpts,


### PR DESCRIPTION
It's redundant, since `-h` and `--help` exist, and it can produce confusing behaviour for subcommands that support trailing varargs.

Fixes: https://github.com/It4innovations/hyperqueue/issues/310