### PR TITLE
Make CLI tables more dense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ find more information in the [documentation](https://it4innovations.github.io/hy
     | `hq progress`       | `hq job progress` |
     | `hq submit`         | `hq submit` or `hq job submit` |
 
+* Tables outputted by various informational commands (like `hq job info` or `hq worker list`)
+are now more densely packed and should thus better fit on terminal screens.
+
 # v0.7.0
 
 ## Fixes

--- a/tests/autoalloc/test_autoalloc_pbs.py
+++ b/tests/autoalloc/test_autoalloc_pbs.py
@@ -254,7 +254,7 @@ def test_pbs_cancel_active_jobs_on_server_stop(hq_env: HqEnv):
         def wait_until_fixpoint():
             jobs = hq_env.command(["alloc", "info", "1"], as_table=True)
             # 2 running + 2 queued
-            return len(jobs) == 5
+            return len(jobs) == 4
 
         wait_until(lambda: wait_until_fixpoint())
 
@@ -288,12 +288,12 @@ def test_pbs_cancel_queued_jobs_on_remove_descriptor(hq_env: HqEnv):
 
         def wait_until_fixpoint():
             jobs = hq_env.command(["alloc", "info", "1"], as_table=True)
-            return len(jobs) == 3
+            return len(jobs) == 2
 
         wait_until(lambda: wait_until_fixpoint())
 
         remove_queue(hq_env, 1)
-        wait_until(lambda: len(hq_env.command(["alloc", "list"], as_table=True)) == 1)
+        wait_until(lambda: len(hq_env.command(["alloc", "list"], as_table=True)) == 0)
 
         expected_job_ids = set(mock.job_id(index) for index in range(2))
         wait_until(lambda: expected_job_ids == set(mock.deleted_jobs()))
@@ -363,12 +363,12 @@ def test_pbs_cancel_active_jobs_on_forced_remove_descriptor(hq_env: HqEnv):
         def wait_until_fixpoint():
             jobs = hq_env.command(["alloc", "info", "1"], as_table=True)
             # 2 running + 2 queued
-            return len(jobs) == 5
+            return len(jobs) == 4
 
         wait_until(lambda: wait_until_fixpoint())
 
         remove_queue(hq_env, 1, force=True)
-        wait_until(lambda: len(hq_env.command(["alloc", "list"], as_table=True)) == 1)
+        wait_until(lambda: len(hq_env.command(["alloc", "list"], as_table=True)) == 0)
 
         expected_job_ids = set(mock.job_id(index) for index in range(4))
         wait_until(lambda: expected_job_ids == set(mock.deleted_jobs()))
@@ -417,7 +417,7 @@ def test_pbs_too_high_time_request(hq_env: HqEnv):
         time.sleep(1)
 
         table = hq_env.command(["alloc", "info", "1"], as_table=True)
-        assert len(table) == 1
+        assert len(table) == 0
 
 
 def test_pbs_pass_cpu_and_resources_to_worker(hq_env: HqEnv):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -30,5 +30,5 @@ def test_job_time_request2(hq_env: HqEnv):
 
     wait_for_job_state(hq_env, 1, "FINISHED")
     table = hq_env.command(["job", "list"], as_table=True)
-    assert table[1][2] == "FINISHED"
-    assert table[2][2] == "WAITING"
+    assert table.get_column_value("State")[0] == "FINISHED"
+    assert table.get_column_value("State")[1] == "WAITING"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,26 +1,75 @@
 from .utils import parse_table
 
 
-def test_table_parser():
+def test_parse_table_horizontal():
+    table = parse_table(
+        """+---------+--------------+
+| Id      | Name            |
++---------+--------------+
+| a | b |
+| c   | d |
+"""
+    )
+    assert table.header == ["Id", "Name"]
+    assert table.rows == [
+        ["a", "b"],
+        ["c", "d"],
+    ]
+
+
+def test_parse_table_horizontal_empty():
+    table = parse_table(
+        """+---------+--------------+
+| Id      | Name            |
++---------+--------------+
+"""
+    )
+    assert table.header == ["Id", "Name"]
+    assert table.rows == []
+
+
+def test_parse_table_vertical():
     table = parse_table(
         """+---------+--------------+
 | Id      | 1            |
+| Name | 2 |
+| Value   | c |
 +---------+--------------+
-|         | WAITING [2]  |
-+---------+--------------+
-| Tasks   | 10           |
-+---------+--------------+
-| Command | xxx          |
-|         | 1            |
-|         | 2            |
-+---------+--------------+
-| Stdout  | N/A          |
-+---------+--------------+"""
+"""
     )
+    assert table.header is None
     assert table.rows == [
         ["Id", "1"],
-        ["", "WAITING [2]"],
-        ["Tasks", "10"],
-        ["Command", "xxx\n1\n2"],
-        ["Stdout", "N/A"],
+        ["Name", "2"],
+        ["Value", "c"],
     ]
+
+
+def test_parse_table_multiline_value():
+    table = parse_table(
+        """+---------+--------------+
+| Id      | 1            |
+| Name | line1 |
+| | line2 |
+| | line3 |
+| Value   | c |
++---------+--------------+
+"""
+    )
+    assert table.header is None
+    assert table.rows == [
+        ["Id", "1"],
+        ["Name", "line1\nline2\nline3"],
+        ["Value", "c"],
+    ]
+
+
+def test_parse_table_empty():
+    table = parse_table(
+        """
+    +---------+--------------+
+    +---------+--------------+
+    """
+    )
+    assert table.header is None
+    assert table.rows == [[]]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -12,13 +12,13 @@ from .utils.table import Table
 def test_worker_list(hq_env: HqEnv):
     hq_env.start_server()
     table = list_all_workers(hq_env)
-    assert len(table) == 1
-    assert table[0][:2] == ["Id", "State"]
+    assert len(table) == 0
+    assert table.header[:2] == ["Id", "State"]
 
     hq_env.start_workers(2)
 
     table = list_all_workers(hq_env)
-    assert len(table) == 3
+    assert len(table) == 2
     table.check_columns_value(["Id", "State"], 0, ["1", "RUNNING"])
     table.check_columns_value(["Id", "State"], 1, ["2", "RUNNING"])
 
@@ -26,7 +26,7 @@ def test_worker_list(hq_env: HqEnv):
     wait_for_worker_state(hq_env, 2, "CONNECTION LOST")
 
     table = list_all_workers(hq_env)
-    assert len(table) == 3
+    assert len(table) == 2
     table.check_columns_value(["Id", "State"], 0, ["1", "RUNNING"])
     table.check_columns_value(["Id", "State"], 1, ["2", "CONNECTION LOST"])
 
@@ -34,7 +34,7 @@ def test_worker_list(hq_env: HqEnv):
     wait_for_worker_state(hq_env, 1, "CONNECTION LOST")
 
     table = list_all_workers(hq_env)
-    assert len(table) == 3
+    assert len(table) == 2
     table.check_columns_value(["Id", "State"], 0, ["1", "CONNECTION LOST"])
     table.check_columns_value(["Id", "State"], 1, ["2", "CONNECTION LOST"])
 
@@ -43,7 +43,7 @@ def test_worker_list(hq_env: HqEnv):
 
     table = list_all_workers(hq_env)
 
-    assert len(table) == 4
+    assert len(table) == 3
     table.check_columns_value(["Id", "State"], 0, ["1", "CONNECTION LOST"])
     table.check_columns_value(["Id", "State"], 1, ["2", "CONNECTION LOST"])
     table.check_columns_value(["Id", "State"], 2, ["3", "RUNNING"])
@@ -107,19 +107,19 @@ def test_worker_list_only_online(hq_env: HqEnv):
     wait_for_worker_state(hq_env, [1, 2], "RUNNING")
 
     table = list_all_workers(hq_env)
-    assert len(table) == 3
+    assert len(table) == 2
     table.check_columns_value(["Id", "State"], 0, ["1", "RUNNING"])
     table.check_columns_value(["Id", "State"], 1, ["2", "RUNNING"])
     hq_env.kill_worker(2)
 
     wait_for_worker_state(hq_env, 2, "CONNECTION LOST")
     table = list_all_workers(hq_env)
-    assert len(table) == 3
+    assert len(table) == 2
     table.check_columns_value(["Id", "State"], 0, ["1", "RUNNING"])
     table.check_columns_value(["Id", "State"], 1, ["2", "CONNECTION LOST"])
 
     table = hq_env.command(["worker", "list"], as_table=True)
-    assert len(table) == 2
+    assert len(table) == 1
     table.check_columns_value(["Id", "State"], 0, ["1", "RUNNING"])
 
 
@@ -133,7 +133,7 @@ def test_worker_list_resources(hq_env: HqEnv):
     wait_for_worker_state(hq_env, [1, 2, 3, 4], "RUNNING")
 
     table = list_all_workers(hq_env)
-    assert len(table) == 5
+    assert len(table) == 4
     table.check_columns_value(
         ["Id", "State", "Resources"], 0, ["1", "RUNNING", "1x10 cpus"]
     )

--- a/tests/utils/wait.py
+++ b/tests/utils/wait.py
@@ -44,7 +44,7 @@ def wait_for_state(
 
         table = env.command(commands, as_table=True)
         last_table = table
-        jobs = [row for row in table[1:] if row[0] in ids]
+        jobs = [row for row in table if row[0] in ids]
         return len(jobs) >= len(ids) and all(
             j[state_index].lower() in target_states for j in jobs
         )


### PR DESCRIPTION
Removes horizontal separators between table cells to make tables more dense.

Before (vertical table):
![image](https://user-images.githubusercontent.com/4539057/149640375-059a8b7b-167b-457d-a4d9-6582e19dad5a.png)

After (vertical table):
![image](https://user-images.githubusercontent.com/4539057/149640329-4437c05b-c14a-4900-9ce1-1f2b09af7dd3.png)

Before (horizontal table):
![image](https://user-images.githubusercontent.com/4539057/149640380-9e408d4d-c1fc-4a26-98f0-86a00aab29cd.png)

After (horizontal table):
![image](https://user-images.githubusercontent.com/4539057/149640339-e15efc7a-707b-4cc6-be85-cdaa5670c2c7.png)

Vertical and horizontal tables are now also handled separately, both in CLI output code and in tests. Autoalloc tables that were previously incorrectly vertical are now correctly horizontal.

Fixes: https://github.com/It4innovations/hyperqueue/issues/318