### PR TITLE
WIP: server state restoration from event log file

### DIFF
--- a/crates/hyperqueue/src/client/commands/server.rs
+++ b/crates/hyperqueue/src/client/commands/server.rs
@@ -55,6 +55,10 @@ struct ServerStartOpts {
     /// Path to a log file where events will be stored.
     #[clap(long, hide(true))]
     event_log_path: Option<PathBuf>,
+
+    /// Restore server state from the provided event log path
+    #[clap(long, hide(true))]
+    restore_from: Option<PathBuf>,
 }
 
 #[derive(Parser)]
@@ -86,6 +90,7 @@ async fn start_server(gsettings: &GlobalSettings, opts: ServerStartOpts) -> anyh
         worker_port: opts.worker_port,
         event_buffer_size: opts.event_store_size,
         event_log_path: opts.event_log_path,
+        restore_from: opts.restore_from,
     };
 
     init_hq_server(gsettings, server_cfg).await

--- a/crates/hyperqueue/src/server/mod.rs
+++ b/crates/hyperqueue/src/server/mod.rs
@@ -3,6 +3,7 @@ pub mod bootstrap;
 pub mod client;
 pub mod event;
 pub mod job;
+mod replay;
 pub mod rpc;
 pub mod state;
 pub mod worker;

--- a/crates/hyperqueue/src/server/replay.rs
+++ b/crates/hyperqueue/src/server/replay.rs
@@ -1,0 +1,38 @@
+use crate::server::event::events::MonitoringEventPayload;
+use crate::server::event::log::EventLogReader;
+use crate::server::event::MonitoringEvent;
+use std::path::Path;
+use tako::messages::gateway::LostWorkerReason;
+
+use crate::server::state::State;
+use crate::server::worker::Worker;
+
+pub async fn replay_server_state(state: &mut State, path: &Path) -> anyhow::Result<()> {
+    let events = EventLogReader::open(path)?;
+    for event in events {
+        let event = event?;
+        replay_event(state, event);
+    }
+
+    let connected_workers: Vec<_> = state
+        .get_workers()
+        .values()
+        .filter(|w| w.ended().is_none())
+        .map(|w| w.worker_id())
+        .collect();
+    for worker in connected_workers {
+        state.remove_worker(worker, LostWorkerReason::ConnectionLost);
+    }
+
+    Ok(())
+}
+
+fn replay_event(state: &mut State, event: MonitoringEvent) {
+    match event.payload {
+        MonitoringEventPayload::WorkerConnected(id, configuration) => {
+            state.add_worker(Worker::new(id, *configuration));
+        }
+        MonitoringEventPayload::WorkerLost(id, reason) => state.remove_worker(id, reason),
+        MonitoringEventPayload::OverviewUpdate(_) => {}
+    }
+}

--- a/crates/hyperqueue/src/server/worker.rs
+++ b/crates/hyperqueue/src/server/worker.rs
@@ -41,14 +41,18 @@ impl Worker {
         });
     }
 
+    pub fn ended(&self) -> Option<WorkerExitInfo> {
+        match &self.state {
+            WorkerState::Online => None,
+            Offline(d) => Some(d.clone()),
+        }
+    }
+
     pub fn make_info(&self) -> WorkerInfo {
         WorkerInfo {
             id: self.worker_id,
             configuration: self.configuration.clone(),
-            ended: match &self.state {
-                WorkerState::Online => None,
-                Offline(d) => Some(d.clone()),
-            },
+            ended: self.ended(),
         }
     }
 }


### PR DESCRIPTION
This is just a draft PR to show how server state could be restored from the event log file.

A manual approach is probably quite brittle, so it would be better if we could change the server logic so that it would do certain things (e.g. adding/removing workers/jobs) only in reaction to events. Then the logic could be same when performing the action and replaying the action from an event.