### PR TITLE
Add basic event log streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +37,19 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "async-compression"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "atty"
@@ -252,6 +271,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -515,6 +543,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +758,7 @@ name = "hyperqueue"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "async-compression",
  "atty",
  "bincode",
  "bstr",
@@ -967,6 +1008,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
 
 [[package]]
 name = "mio"

--- a/crates/hyperqueue/Cargo.toml
+++ b/crates/hyperqueue/Cargo.toml
@@ -46,6 +46,7 @@ tui = { version = "0.16" }
 termion = "1.5"
 indicatif = "0.16.2"
 textwrap = "0.14"
+async-compression = { version = "0.3.8", features = ["tokio", "gzip"] }
 
 # Tako
 tako = { path = "../tako" }

--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -143,6 +143,10 @@ struct ServerStartOpts {
     /// The maximum number of events tako server will store in memory
     #[clap(long, default_value = "1000000")]
     event_store_size: usize,
+
+    /// Path to a log file where events will be stored.
+    #[clap(long, hide(true))]
+    event_log_file: Option<PathBuf>,
 }
 
 #[derive(Parser)]
@@ -292,7 +296,8 @@ async fn command_server_start(
         autoalloc_interval: opts.autoalloc_interval.map(|x| x.unpack()),
         client_port: opts.client_port,
         worker_port: opts.worker_port,
-        event_store_size: opts.event_store_size,
+        event_buffer_size: opts.event_store_size,
+        event_log_file: opts.event_log_file,
     };
 
     init_hq_server(gsettings, server_cfg).await

--- a/crates/hyperqueue/src/event/log/mod.rs
+++ b/crates/hyperqueue/src/event/log/mod.rs
@@ -1,0 +1,24 @@
+mod stream;
+mod write;
+
+pub use stream::{start_event_streaming, EventStreamSender};
+pub use write::EventLogWriter;
+
+use bstr::BString;
+use serde::{Deserialize, Serialize};
+
+const HQ_LOG_HEADER: &[u8] = b"hq-event-log";
+const HQ_LOG_VERSION: u32 = 0;
+
+fn canonical_header() -> LogFileHeader {
+    LogFileHeader {
+        header: HQ_LOG_HEADER.into(),
+        version: HQ_LOG_VERSION,
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+struct LogFileHeader {
+    header: BString,
+    version: u32,
+}

--- a/crates/hyperqueue/src/event/log/stream.rs
+++ b/crates/hyperqueue/src/event/log/stream.rs
@@ -1,0 +1,70 @@
+use crate::event::log::write::EventLogWriter;
+use crate::event::MonitoringEvent;
+use std::future::Future;
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+pub type EventStreamSender = mpsc::UnboundedSender<MonitoringEvent>;
+pub type EventStreamReceiver = mpsc::UnboundedReceiver<MonitoringEvent>;
+
+fn create_event_stream_queue() -> (EventStreamSender, EventStreamReceiver) {
+    mpsc::unbounded_channel()
+}
+
+/// Start event streaming into a log file.
+/// Streaming is running on another thread to reduce overhead and interference.
+///
+/// Returns a future that resolves once the event streaming thread finishes.
+/// The thread will finish if there is some I/O error or if the `receiver` is closed.
+pub fn start_event_streaming(
+    writer: EventLogWriter,
+) -> (EventStreamSender, impl Future<Output = ()>) {
+    let (tx, rx) = create_event_stream_queue();
+
+    let handle = std::thread::spawn(move || {
+        let process = streaming_process(writer, rx);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        if let Err(error) = runtime.block_on(process) {
+            log::error!("Event streaming has ended with an error: {error:?}");
+        } else {
+            log::debug!("Event streaming has finished successfully");
+        }
+    });
+    let end_fut = async move {
+        handle.join().expect("Event streaming thread has crashed");
+    };
+    (tx, end_fut)
+}
+
+const FLUSH_PERIOD: Duration = Duration::from_secs(30);
+
+async fn streaming_process(
+    mut writer: EventLogWriter,
+    mut receiver: EventStreamReceiver,
+) -> anyhow::Result<()> {
+    let mut flush_fut = tokio::time::interval(FLUSH_PERIOD);
+
+    loop {
+        tokio::select! {
+            _ = flush_fut.tick() => {
+                writer.flush().await?;
+            }
+            res = receiver.recv() => {
+                match res {
+                    Some(event) => {
+                        log::trace!("Event: {event:?}");
+                        writer.store(event).await?;
+                    }
+                    None => break
+                }
+            }
+        }
+    }
+    writer.finish().await?;
+    Ok(())
+}

--- a/crates/hyperqueue/src/event/log/write.rs
+++ b/crates/hyperqueue/src/event/log/write.rs
@@ -1,0 +1,65 @@
+use crate::event::log::canonical_header;
+use crate::event::MonitoringEvent;
+use async_compression::tokio::write::GzipEncoder;
+use async_compression::Level;
+use std::path::Path;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+
+/// Streams monitoring events into a file on disk.
+pub struct EventLogWriter {
+    file: GzipEncoder<File>,
+    buffer: Vec<u8>,
+}
+
+const BUF_MAX_SIZE: usize = 16 * 1024;
+
+impl EventLogWriter {
+    pub async fn create(path: &Path) -> anyhow::Result<Self> {
+        let mut file = File::create(path).await?;
+        let header = rmp_serde::encode::to_vec(&canonical_header())?;
+        file.write_all(&header).await?;
+        file.flush().await?;
+
+        let file = GzipEncoder::with_quality(file, Level::Fastest);
+
+        // Keep buffer capacity larger than max size to avoid reallocation if we overflow
+        // the buffer.
+        let buffer = Vec::with_capacity(BUF_MAX_SIZE * 2);
+        Ok(Self { file, buffer })
+    }
+
+    #[inline]
+    pub async fn store(&mut self, event: MonitoringEvent) -> anyhow::Result<()> {
+        rmp_serde::encode::write(&mut self.buffer, &event)?;
+        if self.is_buffer_full() {
+            self.write_buffer().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn flush(&mut self) -> anyhow::Result<()> {
+        if !self.buffer.is_empty() {
+            self.write_buffer().await?;
+        }
+        self.file.flush().await?;
+        Ok(())
+    }
+
+    pub async fn finish(mut self) -> anyhow::Result<()> {
+        self.flush().await?;
+        self.file.shutdown().await?;
+        Ok(())
+    }
+
+    async fn write_buffer(&mut self) -> tokio::io::Result<()> {
+        self.file.write_all(&self.buffer).await?;
+        self.buffer.clear();
+        Ok(())
+    }
+
+    #[inline]
+    fn is_buffer_full(&self) -> bool {
+        self.buffer.len() >= BUF_MAX_SIZE
+    }
+}

--- a/crates/hyperqueue/src/event/mod.rs
+++ b/crates/hyperqueue/src/event/mod.rs
@@ -1,4 +1,5 @@
 pub mod events;
+pub mod log;
 pub mod storage;
 
 use events::MonitoringEventPayload;

--- a/crates/hyperqueue/src/lib.rs
+++ b/crates/hyperqueue/src/lib.rs
@@ -20,7 +20,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 // ID types
 use tako::define_id_type;
 
-pub type WorkerId = tako::WorkerId;
+pub use tako::WorkerId;
 pub type TakoTaskId = tako::TaskId;
 pub type Priority = tako::Priority;
 


### PR DESCRIPTION
This PR implements event streaming into a log file. Streaming is implemented inside the HyperQueue server and is optional. 

The log file has a simple header and GZIP compression. I tried other compression algorithms, but the landscape is not very large if we want to avoid binding C libraries and have support for async writing. Actually it wouldn't have to be async currently, because the writing is offloaded to another thread to avoid interference with HQ/Tako, but it's easier to handle the flush timeout with `async`.

I have implemented the reading part, so the file can be read, I swear :)
I'll include it in a follow-up PR, along with documentation, tests and some actual functionality (probably export to JSON).

Serializing 100k HW events into a file: ~30ms compression, ~600 KiB file size, ~200ms decompression.

Closes: https://github.com/It4innovations/hyperqueue/issues/247