### PR TITLE
Change default behaviour of `hq job list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,11 @@ individual tasks of a job, please use the new `hq job tasks <job-id>` command.
     # Now: submits a single task that executes `foo --array 1-4`
     ```
 
+* `hq job list` will now only show queued and running jobs by default. You can use the `--all` flag
+  to display all jobs or the `--filter` flag to filter jobs that are in specified states.
+
+* The `--status` flag of `hq job resubmit` has been renamed to `--filter`.
+
 * Tables outputted by various informational commands (like `hq job info` or `hq worker list`)
 are now more densely packed and should thus better fit on terminal screens.
 
@@ -111,7 +116,7 @@ are now more densely packed and should thus better fit on terminal screens.
      tool builders that use HyperQueue programmatically, not regular users. It is also currently
      unstable.*
 
-* Release the preview version of HQ dashboard. It can be started via:
+* You can now try the preview version of HQ dashboard. It can be started via:
 
   ```bash
   $ hq dashboard

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ them to fully utilize allocated notes. You thus do not have to manually aggregat
 * Monitor the state of jobs
 
   ```bash
-  $ hq job list
+  $ hq job list --all
   ```
 
 ## What's next?

--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -251,7 +251,7 @@ async fn command_job_list(gsettings: &GlobalSettings, opts: JobListOpts) -> anyh
 async fn command_job_detail(gsettings: &GlobalSettings, opts: JobInfoOpts) -> anyhow::Result<()> {
     if matches!(opts.selector_arg, SelectorArg::All) {
         log::warn!(
-            "Job detail doesn't support the `all` selector, did you mean to use `hq job list`?"
+            "Job detail doesn't support the `all` selector, did you mean to use `hq job list --all`?"
         );
         return Ok(());
     }

--- a/crates/hyperqueue/src/client/commands/job.rs
+++ b/crates/hyperqueue/src/client/commands/job.rs
@@ -15,9 +15,18 @@ use clap::Parser;
 
 #[derive(Parser)]
 pub struct JobListOpts {
-    /// List only jobs with the given states.
+    /// Display all jobs.
+    #[clap(long, conflicts_with("filter"))]
+    pub all: bool,
+
+    /// Display only jobs with the given states.
     /// You can use multiple states separated by a comma.
-    #[clap(long, multiple_occurrences(false), use_delimiter(true))]
+    #[clap(
+        long,
+        multiple_occurrences(false),
+        use_delimiter(true),
+        possible_values = &["waiting", "running", "finished", "failed", "canceled"]
+    )]
     pub filter: Vec<Status>,
 }
 

--- a/crates/hyperqueue/src/client/commands/job.rs
+++ b/crates/hyperqueue/src/client/commands/job.rs
@@ -95,13 +95,16 @@ pub async fn output_job_list(
     let mut response =
         rpc_call!(connection, message, ToClientMessage::JobInfoResponse(r) => r).await?;
 
+    let total_count = response.jobs.len();
     if !job_filters.is_empty() {
         response
             .jobs
             .retain(|j| job_filters.contains(&job_status(j)));
     }
     response.jobs.sort_unstable_by_key(|j| j.id);
-    gsettings.printer().print_job_list(response.jobs);
+    gsettings
+        .printer()
+        .print_job_list(response.jobs, total_count);
     Ok(())
 }
 

--- a/crates/hyperqueue/src/client/commands/job.rs
+++ b/crates/hyperqueue/src/client/commands/job.rs
@@ -15,8 +15,10 @@ use clap::Parser;
 
 #[derive(Parser)]
 pub struct JobListOpts {
-    /// Only jobs with the passed statuses will be shown
-    pub job_filters: Vec<Status>,
+    /// List only jobs with the given states.
+    /// You can use multiple states separated by a comma.
+    #[clap(long, multiple_occurrences(false), use_delimiter(true))]
+    pub filter: Vec<Status>,
 }
 
 #[derive(Parser)]

--- a/crates/hyperqueue/src/client/commands/submit/command.rs
+++ b/crates/hyperqueue/src/client/commands/submit/command.rs
@@ -626,7 +626,12 @@ pub struct JobResubmitOpts {
 
     /// Resubmit only tasks with the given states.
     /// You can use multiple states separated by a comma.
-    #[clap(long, multiple_occurrences(false), use_delimiter(true))]
+    #[clap(
+        long,
+        multiple_occurrences(false),
+        use_delimiter(true),
+        possible_values = &["waiting", "running", "finished", "failed", "canceled"]
+    )]
     filter: Vec<Status>,
 }
 

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -32,7 +32,7 @@ use tako::common::resources::{CpuRequest, ResourceDescriptor};
 use tako::messages::common::StdioDef;
 
 use crate::client::output::common::{resolve_task_paths, TaskToPathsMap};
-use crate::common::strutils::pluralize;
+use crate::common::strutils::{pluralize, select_plural};
 use crate::worker::start::WORKER_EXTRA_PROCESS_PID;
 use anyhow::Error;
 use colored::Color as Colorization;
@@ -388,8 +388,9 @@ impl Output for CliOutput {
         );
     }
 
-    fn print_job_list(&self, tasks: Vec<JobInfo>) {
-        let rows: Vec<_> = tasks
+    fn print_job_list(&self, jobs: Vec<JobInfo>, total_jobs: usize) {
+        let job_count = jobs.len();
+        let rows: Vec<_> = jobs
             .into_iter()
             .map(|t| {
                 let status = task_status_to_cell(job_status(&t));
@@ -409,6 +410,14 @@ impl Output for CliOutput {
             "Tasks".cell().bold(true),
         ];
         self.print_horizontal_table(rows, header);
+
+        if job_count != total_jobs {
+            println!(
+                "There {} {total_jobs} {} in total. Use `--all` to display all jobs.",
+                select_plural("is", "are", total_jobs),
+                pluralize("job", total_jobs)
+            );
+        }
     }
 
     fn print_job_detail(&self, job: JobDetail, worker_map: WorkerMap) {

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -71,8 +71,8 @@ impl Output for JsonOutput {
         }))
     }
 
-    fn print_job_list(&self, tasks: Vec<JobInfo>) {
-        self.print(tasks.into_iter().map(format_job_info).collect());
+    fn print_job_list(&self, jobs: Vec<JobInfo>, _total_jobs: usize) {
+        self.print(jobs.into_iter().map(format_job_info).collect());
     }
     fn print_job_detail(&self, job: JobDetail, _worker_map: WorkerMap) {
         let task_paths = resolve_task_paths(&job);

--- a/crates/hyperqueue/src/client/output/outputs.rs
+++ b/crates/hyperqueue/src/client/output/outputs.rs
@@ -68,7 +68,7 @@ pub trait Output {
 
     // Jobs
     fn print_job_submitted(&self, job: JobDetail);
-    fn print_job_list(&self, tasks: Vec<JobInfo>);
+    fn print_job_list(&self, jobs: Vec<JobInfo>, total_jobs: usize);
     fn print_job_detail(&self, job: JobDetail, worker_map: WorkerMap);
     fn print_job_tasks(&self, job: JobDetail, worker_map: WorkerMap);
     fn print_job_wait(&self, duration: Duration, response: &WaitForJobsResponse);

--- a/crates/hyperqueue/src/client/output/quiet.rs
+++ b/crates/hyperqueue/src/client/output/quiet.rs
@@ -59,8 +59,8 @@ impl Output for Quiet {
     fn print_job_submitted(&self, job: JobDetail) {
         println!("{}", job.info.id)
     }
-    fn print_job_list(&self, tasks: Vec<JobInfo>) {
-        for task in tasks {
+    fn print_job_list(&self, jobs: Vec<JobInfo>, _total_jobs: usize) {
+        for task in jobs {
             let status = job_status(&task);
             println!("{} {}", task.id, format_status(&status))
         }

--- a/crates/hyperqueue/src/client/status.rs
+++ b/crates/hyperqueue/src/client/status.rs
@@ -1,15 +1,8 @@
 use std::str::FromStr;
 
-use nom::branch::alt;
-use nom::character::complete::space0;
-use nom::combinator::map;
-use nom::multi::separated_list1;
-use nom::sequence::tuple;
-use nom_supreme::tag::complete::tag;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::common::parser::{consume_all, NomResult};
 use crate::server::job::JobTaskState;
 use crate::transfer::messages::JobInfo;
 
@@ -25,32 +18,17 @@ pub enum Status {
 impl FromStr for Status {
     type Err = anyhow::Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        Ok(match input {
             "waiting" => Self::Waiting,
             "running" => Self::Running,
             "finished" => Self::Finished,
             "failed" => Self::Failed,
             "canceled" => Self::Canceled,
-            _ => anyhow::bail!("Invalid job status"),
+            _ => {
+                anyhow::bail!("Invalid job status, possible options: `waiting`, `running`, `finished`, `failed` or `canceled`.")
+            }
         })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct StatusList(Vec<Status>);
-
-impl StatusList {
-    pub fn to_vec(self) -> Vec<Status> {
-        self.0
-    }
-}
-
-impl FromStr for StatusList {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_status_list(s).map(StatusList)
     }
 }
 
@@ -82,45 +60,5 @@ pub fn task_status(status: &JobTaskState) -> Status {
         JobTaskState::Finished { .. } => Status::Finished,
         JobTaskState::Failed { .. } => Status::Failed,
         JobTaskState::Canceled { .. } => Status::Canceled,
-    }
-}
-
-fn p_status(input: &str) -> NomResult<Status> {
-    alt((
-        map(tag("waiting"), |_| Status::Waiting),
-        map(tag("running"), |_| Status::Running),
-        map(tag("finished"), |_| Status::Finished),
-        map(tag("failed"), |_| Status::Failed),
-        map(tag("canceled"), |_| Status::Canceled),
-    ))(input)
-}
-
-fn p_status_list(input: &str) -> NomResult<Vec<Status>> {
-    separated_list1(tuple((tag(","), space0)), p_status)(input)
-}
-
-pub fn parse_status_list(input: &str) -> anyhow::Result<Vec<Status>> {
-    consume_all(p_status_list, input)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    pub fn test_parse_status_list() {
-        assert_eq!(parse_status_list("waiting").unwrap(), vec![Status::Waiting]);
-        assert_eq!(
-            parse_status_list("canceled").unwrap(),
-            vec![Status::Canceled]
-        );
-        assert_eq!(
-            parse_status_list("running,failed,waiting").unwrap(),
-            vec![Status::Running, Status::Failed, Status::Waiting]
-        );
-        assert_eq!(
-            parse_status_list("running, failed, waiting").unwrap(),
-            vec![Status::Running, Status::Failed, Status::Waiting]
-        );
     }
 }

--- a/crates/hyperqueue/src/common/strutils.rs
+++ b/crates/hyperqueue/src/common/strutils.rs
@@ -8,3 +8,12 @@ pub fn pluralize(value: &str, count: usize) -> Cow<str> {
         Cow::Owned(format!("{}s", value))
     }
 }
+
+/// Select `single` variant if `count` is one or `other` variant otherwise.
+pub fn select_plural<'a>(single: &'a str, other: &'a str, count: usize) -> Cow<'a, str> {
+    if count == 1 {
+        Cow::Borrowed(single)
+    } else {
+        Cow::Borrowed(other)
+    }
+}

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -142,7 +142,7 @@ pub async fn handle_resubmit(
                 }
             }
 
-            let job_desc = if let Some(filter) = &message.status {
+            let job_desc = if !message.filter.is_empty() {
                 match &job.job_desc {
                     JobDescription::Array {
                         task_desc,
@@ -153,7 +153,7 @@ pub async fn handle_resubmit(
                             .tasks
                             .values()
                             .filter_map(|v| {
-                                if filter.contains(&task_status(&v.state)) {
+                                if message.filter.contains(&task_status(&v.state)) {
                                     Some(v.task_id.as_num())
                                 } else {
                                     None

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -101,7 +101,7 @@ pub enum Selector {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ResubmitRequest {
     pub job_id: JobId,
-    pub status: Option<Vec<Status>>,
+    pub filter: Vec<Status>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -295,25 +295,30 @@ If you want to parse #HQ directives from stdin, you can use ``--directives=stdin
 ## Useful job commands
 Here is a list of useful job commands:
 
-### Display all jobs
+### Display job table
 
-```bash
-$ hq job list
-```
+=== "List queued and running jobs"
+    ```bash
+    $ hq job list
+    ```
+=== "List all jobs"
+    ```bash
+    $ hq job list --all
+    ```
+=== "List jobs by status"
+    You can display only jobs having the selected [states](#job-state) by using the `--filter` flag:
 
-You can display only jobs having the selected [states](#job-state) by appending them to the command:
+    ```bash
+    $ hq job list --filter running,waiting
+    ```
 
-```bash
-$ hq job list running waiting
-```
+    Valid filter values are:
 
-Valid filter values are:
-
-- `waiting`
-- `running`
-- `finished`
-- `failed`
-- `canceled`
+    - `waiting`
+    - `running`
+    - `finished`
+    - `failed`
+    - `canceled`
 
 ### Display information about a specific job
 

--- a/tests/output/test_quiet.py
+++ b/tests/output/test_quiet.py
@@ -19,7 +19,7 @@ def test_print_job_list(hq_env: HqEnv):
 
     wait_for_job_state(hq_env, list(range(1, 10)), "FINISHED")
 
-    output = hq_env.command(["--output-mode=quiet", "job", "list"])
+    output = hq_env.command(["--output-mode=quiet", "job", "list", "--all"])
     output = output.splitlines(keepends=False)
     assert output == [f"{id + 1} FINISHED" for id in range(9)]
 

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -6,7 +6,7 @@ import time
 from .conftest import HqEnv
 from .utils import JOB_TABLE_ROWS, wait_for_job_state
 from .utils.io import check_file_contents
-from .utils.job import default_task_output
+from .utils.job import default_task_output, list_jobs
 from .utils.table import parse_multiline_cell
 
 
@@ -48,7 +48,7 @@ def test_job_array_report(hq_env: HqEnv):
     hq_env.start_worker(cpus=4)
     hq_env.command(["submit", "--array=10-19", "--", "sleep", "1"])
     time.sleep(1.6)
-    table = hq_env.command(["job", "list"], as_table=True)
+    table = list_jobs(hq_env)
     table.check_column_value("State", 0, "RUNNING")
 
     table = hq_env.command(["job", "info", "1"], as_table=True)
@@ -81,7 +81,7 @@ def test_job_array_error_some(hq_env: HqEnv):
 
     wait_for_job_state(hq_env, 1, "FAILED")
 
-    table = hq_env.command(["job", "list"], as_table=True)
+    table = list_jobs(hq_env)
     table.check_column_value("State", 0, "FAILED")
 
     table = hq_env.command(["job", "info", "1"], as_table=True)
@@ -134,7 +134,7 @@ def test_job_array_error_all(hq_env: HqEnv):
 
     wait_for_job_state(hq_env, 1, "FAILED")
 
-    table = hq_env.command(["job", "list"], as_table=True)
+    table = list_jobs(hq_env)
     table.check_column_value("State", 0, "FAILED")
 
     table = hq_env.command(["job", "info", "1"], as_table=True)
@@ -175,7 +175,7 @@ def test_job_array_cancel(hq_env: HqEnv):
     assert c.get("FINISHED") == 4
     assert c.get("CANCELED") == 6
 
-    table = hq_env.command(["job", "list"], as_table=True)
+    table = list_jobs(hq_env)
     table.check_column_value("State", 0, "CANCELED")
 
 
@@ -214,7 +214,7 @@ def test_array_mix_with_simple_jobs(hq_env: HqEnv):
 
     wait_for_job_state(hq_env, list(range(1, 101)), "FINISHED")
 
-    table = hq_env.command(["job", "list"], as_table=True)
+    table = list_jobs(hq_env)
     for i in range(100):
         assert table.get_column_value("ID")[i] == str(i + 1)
         assert table.get_column_value("State")[i] == "FINISHED"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -254,10 +254,14 @@ def test_job_filters(hq_env: HqEnv):
     table.check_column_value("State", 2, "WAITING")
     assert len(table) == 3
 
-    table_canceled = hq_env.command(["job", "list", "canceled"], as_table=True)
+    table_canceled = hq_env.command(
+        ["job", "list", "--filter", "canceled"], as_table=True
+    )
     assert len(table_canceled) == 1
 
-    table_waiting = hq_env.command(["job", "list", "waiting"], as_table=True)
+    table_waiting = hq_env.command(
+        ["job", "list", "--filter", "waiting"], as_table=True
+    )
     assert len(table_waiting) == 2
 
     hq_env.start_worker(cpus=1)
@@ -265,14 +269,23 @@ def test_job_filters(hq_env: HqEnv):
 
     wait_for_job_state(hq_env, 4, "RUNNING")
 
-    table_running = hq_env.command(["job", "list", "running"], as_table=True)
+    table_running = hq_env.command(
+        ["job", "list", "--filter", "running"], as_table=True
+    )
     assert len(table_running) == 1
 
-    table_finished = hq_env.command(["job", "list", "finished"], as_table=True)
+    table_finished = hq_env.command(
+        ["job", "list", "--filter", "finished"], as_table=True
+    )
     assert len(table_finished) == 1
 
-    table_failed = hq_env.command(["job", "list", "failed"], as_table=True)
+    table_failed = hq_env.command(["job", "list", "--filter", "failed"], as_table=True)
     assert len(table_failed) == 1
+
+    table_failed = hq_env.command(
+        ["job", "list", "--filter", "failed,finished"], as_table=True
+    )
+    assert len(table_failed) == 2
 
 
 def test_job_fail(hq_env: HqEnv):
@@ -577,10 +590,10 @@ def test_job_resubmit_with_status(hq_env: HqEnv):
     hq_env.start_workers(2, cpus=1)
     wait_for_job_state(hq_env, 1, "FAILED")
 
-    table = hq_env.command(["job", "resubmit", "1", "--status=failed"], as_table=True)
+    table = hq_env.command(["job", "resubmit", "1", "--filter=failed"], as_table=True)
     table.check_row_value("Tasks", "4; Ids: 4-6, 8")
 
-    table = hq_env.command(["job", "resubmit", "1", "--status=finished"], as_table=True)
+    table = hq_env.command(["job", "resubmit", "1", "--filter=finished"], as_table=True)
     table.check_row_value("Tasks", "3; Ids: 3, 7, 9")
 
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -288,6 +288,22 @@ def test_job_filters(hq_env: HqEnv):
     assert len(table_failed) == 2
 
 
+def test_job_list_hidden_jobs(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.start_worker()
+    hq_env.command(["submit", "hostname"])
+    wait_for_job_state(hq_env, 1, "FINISHED")
+
+    output = hq_env.command(["job", "list"])
+    assert "There is 1 job in total." in output
+
+    hq_env.command(["submit", "hostname"])
+    wait_for_job_state(hq_env, 2, "FINISHED")
+
+    output = hq_env.command(["job", "list"])
+    assert "There are 2 jobs in total." in output
+
+
 def test_job_fail(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.start_worker(cpus=1)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -2,10 +2,11 @@ import time
 
 from .conftest import HqEnv
 from .utils import wait_for_job_state
+from .utils.job import list_jobs
 
 
 def test_job_time_request1(hq_env: HqEnv):
-    # Tests that tasks are send only to worker3 and worker 4 (because of time requests)
+    # Tests that tasks are sent only to worker3 and worker 4 (because of time requests)
     hq_env.start_server()
     hq_env.start_worker(args=["--time-limit", "2s"])
     hq_env.start_worker(args=["--time-limit", "4s"])
@@ -29,6 +30,6 @@ def test_job_time_request2(hq_env: HqEnv):
     # hq_env.start_worker(args=["--time-limit", "5s"])
 
     wait_for_job_state(hq_env, 1, "FINISHED")
-    table = hq_env.command(["job", "list"], as_table=True)
+    table = list_jobs(hq_env)
     assert table.get_column_value("State")[0] == "FINISHED"
     assert table.get_column_value("State")[1] == "WAITING"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ def test_parse_table_horizontal():
 +---------+--------------+
 | a | b |
 | c   | d |
++---------+--------------+
 """
     )
     assert table.header == ["Id", "Name"]
@@ -67,9 +68,24 @@ def test_parse_table_multiline_value():
 def test_parse_table_empty():
     table = parse_table(
         """
-    +---------+--------------+
-    +---------+--------------+
++---------+--------------+
++---------+--------------+
     """
     )
     assert table.header is None
-    assert table.rows == [[]]
+    assert table.rows == []
+
+
+def test_parse_table_ignore_suffix():
+    table = parse_table(
+        """
++---------+--------------+
+|a|b|
++---------+--------------+
+|c|d|
++---------+--------------+
+hello world
+    """
+    )
+    assert table.header == ["a", "b"]
+    assert table.rows == [["c", "d"]]

--- a/tests/utils/job.py
+++ b/tests/utils/job.py
@@ -1,5 +1,8 @@
 import os
-from typing import Optional
+from typing import List, Optional
+
+from ..conftest import HqEnv
+from .table import Table
 
 
 def default_task_output(
@@ -7,3 +10,14 @@ def default_task_output(
 ) -> str:
     submit_dir = submit_dir if submit_dir else os.getcwd()
     return f"{submit_dir}/job-{job_id}/{task_id}.{type}"
+
+
+def list_jobs(hq_env: HqEnv, all=True, filters: List[str] = None) -> Table:
+    args = ["job", "list"]
+    if all:
+        assert filters is None
+        args.append("--all")
+    elif filters:
+        args.extend(["--filter", ",".join(filters)])
+
+    return hq_env.command(args, as_table=True)

--- a/tests/utils/wait.py
+++ b/tests/utils/wait.py
@@ -60,7 +60,7 @@ def wait_for_state(
 def wait_for_job_state(
     env, ids: Union[int, List[int]], target_states: Union[str, List[str]], **kwargs
 ):
-    wait_for_state(env, ids, target_states, ["job", "list"], 2, **kwargs)
+    wait_for_state(env, ids, target_states, ["job", "list", "--all"], 2, **kwargs)
 
 
 def wait_for_worker_state(


### PR DESCRIPTION
Now only queued and running jobs are shown by default in `hq job list`.

Fixes: https://github.com/It4innovations/hyperqueue/issues/245