### PR TITLE
Make task table more narrow (dense) by putting times and paths into a single column

### DIFF
--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from ..conftest import HqEnv
 from ..utils import wait_for_job_state
 from ..utils.io import check_file_contents
+from ..utils.table import parse_multiline_cell
 from . import bash, prepare_job_client
 
 
@@ -27,7 +28,8 @@ def test_submit_cwd(hq_env: HqEnv):
     wait_for_job_state(hq_env, job_id, "FINISHED")
 
     table = hq_env.command(["job", "tasks", str(job_id)], as_table=True)
-    table.check_column_value("Working directory", 0, str(cwd))
+    cell = table.get_column_value("Paths")[0]
+    assert parse_multiline_cell(cell)["Workdir"] == str(cwd)
 
 
 def test_submit_env(hq_env: HqEnv):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -10,6 +10,7 @@ from .conftest import HqEnv
 from .utils import wait_for_job_state
 from .utils.io import check_file_contents
 from .utils.job import default_task_output
+from .utils.table import parse_multiline_cell
 
 
 def test_job_submit(hq_env: HqEnv):
@@ -291,7 +292,7 @@ def test_job_fail(hq_env: HqEnv):
     table.check_row_value("State", "FAILED")
 
     table = hq_env.command(["job", "tasks", "1"], as_table=True)
-    table.check_column_value("Task ID", 0, "0")
+    table.check_column_value("ID", 0, "0")
     assert "No such file or directory" in table.get_column_value("Error")[0]
 
 
@@ -738,7 +739,9 @@ def test_job_completion_time(hq_env: HqEnv):
     assert table.get_row_value("Makespan").startswith("1s")
 
     table = hq_env.command(["job", "tasks", "1"], as_table=True)
-    table.get_column_value("Time")[0].startswith("1s")
+    parse_multiline_cell(table.get_column_value("Times")[0])["Makespan"].startswith(
+        "1s"
+    )
 
 
 def test_job_timeout(hq_env: HqEnv):

--- a/tests/utils/table.py
+++ b/tests/utils/table.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 JOB_TABLE_ROWS = 16
 
@@ -116,3 +116,8 @@ def parse_table(table_string: str) -> Table:
                 if item:
                     rows[-1][i] += "\n" + item
     return Table(rows, header=header)
+
+
+def parse_multiline_cell(cell: str) -> Dict[str, str]:
+    lines = cell.splitlines(keepends=False)
+    return dict(line.split(": ") for line in lines)


### PR DESCRIPTION
This PR reduces the width of `hq job tasks` table. It also changes the format of printed times to be shorter.

Before:
![image](https://user-images.githubusercontent.com/4539057/150334581-c476d12d-3ef0-4987-be14-7ceef9839271.png)

After:
![image](https://user-images.githubusercontent.com/4539057/150334506-a035259d-acac-4658-a4b8-41b4cffffb8c.png)

We should also clip the errors somehow probably, because these can be arbitrarily long.

Fixes: https://github.com/It4innovations/hyperqueue/issues/327