### PR TITLE
Placeholder refactoring

### DIFF
--- a/crates/hyperqueue/src/client/commands/submit/command.rs
+++ b/crates/hyperqueue/src/client/commands/submit/command.rs
@@ -364,7 +364,7 @@ pub async fn submit_computation(
 
     let stdout = create_stdio(stdout, &log, DEFAULT_STDOUT_PATH);
     let stderr = create_stdio(stderr, &log, DEFAULT_STDERR_PATH);
-    let cwd = Some(cwd.unwrap_or_else(|| PathBuf::from("%{SUBMIT_DIR}")));
+    let cwd = cwd.unwrap_or_else(|| PathBuf::from("%{SUBMIT_DIR}"));
     let priority = priority.unwrap_or(0);
     let time_limit = time_limit.map(|x| x.unpack());
 

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -143,12 +143,7 @@ impl CliOutput {
 
         rows.push(vec![
             "Working directory".cell().bold(true),
-            program
-                .cwd
-                .as_ref()
-                .map(|cwd| cwd.display().to_string())
-                .unwrap()
-                .cell(),
+            program.cwd.display().to_string().cell(),
         ]);
 
         rows.push(vec![

--- a/crates/hyperqueue/src/client/output/common.rs
+++ b/crates/hyperqueue/src/client/output/common.rs
@@ -1,0 +1,68 @@
+use crate::common::placeholders::{
+    fill_placeholders_in_paths, CompletePlaceholderCtx, ResolvablePaths,
+};
+use crate::server::job::JobTaskState;
+use crate::transfer::messages::{JobDescription, JobDetail, TaskDescription};
+use crate::JobTaskId;
+use std::path::PathBuf;
+use tako::common::Map;
+use tako::messages::common::StdioDef;
+
+pub struct ResolvedTaskPaths {
+    pub cwd: PathBuf,
+    pub stdout: StdioDef,
+    pub stderr: StdioDef,
+}
+
+pub type TaskToPathsMap = Map<JobTaskId, Option<ResolvedTaskPaths>>;
+
+/// Resolves task paths of the given job, as they would look like from the perspective of the worker.
+pub fn resolve_task_paths(job: &JobDetail) -> TaskToPathsMap {
+    let task_to_desc_map: Map<JobTaskId, &TaskDescription> = match &job.job_desc {
+        JobDescription::Array { .. } => Default::default(),
+        JobDescription::Graph { tasks } => tasks.iter().map(|t| (t.id, &t.task_desc)).collect(),
+    };
+    let get_task_desc = |id: JobTaskId| -> &TaskDescription {
+        match &job.job_desc {
+            JobDescription::Array { task_desc, .. } => task_desc,
+            JobDescription::Graph { .. } => task_to_desc_map[&id],
+        }
+    };
+
+    job.tasks
+        .iter()
+        .map(|task| {
+            let program = &get_task_desc(task.task_id).program;
+            let paths = match &task.state {
+                JobTaskState::Canceled {
+                    started_data: Some(started_data),
+                }
+                | JobTaskState::Running { started_data, .. }
+                | JobTaskState::Finished { started_data, .. }
+                | JobTaskState::Failed { started_data, .. } => {
+                    let ctx = CompletePlaceholderCtx {
+                        job_id: job.info.id,
+                        task_id: task.task_id,
+                        instance_id: started_data.context.instance_id,
+                        submit_dir: &job.submit_dir,
+                    };
+
+                    let mut resolved_paths = ResolvedTaskPaths {
+                        cwd: program.cwd.clone(),
+                        stdout: program.stdout.clone(),
+                        stderr: program.stderr.clone(),
+                    };
+                    let paths = ResolvablePaths {
+                        cwd: &mut resolved_paths.cwd,
+                        stdout: &mut resolved_paths.stdout,
+                        stderr: &mut resolved_paths.stderr,
+                    };
+                    fill_placeholders_in_paths(paths, ctx);
+                    Some(resolved_paths)
+                }
+                _ => None,
+            };
+            (task.task_id, paths)
+        })
+        .collect()
+}

--- a/crates/hyperqueue/src/client/output/mod.rs
+++ b/crates/hyperqueue/src/client/output/mod.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+mod common;
 pub mod json;
 pub mod outputs;
 pub mod quiet;

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -978,7 +978,7 @@ mod tests {
             env: Default::default(),
             stdout: Default::default(),
             stderr: Default::default(),
-            cwd: None,
+            cwd: Default::default(),
         };
         let resources = ResourceRequest {
             cpus: Default::default(),

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -470,7 +470,7 @@ mod tests {
                 env: Default::default(),
                 stdout: Default::default(),
                 stderr: Default::default(),
-                cwd: None,
+                cwd: Default::default(),
             },
             resources: ResourceRequest {
                 cpus: CpuRequest::Compact(cpu_count),

--- a/crates/hyperqueue/src/server/state.rs
+++ b/crates/hyperqueue/src/server/state.rs
@@ -253,7 +253,7 @@ mod tests {
             env: Default::default(),
             stdout: StdioDef::Null,
             stderr: StdioDef::Null,
-            cwd: None,
+            cwd: Default::default(),
         }
     }
 

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -110,7 +110,7 @@ impl TaskLauncher for HqTaskLauncher {
         };
 
         let context = RunningTaskContext {
-            cwd: program.cwd.clone().unwrap(),
+            cwd: program.cwd.clone(),
             stdout: program.stdout.clone(),
             stderr: program.stderr.clone(),
         };
@@ -241,7 +241,7 @@ fn map_spawn_error(error: std::io::Error, program: &ProgramDefinition) -> tako::
 
             let path = Path::new(OsStr::from_bytes(file.as_bytes()));
             if !path.is_absolute() && !path.starts_with(".") {
-                let possible_path = program.cwd.as_ref().unwrap().join(path);
+                let possible_path = program.cwd.join(path);
                 if possible_path.is_file() {
                     msg.write_fmt(format_args!(
                         "\nThe file {:?} exists, maybe you have meant `./{}` instead?",

--- a/crates/pyhq/src/job.rs
+++ b/crates/pyhq/src/job.rs
@@ -7,6 +7,7 @@ use hyperqueue::transfer::messages::{
 };
 use pyo3::{PyResult, Python};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use crate::utils::error::ToPyResult;
 use crate::{borrow_mut, run_future, ContextPtr, FromPyObject};
@@ -15,7 +16,7 @@ use crate::{borrow_mut, run_future, ContextPtr, FromPyObject};
 pub struct TaskDescription {
     id: u32,
     args: Vec<String>,
-    cwd: Option<String>,
+    cwd: Option<PathBuf>,
     env: HashMap<String, String>,
     dependencies: Vec<u32>,
 }
@@ -27,14 +28,15 @@ pub struct JobDescription {
 
 pub(crate) fn submit_job_impl(py: Python, ctx: ContextPtr, job: JobDescription) -> PyResult<u32> {
     run_future(async move {
-        let tasks = build_tasks(job.tasks);
+        let submit_dir = get_current_dir();
+        let tasks = build_tasks(job.tasks, &submit_dir);
         let job_desc = HqJobDescription::Graph { tasks };
 
         let message = FromClientMessage::Submit(SubmitRequest {
             job_desc,
             name: "".to_string(),
             max_fails: None,
-            submit_dir: get_current_dir(),
+            submit_dir,
             log: None,
         });
 
@@ -46,12 +48,16 @@ pub(crate) fn submit_job_impl(py: Python, ctx: ContextPtr, job: JobDescription) 
     })
 }
 
-fn build_tasks(tasks: Vec<TaskDescription>) -> Vec<TaskWithDependencies> {
+fn build_tasks(tasks: Vec<TaskDescription>, submit_dir: &Path) -> Vec<TaskWithDependencies> {
     tasks
         .into_iter()
         .map(|task| TaskWithDependencies {
             id: task.id.into(),
-            task_desc: build_task_desc(task.args, task.env, task.cwd),
+            task_desc: build_task_desc(
+                task.args,
+                task.env,
+                task.cwd.unwrap_or_else(|| submit_dir.to_path_buf()),
+            ),
             dependencies: task.dependencies.into_iter().map(|id| id.into()).collect(),
         })
         .collect()
@@ -60,7 +66,7 @@ fn build_tasks(tasks: Vec<TaskDescription>) -> Vec<TaskWithDependencies> {
 fn build_task_desc(
     args: Vec<String>,
     env: HashMap<String, String>,
-    cwd: Option<String>,
+    cwd: PathBuf,
 ) -> HqTaskDescription {
     HqTaskDescription {
         program: ProgramDefinition {
@@ -68,7 +74,7 @@ fn build_task_desc(
             env: env.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
             stdout: Default::default(),
             stderr: Default::default(),
-            cwd: cwd.map(|p| p.into()),
+            cwd,
         },
         resources: Default::default(),
         pin: false,

--- a/crates/tako/src/messages/common.rs
+++ b/crates/tako/src/messages/common.rs
@@ -72,7 +72,7 @@ pub struct ProgramDefinition {
     pub stderr: StdioDef,
 
     #[serde(default)]
-    pub cwd: Option<PathBuf>,
+    pub cwd: PathBuf,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/tako/src/tests/integration/utils/task.rs
+++ b/crates/tako/src/tests/integration/utils/task.rs
@@ -142,7 +142,7 @@ pub struct TaskConfig {
     #[builder(default)]
     stderr: StdioDef,
     #[builder(default)]
-    cwd: Option<PathBuf>,
+    cwd: PathBuf,
 }
 
 #[derive(Builder, Default, Clone)]

--- a/crates/tako/src/tests/integration/utils/task.rs
+++ b/crates/tako/src/tests/integration/utils/task.rs
@@ -141,7 +141,7 @@ pub struct TaskConfig {
     stdout: StdioDef,
     #[builder(default)]
     stderr: StdioDef,
-    #[builder(default)]
+    #[builder(default = "std::env::current_dir().unwrap()")]
     cwd: PathBuf,
 }
 


### PR DESCRIPTION
Placeholders are now resolved lazily on the client. One of the benefits is that instead of sending `(cwd, stdout, stderr)`, the worker now only send the instance ID to the server when a task starts.