### PR TITLE
Event JSON export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@
     $ hq submit --stdin bash
     ```
 
+   * You can now store HyperQueue events into a log file and later export them to JSON for further
+     processing. You can find more information in the
+     [documentation](https://it4innovations.github.io/hyperqueue/stable/jobs/directives/). 
+
+     *Note that this functionality is quite low-level, and it's designed primarily for
+     tool builders that use HyperQueue programmatically, not regular users. It is also currently
+     unstable.*
 
 ### Worker configuration
   * You can now select what should happen when a worker loses its connection to the server using the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,7 @@ dependencies = [
  "derive_builder",
  "dirs",
  "env_logger",
+ "flate2",
  "futures",
  "gethostname",
  "hex",

--- a/crates/hyperqueue/Cargo.toml
+++ b/crates/hyperqueue/Cargo.toml
@@ -47,6 +47,7 @@ termion = "1.5"
 indicatif = "0.16.2"
 textwrap = "0.14"
 async-compression = { version = "0.3.8", features = ["tokio", "gzip"] }
+flate2 = { version = "1.0.22", features = ["default"] }
 
 # Tako
 tako = { path = "../tako" }

--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -8,6 +8,7 @@ use cli_table::ColorChoice;
 
 use clap::ArgSettings::HiddenShortHelp;
 use hyperqueue::client::commands::autoalloc::{command_autoalloc, AutoAllocOpts};
+use hyperqueue::client::commands::event::{command_event_log, EventLogOpts};
 use hyperqueue::client::commands::job::{
     cancel_job, output_job_cat, output_job_detail, output_job_list, output_job_tasks,
     JobCancelOpts, JobCatOpts, JobInfoOpts, JobListOpts, JobTasksOpts,
@@ -111,6 +112,8 @@ enum SubCommand {
     /// Automatic allocation management
     #[clap(name = "alloc")]
     AutoAlloc(AutoAllocOpts),
+    /// Event log management
+    EventLog(EventLogOpts),
     ///Commands for the dashboard
     Dashboard(DashboardOpts),
     /// Generate shell completion script
@@ -146,7 +149,7 @@ struct ServerStartOpts {
 
     /// Path to a log file where events will be stored.
     #[clap(long, hide(true))]
-    event_log_file: Option<PathBuf>,
+    event_log_path: Option<PathBuf>,
 }
 
 #[derive(Parser)]
@@ -297,7 +300,7 @@ async fn command_server_start(
         client_port: opts.client_port,
         worker_port: opts.worker_port,
         event_buffer_size: opts.event_store_size,
-        event_log_file: opts.event_log_file,
+        event_log_path: opts.event_log_path,
     };
 
     init_hq_server(gsettings, server_cfg).await
@@ -601,6 +604,7 @@ async fn main() -> hyperqueue::Result<()> {
         SubCommand::Dashboard(opts) => command_dashboard_start(&gsettings, opts).await,
         SubCommand::Log(opts) => command_log(&gsettings, opts),
         SubCommand::AutoAlloc(opts) => command_autoalloc(&gsettings, opts).await,
+        SubCommand::EventLog(opts) => command_event_log(opts),
         SubCommand::GenerateCompletion(opts) => generate_completion(opts),
     };
 

--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -42,13 +42,13 @@ enum AutoAllocCommand {
 }
 
 #[derive(Parser)]
-pub struct AddQueueOpts {
+struct AddQueueOpts {
     #[clap(subcommand)]
     subcmd: AddQueueCommand,
 }
 
 #[derive(Parser)]
-pub struct RemoveQueueOpts {
+struct RemoveQueueOpts {
     /// ID of the allocation queue that should be removed
     queue_id: DescriptorId,
 
@@ -59,7 +59,7 @@ pub struct RemoveQueueOpts {
 }
 
 #[derive(Parser)]
-pub enum AddQueueCommand {
+enum AddQueueCommand {
     /// Create a PBS allocation queue
     Pbs(SharedQueueOpts),
     /// Create a SLURM allocation queue
@@ -68,7 +68,7 @@ pub enum AddQueueCommand {
 
 #[derive(Parser)]
 #[clap(setting = clap::AppSettings::TrailingVarArg)]
-pub struct SharedQueueOpts {
+struct SharedQueueOpts {
     /// How many jobs should be waiting in the queue to be started
     #[clap(long, short, default_value = "4")]
     backlog: u32,
@@ -116,13 +116,13 @@ pub struct SharedQueueOpts {
 }
 
 #[derive(Parser)]
-pub struct DryRunOpts {
+struct DryRunOpts {
     #[clap(subcommand)]
     subcmd: DryRunCommand,
 }
 
 #[derive(Parser)]
-pub enum DryRunCommand {
+enum DryRunCommand {
     /// Try to create a PBS allocation
     Pbs(SharedQueueOpts),
     /// Try to create a SLURM allocation
@@ -130,13 +130,13 @@ pub enum DryRunCommand {
 }
 
 #[derive(Parser)]
-pub struct EventsOpts {
+struct EventsOpts {
     /// ID of the allocation queue
     queue: u32,
 }
 
 #[derive(Parser)]
-pub struct AllocationsOpts {
+struct AllocationsOpts {
     /// ID of the allocation queue
     queue: u32,
 

--- a/crates/hyperqueue/src/client/commands/event/mod.rs
+++ b/crates/hyperqueue/src/client/commands/event/mod.rs
@@ -1,0 +1,71 @@
+mod output;
+
+use crate::client::commands::event::output::format_event;
+use crate::common::strutils::pluralize;
+use crate::event::log::EventLogReader;
+use anyhow::anyhow;
+use clap::{Parser, ValueHint};
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+pub struct EventLogOpts {
+    /// Manage event log files.
+    #[clap(subcommand)]
+    command: EventCommand,
+}
+
+#[derive(Parser)]
+enum EventCommand {
+    /// Export events from a log file to NDJSON (line-delimited JSON).
+    /// Events will be exported to `stdout`, you can redirect it e.g. to a file.
+    Export(ExportOpts),
+}
+
+#[derive(Parser)]
+struct ExportOpts {
+    /// Path to a file containing the event log.
+    /// The file had to be created with `hq server start --event-log-path=<PATH>`.
+    #[clap(value_hint = ValueHint::FilePath)]
+    logfile: PathBuf,
+}
+
+pub fn command_event_log(opts: EventLogOpts) -> anyhow::Result<()> {
+    match opts.command {
+        EventCommand::Export(opts) => export_json(opts),
+    }
+}
+
+fn export_json(opts: ExportOpts) -> anyhow::Result<()> {
+    let file = EventLogReader::open(&opts.logfile).map_err(|error| {
+        anyhow!(
+            "Cannot open event log file at `{}`: {error:?}",
+            opts.logfile.display()
+        )
+    })?;
+
+    let stdout = std::io::stdout();
+    let stdout = stdout.lock();
+    let mut stdout = BufWriter::new(stdout);
+
+    let mut count = 0;
+    for event in file {
+        match event {
+            Ok(event) => {
+                writeln!(stdout, "{}", format_event(event))?;
+                count += 1;
+            }
+            Err(error) => {
+                log::error!(
+                    "Encountered an error while reading event log file: {error:?}.\n
+The file might have been incomplete."
+                )
+            }
+        }
+    }
+
+    log::info!("Outputted {count} {}", pluralize("event", count));
+
+    stdout.flush()?;
+    Ok(())
+}

--- a/crates/hyperqueue/src/client/commands/event/output.rs
+++ b/crates/hyperqueue/src/client/commands/event/output.rs
@@ -1,0 +1,32 @@
+use crate::client::output::json::format_datetime;
+use crate::event::events::MonitoringEventPayload;
+use crate::event::MonitoringEvent;
+use serde_json::json;
+use tako::messages::worker::WorkerOverview;
+
+pub fn format_event(event: MonitoringEvent) -> serde_json::Value {
+    json!({
+        "id": event.id,
+        "time": format_datetime(event.time),
+        "event": format_payload(event.payload)
+    })
+}
+
+fn format_payload(event: MonitoringEventPayload) -> serde_json::Value {
+    match event {
+        MonitoringEventPayload::WorkerConnected(id, ..) => json!({
+            "type": "worker-connected",
+            "id": id
+        }),
+        MonitoringEventPayload::WorkerLost(id, reason) => json!({
+            "type": "worker-lost",
+            "id": id,
+            "reason": reason
+        }),
+        MonitoringEventPayload::OverviewUpdate(WorkerOverview { id, hw_state, .. }) => json!({
+            "type": "worker-overview",
+            "id": id,
+            "hw_state": hw_state
+        }),
+    }
+}

--- a/crates/hyperqueue/src/client/commands/mod.rs
+++ b/crates/hyperqueue/src/client/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod autoalloc;
+pub mod event;
 pub mod job;
 pub mod log;
 pub mod stats;

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -472,6 +472,6 @@ fn format_duration(duration: Duration) -> serde_json::Value {
     let value = duration.as_secs() as f64 + duration.subsec_nanos() as f64 * 1e-9;
     json!(value)
 }
-fn format_datetime<T: Into<DateTime<Utc>>>(time: T) -> serde_json::Value {
+pub fn format_datetime<T: Into<DateTime<Utc>>>(time: T) -> serde_json::Value {
     json!(time.into())
 }

--- a/crates/hyperqueue/src/common/strutils.rs
+++ b/crates/hyperqueue/src/common/strutils.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 
-/// Return the input string with an added "s" at the end if `count` is larger than one.
+/// Return the input string with an added "s" at the end if `count` is larger than one and non-zero.
 pub fn pluralize(value: &str, count: usize) -> Cow<str> {
-    if count > 1 {
-        Cow::Owned(format!("{}s", value))
-    } else {
+    if count == 1 {
         Cow::Borrowed(value)
+    } else {
+        Cow::Owned(format!("{}s", value))
     }
 }

--- a/crates/hyperqueue/src/event/log/mod.rs
+++ b/crates/hyperqueue/src/event/log/mod.rs
@@ -1,6 +1,8 @@
+mod read;
 mod stream;
 mod write;
 
+pub use read::EventLogReader;
 pub use stream::{start_event_streaming, EventStreamSender};
 pub use write::EventLogWriter;
 

--- a/crates/hyperqueue/src/event/log/read.rs
+++ b/crates/hyperqueue/src/event/log/read.rs
@@ -1,0 +1,140 @@
+use crate::event::log::{canonical_header, LogFileHeader};
+use crate::event::MonitoringEvent;
+use anyhow::anyhow;
+use flate2::read::GzDecoder;
+use rmp_serde::decode::Error;
+use std::fs::File;
+use std::io::ErrorKind;
+use std::path::Path;
+
+/// Reads events from a file in a streaming fashion.
+pub struct EventLogReader {
+    source: GzDecoder<File>,
+}
+
+impl EventLogReader {
+    pub fn open(path: &Path) -> anyhow::Result<Self> {
+        let mut file = File::open(path)?;
+        let header: LogFileHeader = rmp_serde::from_read(&mut file)
+            .map_err(|error| anyhow!("Cannot load HQ event log file header: {error:?}"))?;
+
+        let expected_header = canonical_header();
+        if header != expected_header {
+            return Err(anyhow!(
+                "Invalid HQ event log file header.\nFound: {header:?}\nExpected: {expected_header:?}"
+            ));
+        }
+
+        let source = GzDecoder::new(file);
+        Ok(Self { source })
+    }
+}
+
+impl Iterator for EventLogReader {
+    type Item = Result<MonitoringEvent, rmp_serde::decode::Error>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match rmp_serde::from_read(&mut self.source) {
+            Ok(event) => Some(Ok(event)),
+            Err(Error::InvalidMarkerRead(error))
+                if matches!(error.kind(), ErrorKind::UnexpectedEof) =>
+            {
+                None
+            }
+            Err(error) => Some(Err(error)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::event::events::MonitoringEventPayload;
+    use crate::event::log::{
+        EventLogReader, EventLogWriter, LogFileHeader, HQ_LOG_HEADER, HQ_LOG_VERSION,
+    };
+    use crate::event::MonitoringEvent;
+    use std::fs::File;
+    use std::io::Write;
+    use std::time::SystemTime;
+    use tako::messages::gateway::LostWorkerReason;
+    use tempdir::TempDir;
+
+    #[test]
+    fn read_empty_file() {
+        let tmpdir = TempDir::new("hq").unwrap();
+        let path = tmpdir.path().join("foo");
+        File::create(&path).unwrap();
+
+        assert!(EventLogReader::open(&path).is_err());
+    }
+
+    #[test]
+    fn read_invalid_header_version() {
+        let tmpdir = TempDir::new("hq").unwrap();
+        let path = tmpdir.path().join("foo");
+        {
+            let mut file = File::create(&path).unwrap();
+            rmp_serde::encode::write(
+                &mut file,
+                &LogFileHeader {
+                    header: HQ_LOG_HEADER.into(),
+                    version: HQ_LOG_VERSION + 1,
+                },
+            )
+            .unwrap();
+            file.flush().unwrap();
+        }
+
+        assert!(EventLogReader::open(&path).is_err());
+    }
+
+    #[tokio::test]
+    async fn read_no_events() {
+        let tmpdir = TempDir::new("hq").unwrap();
+        let path = tmpdir.path().join("foo");
+        {
+            let writer = EventLogWriter::create(&path).await.unwrap();
+            writer.finish().await.unwrap();
+        }
+
+        let mut reader = EventLogReader::open(&path).unwrap();
+        assert!(reader.next().is_none());
+    }
+
+    #[tokio::test]
+    async fn roundtrip_exhaust_buffer() {
+        let tmpdir = TempDir::new("hq").unwrap();
+        let path = tmpdir.path().join("foo");
+
+        {
+            let mut writer = EventLogWriter::create(&path).await.unwrap();
+            for id in 0..100000 {
+                writer
+                    .store(MonitoringEvent {
+                        id,
+                        time: SystemTime::now(),
+                        payload: MonitoringEventPayload::WorkerLost(
+                            0.into(),
+                            LostWorkerReason::ConnectionLost,
+                        ),
+                    })
+                    .await
+                    .unwrap();
+            }
+            writer.finish().await.unwrap();
+        }
+
+        let mut reader = EventLogReader::open(&path).unwrap();
+        for id in 0..100000 {
+            let event = reader.next().unwrap().unwrap();
+            assert_eq!(event.id, id);
+            assert!(matches!(
+                event.payload,
+                MonitoringEventPayload::WorkerLost(id, LostWorkerReason::ConnectionLost)
+                if id.as_num() == 0
+            ));
+        }
+        assert!(reader.next().is_none());
+    }
+}

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,31 @@
+# Events
+HyperQueue internally records various events that describe what has happened during the lifetime of
+the HQ cluster (worker has connected, task was finished, an allocation was submitted to PBS, etc.).
+These events might be useful for some power-users, for example to analyze task execution statistics
+or allocation durations.
+
+To access these events, you have to start the HyperQueue [server](deployment/server.md) with the
+`--event-log-path` option:
+
+```bash
+$ hq server start --event-log-path=events.bin
+```
+
+If you use this flag, HQ will continuously stream its events into a log file at the provided path.
+The events are serialized using a compressed binary encoding. To access the event data from the log
+file, you first have to export them.
+
+## JSON export
+To export data from the log file to JSON, you can use the following command:
+
+```bash
+$ hq event-log export <event-log-path>
+```
+
+The events will be read from the provided log file and printed to `stdout` encoded in JSON, one
+event per line (this corresponds to line-delimited JSON, i.e. [NDJSON](http://ndjson.org/)).
+
+!!! warning
+
+    The JSON format of the events and their definition is currently unstable and can change
+    with a new HyperQueue version.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
   - CLI:
     - Shortcuts: cli/shortcuts.md
     - Output mode: cli/output-mode.md
+  - Events: events.md
   - FAQ: faq.md
   - Comparison With Other Tools: other-tools.md
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,7 @@ class HqEnv(Env):
         expect_fail=None,
         stdin=None,
         log=False,
+        ignore_stderr=False,
     ):
         if isinstance(args, str):
             args = [args]
@@ -230,14 +231,16 @@ class HqEnv(Env):
         args = [get_hq_binary(self.debug), "--server-dir", self.server_dir] + args
         cwd = cwd or self.work_path
         env = self.make_default_env(log=log)
+        stderr = subprocess.DEVNULL if ignore_stderr else subprocess.STDOUT
+
         if not wait:
-            return subprocess.Popen(args, stderr=subprocess.STDOUT, cwd=cwd, env=env)
+            return subprocess.Popen(args, stderr=stderr, cwd=cwd, env=env)
 
         else:
             process = subprocess.Popen(
                 args,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stderr=stderr,
                 cwd=cwd,
                 env=env,
                 stdin=subprocess.PIPE if stdin is not None else subprocess.DEVNULL,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,42 @@
+import json
+from typing import List
+
+from .conftest import HqEnv
+
+
+def test_worker_connected_event(hq_env: HqEnv):
+    def body():
+        hq_env.start_worker()
+
+    events = get_events(hq_env, body)
+    assert find_events(events, "worker-connected")[0]["id"] == 1
+
+
+def test_worker_lost_event(hq_env: HqEnv):
+    def body():
+        hq_env.start_worker()
+        hq_env.command(["worker", "stop", "1"])
+
+    events = get_events(hq_env, body)
+    event = find_events(events, "worker-lost")[0]
+    assert event["id"] == 1
+    assert event["reason"] == "Stopped"
+
+
+def find_events(events, type: str) -> List:
+    return [e["event"] for e in events if e["event"]["type"] == type]
+
+
+def get_events(hq_env: HqEnv, callback):
+    log_path = "events.log"
+    process = hq_env.start_server(args=["--event-log-path", log_path])
+    callback()
+    hq_env.command(["server", "stop"])
+    process.wait(timeout=5)
+    hq_env.processes.clear()
+
+    output = hq_env.command(["event-log", "export", log_path], ignore_stderr=True)
+    events = []
+    for line in output.splitlines(keepends=False):
+        events.append(json.loads(line))
+    return events


### PR DESCRIPTION
Adds a command that can export evens from a log file into line-delimited JSON (one event per line).