### PR TITLE
Change handling of trailing var args in `hq submit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,15 @@ find more information in the [documentation](https://it4innovations.github.io/hy
 * You can now generate shell completion using the `hq generate-completion <shell>` command.
 
 ## Changes
-
+### CLI
+* The command line parsing of `hq submit` has been changed slightly. All flags and arguments that appear
+  after the first positional argument will now be considered to belong to the executed program, not to
+  the submit command. This mimics the behaviour of e.g. `docker run`. For example:
+    ```bash
+    $ hq submit foo --array 1-4
+    # Before: submits a task array with 4 tasks that execute the program `foo`
+    # Now: submits a single task that executes `foo --array 1-4`
+    ```
 * The command line interface for jobs has been changed to be more consistent with the interface for
   workers. Commands that have been formerly standalone (like `hq jobs`, `hq resubmit`, `hq wait`) are
   not accessed through `hq job`. The only previous job-related command that remained to on the top level

--- a/tests/output/test_json.py
+++ b/tests/output/test_json.py
@@ -138,7 +138,7 @@ def test_print_job_detail(hq_env: HqEnv):
 
 def test_print_job_with_tasks(hq_env: HqEnv):
     hq_env.start_server()
-    hq_env.command(["submit", "echo", "tt", "--array=1-4"])
+    hq_env.command(["submit", "--array=1-4", "echo", "tt"])
     output = parse_json_output(
         hq_env, ["--output-mode=json", "job", "info", "1", "--tasks"]
     )
@@ -150,7 +150,7 @@ def test_print_job_with_tasks(hq_env: HqEnv):
 def test_print_task_placeholders(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.start_worker()
-    hq_env.command(["submit", "echo", "tt", "--array=1-4"])
+    hq_env.command(["submit", "--array=1-4", "echo", "tt"])
     wait_for_job_state(hq_env, 1, "FINISHED")
 
     output = parse_json_output(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -76,7 +76,7 @@ def test_job_submit_dir(hq_env: HqEnv):
 def test_custom_name(hq_env: HqEnv):
     hq_env.start_server()
 
-    hq_env.command(["submit", "sleep", "1", "--name=sleep_prog"])
+    hq_env.command(["submit", "--name=sleep_prog", "sleep", "1"])
     wait_for_job_state(hq_env, 1, "WAITING")
 
     table = hq_env.command(["job", "list"], as_table=True)
@@ -86,16 +86,16 @@ def test_custom_name(hq_env: HqEnv):
     )
 
     with pytest.raises(Exception):
-        hq_env.command(["submit", "sleep", "1", "--name=second_sleep \n"])
+        hq_env.command(["submit", "--name=second_sleep \n", "sleep", "1"])
     with pytest.raises(Exception):
-        hq_env.command(["submit", "sleep", "1", "--name=second_sleep \t"])
+        hq_env.command(["submit", "--name=second_sleep \t", "sleep", "1"])
     with pytest.raises(Exception):
         hq_env.command(
             [
                 "submit",
+                "--name=sleep_sleep_sleep_sleep_sleep_sleep_sleep_sleep",
                 "sleep",
                 "1",
-                "--name=sleep_sleep_sleep_sleep_sleep_sleep_sleep_sleep",
             ]
         )
 
@@ -785,7 +785,7 @@ def test_job_wait(hq_env: HqEnv):
 def test_job_submit_wait(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.start_worker()
-    r = hq_env.command(["submit", "sleep", "1", "--wait"])
+    r = hq_env.command(["submit", "--wait", "sleep", "1"])
     assert "1 job finished" in r
 
     table = hq_env.command(["job", "info", "1"], as_table=True)


### PR DESCRIPTION
Now all arguments and flags after the first positional argument in `hq submit` will be used for the executed command, not for HyperQueue itself.

Before:
```bash
./hq submit --server-dir /foo program           # --server-dir handled by HQ
./hq submit program --server-dir /foo           # --server-dir handled by HQ
./hq submit program foo --server-dir /foo    # --server-dir handled by HQ
./hq submit -- program --server-dir /foo      # --server-dir passed to command
```

Now:
```bash
./hq submit --server-dir /foo program           # --server-dir handled by HQ
./hq submit program --server-dir /foo           # --server-dir passed to command
./hq submit program foo --server-dir /foo    # --server-dir passed to command
./hq submit -- program --server-dir /foo      # --server-dir passed to command
```