### PR TITLE
Replace manual enum parsers with `clap::ArgEnum`

### DIFF
--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -1,6 +1,5 @@
 use std::io;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use clap::{IntoApp, Parser, ValueHint};
 use clap_complete::{generate, Shell};
@@ -57,7 +56,7 @@ struct CommonOpts {
     server_dir: Option<PathBuf>,
 
     /// Console color policy.
-    #[clap(long, default_value = "auto", possible_values = &["auto", "always", "never"])]
+    #[clap(long, default_value = "auto", arg_enum)]
     #[clap(
         global = true,
         help_heading("GLOBAL OPTIONS"),
@@ -66,7 +65,7 @@ struct CommonOpts {
     colors: ColorPolicy,
 
     /// How should the output of the command be formatted.
-    #[clap(long, env = "HQ_OUTPUT_MODE", default_value = "cli", possible_values = &["cli", "json", "quiet"])]
+    #[clap(long, env = "HQ_OUTPUT_MODE", default_value = "cli", arg_enum)]
     #[clap(
         global = true,
         help_heading("GLOBAL OPTIONS"),
@@ -157,7 +156,7 @@ struct WorkerListOpts {
     all: bool,
 
     /// Select only workers with the given state.
-    #[clap(long, possible_values(&["running", "offline"]))]
+    #[clap(long, arg_enum)]
     filter: Option<WorkerFilter>,
 }
 
@@ -407,23 +406,11 @@ async fn command_dashboard_start(
     Ok(())
 }
 
+#[derive(clap::ArgEnum, Clone)]
 pub enum ColorPolicy {
     Auto,
     Always,
     Never,
-}
-
-impl FromStr for ColorPolicy {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "auto" => Self::Auto,
-            "always" => Self::Always,
-            "never" => Self::Never,
-            _ => anyhow::bail!("Invalid color policy"),
-        })
-    }
 }
 
 fn make_global_settings(opts: CommonOpts) -> GlobalSettings {

--- a/crates/hyperqueue/src/client/commands/job.rs
+++ b/crates/hyperqueue/src/client/commands/job.rs
@@ -24,12 +24,7 @@ pub struct JobListOpts {
 
     /// Display only jobs with the given states.
     /// You can use multiple states separated by a comma.
-    #[clap(
-        long,
-        multiple_occurrences(false),
-        use_delimiter(true),
-        possible_values = &["waiting", "running", "finished", "failed", "canceled"]
-    )]
+    #[clap(long, multiple_occurrences(false), use_delimiter(true), arg_enum)]
     pub filter: Vec<Status>,
 }
 
@@ -62,12 +57,7 @@ pub struct JobCatOpts {
 
     /// Display only task(s) with the given states.
     /// You can use multiple states separated by a comma.
-    #[clap(
-        long,
-        multiple_occurrences(false),
-        use_delimiter(true),
-        possible_values = &["waiting", "running", "finished", "failed", "canceled"]
-    )]
+    #[clap(long, multiple_occurrences(false), use_delimiter(true), arg_enum)]
     pub task_status: Vec<Status>,
 
     /// Prepend the output of each task with a header line that identifies the task
@@ -76,7 +66,7 @@ pub struct JobCatOpts {
     pub print_task_header: bool,
 
     /// Type of output stream to display
-    #[clap(possible_values = &["stdout", "stderr"])]
+    #[clap(arg_enum)]
     pub stream: OutputStream,
 }
 

--- a/crates/hyperqueue/src/client/commands/log.rs
+++ b/crates/hyperqueue/src/client/commands/log.rs
@@ -3,7 +3,6 @@ use crate::common::arraydef::IntArray;
 use crate::stream::reader::logfile::LogFile;
 use clap::Parser;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 #[derive(Parser)]
 pub struct LogOpts {
@@ -21,7 +20,7 @@ pub struct SummaryOpts {}
 #[derive(Parser)]
 pub struct ShowOpts {
     /// Filter only specific channel
-    #[clap(long)]
+    #[clap(long, arg_enum)]
     pub channel: Option<Channel>,
 
     /// Show close message even for tasks with empty stream
@@ -32,6 +31,7 @@ pub struct ShowOpts {
 #[derive(Parser)]
 pub struct CatOpts {
     /// Channel name: "stdout" or "stderr"
+    #[clap(arg_enum)]
     pub channel: Channel,
 
     /// Print only the specified task(s) output. You can use the array syntax to specify multiple tasks.
@@ -55,22 +55,10 @@ pub enum LogCommand {
     Cat(CatOpts),
 }
 
-#[derive(Parser)]
+#[derive(clap::ArgEnum, Clone)]
 pub enum Channel {
     Stdout,
     Stderr,
-}
-
-impl FromStr for Channel {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "stdout" => Ok(Channel::Stdout),
-            "stderr" => Ok(Channel::Stderr),
-            _ => Err("Invalid channel"),
-        }
-    }
 }
 
 pub fn command_log(gsettings: &GlobalSettings, opts: LogOpts) -> anyhow::Result<()> {

--- a/crates/hyperqueue/src/client/output/outputs.rs
+++ b/crates/hyperqueue/src/client/output/outputs.rs
@@ -7,55 +7,27 @@ use crate::client::job::WorkerMap;
 use crate::server::autoalloc::{Allocation, AllocationEventHolder};
 use crate::stream::reader::logfile::Summary;
 use std::path::Path;
-use std::str::FromStr;
 
 use crate::client::output::common::TaskToPathsMap;
 use crate::server::job::JobTaskInfo;
-use clap::Parser;
 use core::time::Duration;
 use tako::common::resources::ResourceDescriptor;
 
 pub const MAX_DISPLAYED_WORKERS: usize = 2;
 
-#[derive(Parser)]
+#[derive(clap::ArgEnum, Clone)]
 pub enum Outputs {
     CLI,
     JSON,
     Quiet,
 }
 
-impl FromStr for Outputs {
-    type Err = anyhow::Error;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        match input {
-            "cli" => Ok(Outputs::CLI),
-            "json" => Ok(Outputs::JSON),
-            "quiet" => Ok(Outputs::Quiet),
-            _ => {
-                anyhow::bail!("Invalid output mode. Possible values are `cli`, `json` or `quiet`.")
-            }
-        }
-    }
-}
-
+#[derive(clap::ArgEnum, Clone)]
 pub enum OutputStream {
     /// Displays stdout output stream for given job and task(s)
     Stdout,
     /// Displays stderr output stream for given job and task(s)
     Stderr,
-}
-
-impl FromStr for OutputStream {
-    type Err = anyhow::Error;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        match input {
-            "stdout" => Ok(OutputStream::Stdout),
-            "stderr" => Ok(OutputStream::Stderr),
-            _ => anyhow::bail!("Invalid output stream. Possible values are `stdout` or `stderr`."),
-        }
-    }
 }
 
 pub trait Output {

--- a/crates/hyperqueue/src/client/status.rs
+++ b/crates/hyperqueue/src/client/status.rs
@@ -1,35 +1,16 @@
-use std::str::FromStr;
-
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::server::job::JobTaskState;
 use crate::transfer::messages::JobInfo;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(clap::ArgEnum, Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub enum Status {
     Waiting,
     Running,
     Finished,
     Failed,
     Canceled,
-}
-
-impl FromStr for Status {
-    type Err = anyhow::Error;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        Ok(match input {
-            "waiting" => Self::Waiting,
-            "running" => Self::Running,
-            "finished" => Self::Finished,
-            "failed" => Self::Failed,
-            "canceled" => Self::Canceled,
-            _ => {
-                anyhow::bail!("Invalid job status, possible options: `waiting`, `running`, `finished`, `failed` or `canceled`.")
-            }
-        })
-    }
 }
 
 pub fn job_status(info: &JobInfo) -> Status {

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -553,7 +553,7 @@ pub fn gather_configuration(opts: WorkerStartOpts) -> anyhow::Result<WorkerConfi
         hostname,
         work_dir,
         log_dir,
-        on_server_lost: opts.on_server_lost.unpack(),
+        on_server_lost: opts.on_server_lost.into(),
         heartbeat_interval: opts.heartbeat.unpack(),
         idle_timeout: opts.idle_timeout.map(|x| x.unpack()),
         send_overview_interval: Some(Duration::from_millis(1000)),


### PR DESCRIPTION
This allows us to remove the possible_values annotations, which are fragile, and it makes parsing and mainly its error messages more consistent.