### PR TITLE
Parse shebang when executing shell scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,21 @@
 
 ## New features
 
-
-### Job configurations
+### Job submission
    * ``#HQ`` directives - Job arguments can be defined inside a submitted script, e.g.
      ``#HQ --cpus=4``.
+
+   * HyperQueue will now attempt to parse shebang (like `#!/bin/bash`) if you provide a path to a
+     shell script (`.sh`) as the first command in `hq submit`. If the parsing is successful, HyperQueue
+     will use the parsed interpreter path to execute the shell script. In practice, this means that
+     you can now submit scripts beginning with a shebang like this:
+
+        ```bash
+        $ hq submit script.sh
+        ```
+
+        This previously failed, unless you provided an interpreter, or provided a path starting with
+        `.` or an absolute path to the script.
 
 
 ### Worker configuration

--- a/crates/hyperqueue/src/common/fsutils.rs
+++ b/crates/hyperqueue/src/common/fsutils.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsStr;
+use std::os::unix::prelude::OsStrExt;
 use std::path::{Path, PathBuf};
 
 pub fn absolute_path(path: PathBuf) -> PathBuf {
@@ -19,4 +21,17 @@ pub fn create_symlink(symlink_path: &Path, target: &Path) -> crate::Result<()> {
 
 pub fn get_current_dir() -> PathBuf {
     std::env::current_dir().expect("Cannot get current working directory")
+}
+
+/// Returns true if the path is relative and doesn't start with `.`.
+pub fn is_implicit_path(path: &Path) -> bool {
+    !path.is_absolute() && !path.starts_with(".")
+}
+
+pub fn bytes_to_path(path: &[u8]) -> &Path {
+    Path::new(OsStr::from_bytes(path))
+}
+
+pub fn path_has_extension(path: &Path, extension: &str) -> bool {
+    path.extension() == Some(OsStr::from_bytes(extension.as_bytes()))
 }

--- a/tests/autoalloc/test_autoalloc_pbs.py
+++ b/tests/autoalloc/test_autoalloc_pbs.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List
 
 from ..conftest import HqEnv
+from ..utils.io import check_file_contents
 from ..utils.wait import wait_until
 from .pbs_mock import JobState, NewJobFailed, NewJobId, PbsMock
 from .utils import (
@@ -184,10 +185,9 @@ print("1")
             wait_until(lambda: os.path.isfile(qsub_path))
             wait_until(lambda: os.path.isfile(qstat_path))
 
-            with open(qsub_path) as f:
-                assert f.read() == str(
-                    Path(hq_env.server_dir) / "001/autoalloc/1-foo/001"
-                )
+            check_file_contents(
+                qsub_path, Path(hq_env.server_dir) / "001/autoalloc/1-foo/001"
+            )
 
 
 def test_pbs_ignore_job_changes_after_finish(hq_env: HqEnv):

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from ..conftest import HqEnv
 from ..utils import wait_for_job_state
+from ..utils.io import check_file_contents
 from . import bash, prepare_job_client
 
 
@@ -38,5 +39,4 @@ def test_submit_env(hq_env: HqEnv):
     job_id = client.submit(job)
 
     wait_for_job_state(hq_env, job_id, "FINISHED")
-    with open("out.txt") as f:
-        assert f.read() == "BAR\n123\n"
+    check_file_contents("out.txt", "BAR\n123\n")

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -5,6 +5,7 @@ import time
 
 from .conftest import HqEnv
 from .utils import JOB_TABLE_ROWS, wait_for_job_state
+from .utils.io import check_file_contents
 from .utils.job import default_task_output
 
 
@@ -38,8 +39,7 @@ def test_job_array_submit(hq_env: HqEnv):
                 default_task_output(job_id=1, task_id=i, type="stderr"),
             )
         )
-        with open(stdout) as f:
-            assert f.read() == f"1-{i}\n"
+        check_file_contents(stdout, f"1-{i}\n")
 
 
 def test_job_array_report(hq_env: HqEnv):

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -4,6 +4,7 @@ import pytest
 
 from .conftest import HqEnv
 from .utils import wait_for_job_state
+from .utils.io import check_file_contents
 from .utils.job import default_task_output
 
 
@@ -27,9 +28,7 @@ def test_entries_no_newline(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FINISHED")
 
     for i, test in enumerate(["One\n", "Two\n", "Three\n", "Four\n"]):
-        with open(default_task_output(job_id=1, task_id=i)) as f:
-            line = f.read()
-        assert line == test
+        check_file_contents(default_task_output(job_id=1, task_id=i), test)
     assert not os.path.isfile(default_task_output(job_id=1, task_id=4))
 
     table = hq_env.command(["job", "info", "1"], as_table=True)
@@ -56,9 +55,7 @@ def test_entries_with_newline(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FINISHED")
 
     for i, test in enumerate(["One\n", "Two\n", "Three\n", "Four\n"]):
-        with open(default_task_output(job_id=1, task_id=i)) as f:
-            line = f.read()
-        assert line == test
+        check_file_contents(default_task_output(job_id=1, task_id=i), test)
     assert not os.path.isfile(default_task_output(task_id=4))
 
     table = hq_env.command(["job", "info", "1"], as_table=True)
@@ -85,9 +82,7 @@ def test_entries_from_json_entry(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FINISHED")
 
     for i, test in enumerate(["123\n", '{"x":[1,2,3]}\n', "2.5\n"]):
-        with open(default_task_output(job_id=1, task_id=i)) as f:
-            line = f.read()
-        assert line == test
+        check_file_contents(default_task_output(job_id=1, task_id=i), test)
     assert not os.path.isfile(default_task_output(task_id=3))
 
     table = hq_env.command(["job", "info", "1"], as_table=True)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -2,6 +2,7 @@ import time
 
 from .conftest import HqEnv
 from .utils import wait_for_job_state
+from .utils.io import check_file_contents
 
 
 def check_no_stream_connections(hq_env: HqEnv):
@@ -245,9 +246,7 @@ def test_stream_partial(hq_env: HqEnv):
     assert result[1] == "0: > stream closed"
 
     check_no_stream_connections(hq_env)
-
-    with open("task-1-0-0.out") as f:
-        assert f.read() == "Ok\n"
+    check_file_contents("task-1-0-0.out", "Ok\n")
 
 
 def test_stream_unfinished_small(hq_env: HqEnv):

--- a/tests/utils/io.py
+++ b/tests/utils/io.py
@@ -1,0 +1,3 @@
+def check_file_contents(path: str, content):
+    with open(path) as f:
+        assert f.read() == str(content)


### PR DESCRIPTION
And use the provided interpreter when executing the command.

Fixes: https://github.com/It4innovations/hyperqueue/issues/263