### PR TITLE
Fix missing placeholder validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### CLI
 * Add `--filter` flag to `worker list` to allow filtering workers by their status.
 
+## Fixes
+* HQ will no longer warn that `stdout`/`stderr` path does not contain the `%{TASK_ID}` placeholder
+when submitting array jobs if the placeholder is contained within the working directory path and
+`stdout`/`stderr` contains the `%{CWD}` placeholder.
+
 # 0.8.0
 
 ## Fixes

--- a/tests/test_placeholders.py
+++ b/tests/test_placeholders.py
@@ -110,6 +110,23 @@ def test_warning_missing_placeholder_in_output(hq_env: HqEnv, channel: str):
     assert f"Consider adding `%{{TASK_ID}}` to the `--{channel}` value."
 
 
+@pytest.mark.parametrize("channel", ("stdout", "stderr"))
+def test_missing_placeholder_in_output_present_in_cwd(hq_env: HqEnv, channel: str):
+    hq_env.start_server()
+    output = hq_env.command(
+        [
+            "submit",
+            "--array=1-4",
+            "--cwd",
+            "task-%{TASK_ID}",
+            f"--{channel}",
+            "%{CWD}/foo",
+            "/bin/hostname",
+        ]
+    )
+    assert "path does not contain the task ID placeholder." not in output
+
+
 def test_unknown_placeholder(hq_env: HqEnv):
     hq_env.start_server()
     output = hq_env.command(


### PR DESCRIPTION
Do not warn that stdout/stderr of an array job misses the TASK_ID placeholder if it is contained in CWD and the path contains the CWD placeholder.