### PR TITLE
Dashboard Allocations Screen

### DIFF
--- a/crates/hyperqueue/src/client/commands/event/output.rs
+++ b/crates/hyperqueue/src/client/commands/event/output.rs
@@ -28,41 +28,45 @@ fn format_payload(event: MonitoringEventPayload) -> serde_json::Value {
             json!({
                 "type": "worker-overview",
                 "id": id,
-                "hw_state": hw_state
+                "hw-state": hw_state
             })
         }
         MonitoringEventPayload::AllocationQueueCreated(id, _params) => {
             json!({
                 "type": "autoalloc-queue-created",
-                "id": id
+                "descriptor-id": id
             })
         }
         MonitoringEventPayload::AllocationQueueRemoved(id) => {
             json!({
                 "type": "autoalloc-queue-removed",
-                "id": id
+                "descriptor-id": id
             })
         }
         MonitoringEventPayload::AllocationQueued {
+            descriptor_id,
             allocation_id,
             worker_count,
         } => {
             json!({
                 "type": "autoalloc-allocation-queued",
-                "id": allocation_id,
+                "descriptor-id": descriptor_id,
+                "allocation-id": allocation_id,
                 "worker-count": worker_count
             })
         }
-        MonitoringEventPayload::AllocationStarted(id) => {
+        MonitoringEventPayload::AllocationStarted(descriptor_id, allocation_id) => {
             json!({
                 "type": "autoalloc-allocation-started",
-                "id": id,
+                "descriptor-id": descriptor_id,
+                "allocation-id": allocation_id,
             })
         }
-        MonitoringEventPayload::AllocationFinished(id) => {
+        MonitoringEventPayload::AllocationFinished(descriptor_id, allocation_id) => {
             json!({
                 "type": "autoalloc-allocation-finished",
-                "id": id,
+                "descriptor-id": descriptor_id,
+                "allocation-id": allocation_id,
             })
         }
         MonitoringEventPayload::TaskStarted { task_id, worker_id } => json!({

--- a/crates/hyperqueue/src/dashboard/data/alloc_timeline.rs
+++ b/crates/hyperqueue/src/dashboard/data/alloc_timeline.rs
@@ -1,0 +1,179 @@
+use crate::server::autoalloc::{AllocationId, DescriptorId};
+use crate::server::event::events::MonitoringEventPayload;
+use crate::server::event::MonitoringEvent;
+use crate::transfer::messages::AllocationQueueParams;
+use crate::Map;
+use std::time::SystemTime;
+
+pub struct AllocationQueueInfo {
+    pub queue_params: AllocationQueueParams,
+    pub creation_time: SystemTime,
+    pub removal_time: Option<SystemTime>,
+
+    pub allocations: Map<AllocationId, AllocationInfo>,
+}
+
+#[derive(Copy, Clone)]
+pub struct AllocationInfo {
+    pub worker_count: u64,
+    pub queued_time: SystemTime,
+    pub start_time: Option<SystemTime>,
+    pub finish_time: Option<SystemTime>,
+}
+
+#[derive(Copy, Clone)]
+pub enum AllocationStatus {
+    Queued,
+    Running,
+    Finished,
+}
+
+pub fn get_allocation_status(info: &AllocationInfo, query_time: SystemTime) -> AllocationStatus {
+    let has_started = info.start_time.is_some() && info.start_time.unwrap() < query_time;
+    let has_finished = match info.finish_time {
+        None => false,
+        Some(finish_time) => finish_time < query_time,
+    };
+    match has_started && !has_finished {
+        true => (AllocationStatus::Running),
+        false => match has_finished {
+            true => AllocationStatus::Finished,
+            false => AllocationStatus::Queued,
+        },
+    }
+}
+/// Stores the state of different allocation queues and their allocations
+#[derive(Default)]
+pub struct AllocationTimeline {
+    queue_timelines: Map<DescriptorId, AllocationQueueInfo>,
+}
+
+impl AllocationQueueInfo {
+    // Add a new allocation that has been queued.
+    pub fn add_queued_allocation(
+        &mut self,
+        allocation_id: AllocationId,
+        worker_count: u64,
+        queued_time: SystemTime,
+    ) {
+        self.allocations.insert(
+            allocation_id,
+            AllocationInfo {
+                worker_count,
+                queued_time,
+                start_time: None,
+                finish_time: None,
+            },
+        );
+    }
+
+    // Update the state of an existing allocation in the queue.
+    fn update_allocation_state(
+        &mut self,
+        allocation_id: &AllocationId,
+        new_state: AllocationStatus,
+        at_time: SystemTime,
+    ) {
+        let state = self
+            .allocations
+            .iter_mut()
+            .find(|(id, _)| id == &allocation_id)
+            .map(|(_, state)| state)
+            .unwrap();
+        match new_state {
+            AllocationStatus::Running => {
+                state.start_time = Some(at_time);
+            }
+            AllocationStatus::Finished => {
+                state.finish_time = Some(at_time);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl AllocationTimeline {
+    /// Assumes that `events` are sorted by time.
+    pub fn handle_new_events(&mut self, events: &[MonitoringEvent]) {
+        for event in events {
+            match &event.payload {
+                MonitoringEventPayload::AllocationQueueCreated(id, params) => {
+                    self.queue_timelines.insert(
+                        *id,
+                        AllocationQueueInfo {
+                            queue_params: *params.clone(),
+                            creation_time: event.time,
+                            removal_time: None,
+                            allocations: Default::default(),
+                        },
+                    );
+                }
+                MonitoringEventPayload::AllocationQueueRemoved(descriptor_id) => {
+                    let queue_state = self.queue_timelines.get_mut(descriptor_id).unwrap();
+                    queue_state.removal_time = Some(event.time);
+                }
+                MonitoringEventPayload::AllocationQueued {
+                    descriptor_id,
+                    allocation_id,
+                    worker_count,
+                } => {
+                    let queue_state = self.queue_timelines.get_mut(descriptor_id).unwrap();
+                    queue_state.add_queued_allocation(
+                        allocation_id.clone(),
+                        *worker_count,
+                        event.time,
+                    );
+                }
+                MonitoringEventPayload::AllocationStarted(descriptor_id, allocation_id) => {
+                    let queue_state = self.queue_timelines.get_mut(descriptor_id).unwrap();
+                    queue_state.update_allocation_state(
+                        allocation_id,
+                        AllocationStatus::Running,
+                        event.time,
+                    );
+                }
+                MonitoringEventPayload::AllocationFinished(descriptor_id, allocation_id) => {
+                    let queue_state = self.queue_timelines.get_mut(descriptor_id).unwrap();
+                    queue_state.update_allocation_state(
+                        allocation_id,
+                        AllocationStatus::Finished,
+                        event.time,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    pub fn get_queue_infos_at(
+        &self,
+        time: SystemTime,
+    ) -> impl Iterator<Item = (&DescriptorId, &AllocationQueueInfo)> + '_ {
+        self.queue_timelines
+            .iter()
+            .filter(move |(_, info)| info.creation_time <= time)
+    }
+
+    pub fn get_queue_params_for(
+        &self,
+        descriptor_id: &DescriptorId,
+    ) -> Option<&AllocationQueueParams> {
+        self.queue_timelines
+            .get(descriptor_id)
+            .map(|queue_info| &queue_info.queue_params)
+    }
+
+    pub fn get_allocations_for_queue(
+        &self,
+        descriptor_id: DescriptorId,
+        time: SystemTime,
+    ) -> Option<impl Iterator<Item = (&AllocationId, &AllocationInfo)> + '_> {
+        self.get_queue_infos_at(time)
+            .find(|(id, _)| **id == descriptor_id)
+            .map(move |(_, info)| {
+                info.allocations
+                    .iter()
+                    .filter(move |(_, info)| info.queued_time <= time)
+            })
+    }
+}

--- a/crates/hyperqueue/src/dashboard/state.rs
+++ b/crates/hyperqueue/src/dashboard/state.rs
@@ -1,6 +1,7 @@
 use crate::dashboard::data::DashboardData;
 use crate::dashboard::ui::screen::controller::{ChangeScreenCommand, ScreenController};
 use crate::dashboard::ui::screen::Screen;
+use crate::dashboard::ui::screens::auto_allocator::screen::AutoAllocatorScreen;
 use crate::dashboard::ui::screens::home::screen::ClusterOverviewScreen;
 use crate::dashboard::ui::screens::worker::screen::WorkerOverviewScreen;
 use tako::common::WrappedRcRefCell;
@@ -8,6 +9,7 @@ use tako::common::WrappedRcRefCell;
 pub struct DashboardState {
     cluster_overview_screen: ClusterOverviewScreen,
     worker_overview_screen: WorkerOverviewScreen,
+    auto_allocator_screen: AutoAllocatorScreen,
 
     data_source: WrappedRcRefCell<DashboardData>,
 
@@ -16,8 +18,9 @@ pub struct DashboardState {
 }
 
 enum DashboardScreenState {
-    ClusterOverviewScreen,
-    WorkerOverviewScreen,
+    ClusterOverview,
+    WorkerOverview,
+    AutoAllocator,
 }
 
 impl DashboardState {
@@ -26,7 +29,8 @@ impl DashboardState {
             data_source: WrappedRcRefCell::wrap(data_source),
             cluster_overview_screen: ClusterOverviewScreen::default(),
             worker_overview_screen: WorkerOverviewScreen::default(),
-            current_screen: DashboardScreenState::ClusterOverviewScreen,
+            auto_allocator_screen: Default::default(),
+            current_screen: DashboardScreenState::ClusterOverview,
             controller,
         }
     }
@@ -39,11 +43,14 @@ impl DashboardState {
     pub fn change_current_screen(&mut self, next_screen: ChangeScreenCommand) {
         match next_screen {
             ChangeScreenCommand::ClusterOverviewScreen => {
-                self.current_screen = DashboardScreenState::ClusterOverviewScreen;
+                self.current_screen = DashboardScreenState::ClusterOverview;
             }
             ChangeScreenCommand::WorkerOverviewScreen(worker_id) => {
                 self.worker_overview_screen.set_worker_id(worker_id);
-                self.current_screen = DashboardScreenState::WorkerOverviewScreen;
+                self.current_screen = DashboardScreenState::WorkerOverview;
+            }
+            ChangeScreenCommand::AutoAllocatorScreen => {
+                self.current_screen = DashboardScreenState::AutoAllocator;
             }
         }
     }
@@ -52,11 +59,14 @@ impl DashboardState {
         &mut self,
     ) -> (&mut dyn Screen, &mut ScreenController) {
         match self.current_screen {
-            DashboardScreenState::ClusterOverviewScreen => {
+            DashboardScreenState::ClusterOverview => {
                 (&mut self.cluster_overview_screen, &mut self.controller)
             }
-            DashboardScreenState::WorkerOverviewScreen => {
+            DashboardScreenState::WorkerOverview => {
                 (&mut self.worker_overview_screen, &mut self.controller)
+            }
+            DashboardScreenState::AutoAllocator => {
+                (&mut self.auto_allocator_screen, &mut self.controller)
             }
         }
     }

--- a/crates/hyperqueue/src/dashboard/ui/screen/controller.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screen/controller.rs
@@ -6,6 +6,7 @@ use tokio::sync::mpsc::UnboundedSender;
 pub enum ChangeScreenCommand {
     ClusterOverviewScreen,
     WorkerOverviewScreen(WorkerId),
+    AutoAllocatorScreen,
 }
 
 pub struct ScreenController {
@@ -23,6 +24,10 @@ impl ScreenController {
 
     pub fn show_cluster_overview(&mut self) {
         self.send_change_command(ChangeScreenCommand::ClusterOverviewScreen)
+    }
+
+    pub fn show_auto_allocator_screen(&mut self) {
+        self.send_change_command(ChangeScreenCommand::AutoAllocatorScreen)
     }
 
     fn send_change_command(&mut self, command: ChangeScreenCommand) {

--- a/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/alloc_timeline_chart.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/alloc_timeline_chart.rs
@@ -1,0 +1,191 @@
+use std::time::{Duration, SystemTime};
+
+use tako::common::Map;
+use tui::layout::Rect;
+use tui::widgets::canvas::{Canvas, Context, Painter, Shape};
+
+use crate::dashboard::data::alloc_timeline::{get_allocation_status, AllocationStatus};
+use crate::dashboard::data::DashboardData;
+use crate::dashboard::ui::terminal::DashboardFrame;
+use crate::server::autoalloc::{AllocationId, DescriptorId};
+use chrono::{DateTime, Local};
+use std::default::Default;
+use tui::style::{Color, Style};
+use tui::symbols;
+use tui::text::Span;
+use tui::widgets::{Block, Borders};
+
+/// Margin for the chart time labels.
+const LABEL_Y_MARGIN: f64 = 1.00;
+/// Margin between the alloc timeline and its `allocation_id` label.
+const LINE_Y_MARGIN: f64 = 0.10;
+/// Space taken by string = `num_chars` * `CHAR_SPACE_FACTOR`.
+const CHAR_SPACE_FACTOR: f64 = 2.30;
+/// Space taken by time labels in chart `HH:MM`.
+const TIME_CHAR_COUNT: f64 = 5.00 * CHAR_SPACE_FACTOR;
+
+/// Stores the allocation status at a point in time.
+struct AllocationInfoPoint {
+    state: AllocationStatus,
+    time: SystemTime,
+}
+
+struct AllocationsChartData {
+    /// The status of an allocation at different points in time.
+    allocation_records: Map<AllocationId, Vec<AllocationInfoPoint>>,
+    /// Max time that is being shown currently.
+    end_time: SystemTime,
+    /// The size of the viewing window.
+    view_size: Duration,
+}
+
+#[derive(Default)]
+pub struct AllocationsChart {
+    chart_data: AllocationsChartData,
+}
+
+impl AllocationsChart {
+    pub fn update(&mut self, data: &DashboardData, query_descriptor: DescriptorId) {
+        self.chart_data.end_time = SystemTime::now();
+
+        let mut query_time = self.chart_data.end_time - self.chart_data.view_size;
+        let mut query_times = vec![];
+        while query_time <= self.chart_data.end_time {
+            query_times.push(query_time);
+            query_time += Duration::from_secs(1);
+        }
+
+        let mut allocation_history: Vec<(AllocationId, AllocationInfoPoint)> = vec![];
+        query_times.iter().for_each(|query_time| {
+            if let Some(alloc_map) = data.query_allocations_info_at(query_descriptor, *query_time) {
+                let points = alloc_map
+                    .filter(|(_, alloc_info)| {
+                        let finished_before_query = alloc_info
+                            .finish_time
+                            .map(|finish_time| finish_time < *query_time)
+                            .unwrap_or(false);
+
+                        !finished_before_query
+                    })
+                    .map(|(alloc_id, alloc_info)| {
+                        (
+                            alloc_id.clone(),
+                            AllocationInfoPoint {
+                                state: get_allocation_status(alloc_info, *query_time),
+                                time: *query_time,
+                            },
+                        )
+                    });
+                allocation_history.extend(points);
+            }
+        });
+
+        self.chart_data.allocation_records.clear();
+        allocation_history.into_iter().for_each(|(id, point)| {
+            if let Some(points) = self.chart_data.allocation_records.get_mut(&id) {
+                points.push(point);
+            } else {
+                self.chart_data.allocation_records.insert(id, vec![point]);
+            }
+        });
+    }
+
+    pub fn draw(&mut self, rect: Rect, frame: &mut DashboardFrame) {
+        let canvas = Canvas::default()
+            .marker(symbols::Marker::Block)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title("Alloc Timeline"),
+            )
+            .paint(|ctx| {
+                ctx.draw(&self.chart_data);
+                self.draw_labels(ctx);
+            })
+            .x_bounds([0.0, self.chart_data.view_size.as_secs_f64()])
+            .y_bounds([
+                0.0,
+                self.chart_data.allocation_records.len() as f64 + LABEL_Y_MARGIN,
+            ]);
+        frame.render_widget(canvas, rect);
+    }
+}
+
+impl Shape for AllocationsChartData {
+    /// Draws the allocation_queue_timelines
+    fn draw(&self, painter: &mut Painter) {
+        let mut y_pos: f64 = LABEL_Y_MARGIN;
+        for (_, alloc_info_pt) in &self.allocation_records {
+            alloc_info_pt.iter().for_each(|point| {
+                let x_pos = self.view_size.as_secs_f64()
+                    - self
+                        .end_time
+                        .duration_since(point.time)
+                        .unwrap_or_default()
+                        .as_secs_f64();
+                if let Some((x, y)) = painter.get_point(x_pos, y_pos) {
+                    painter.paint(
+                        x,
+                        y,
+                        match point.state {
+                            AllocationStatus::Queued => Color::Yellow,
+                            AllocationStatus::Running => Color::Green,
+                            _ => unreachable!(),
+                        },
+                    );
+                }
+            });
+            y_pos += LABEL_Y_MARGIN;
+        }
+    }
+}
+
+impl AllocationsChart {
+    /// Adds the x_axis labels for time and `allocation_id` label to each timeline.
+    fn draw_labels(&self, ctx: &mut Context) {
+        let begin_time: DateTime<Local> =
+            (self.chart_data.end_time - self.chart_data.view_size).into();
+        let end_time: DateTime<Local> = self.chart_data.end_time.into();
+
+        ctx.print(
+            0.0,
+            0.0,
+            Span::styled(
+                begin_time.format("%H:%M").to_string(),
+                Style::default().fg(Color::Yellow),
+            ),
+        );
+        ctx.print(
+            self.chart_data.view_size.as_secs_f64() - TIME_CHAR_COUNT,
+            0.0,
+            Span::styled(
+                end_time.format("%H:%M").to_string(),
+                Style::default().fg(Color::Yellow),
+            ),
+        );
+        // Margin to prevent overlap with time labels and timeline plots.
+        let mut y_pos: f64 = LABEL_Y_MARGIN + LINE_Y_MARGIN;
+        // Inserts the allocation_id labels for each of the allocation timelines.
+        self.chart_data
+            .allocation_records
+            .iter()
+            .for_each(|(alloc_id, _)| {
+                ctx.print(
+                    0.00,
+                    y_pos,
+                    Span::styled(alloc_id.clone(), Style::default().fg(Color::Yellow)),
+                );
+                y_pos += LABEL_Y_MARGIN;
+            });
+    }
+}
+
+impl Default for AllocationsChartData {
+    fn default() -> Self {
+        Self {
+            allocation_records: Default::default(),
+            end_time: SystemTime::now(),
+            view_size: Duration::from_secs(600),
+        }
+    }
+}

--- a/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/allocations_info_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/allocations_info_table.rs
@@ -1,0 +1,125 @@
+use crate::dashboard::data::alloc_timeline::{
+    get_allocation_status, AllocationInfo, AllocationStatus,
+};
+use crate::dashboard::ui::terminal::DashboardFrame;
+use crate::dashboard::ui::widgets::table::{StatefulTable, TableColumnHeaders};
+use crate::server::autoalloc::AllocationId;
+use chrono::{DateTime, Local};
+use std::time::SystemTime;
+use termion::event::Key;
+use tui::layout::{Constraint, Rect};
+use tui::style::Style;
+use tui::widgets::{Cell, Row};
+
+#[derive(Default)]
+pub struct AllocationInfoTable {
+    table: StatefulTable<(AllocationId, AllocationInfo)>,
+}
+
+impl AllocationInfoTable {
+    pub fn update<'a>(
+        &'a mut self,
+        allocation_info: impl Iterator<Item = (&'a AllocationId, &'a AllocationInfo)>,
+    ) {
+        let rows = create_rows(allocation_info);
+        self.table.set_items(rows);
+    }
+
+    pub fn select_next_allocation(&mut self) {
+        self.table.select_next_wrap();
+    }
+
+    pub fn select_previous_allocation(&mut self) {
+        self.table.select_previous_wrap();
+    }
+
+    pub fn get_selected_allocation_id(&self) -> Option<&AllocationId> {
+        let selection = self.table.current_selection();
+        selection.map(|(id, _)| id)
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.table.clear_selection();
+    }
+
+    pub fn draw(&mut self, rect: Rect, frame: &mut DashboardFrame, table_style: Style) {
+        self.table.draw(
+            rect,
+            frame,
+            TableColumnHeaders {
+                title: "Allocations <2>",
+                inline_help: "",
+                table_headers: Some(vec![
+                    "Allocation ID",
+                    "#Workers",
+                    "Queued Time",
+                    "Start Time",
+                    "Finish Time",
+                ]),
+                column_widths: vec![
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                ],
+            },
+            |(alloc_id, info_row)| {
+                let queued_time: DateTime<Local> = info_row.queued_time.into();
+                let queued_time_string = queued_time.format("%b %e, %T").to_string();
+                let start_time = info_row
+                    .start_time
+                    .map(|time| {
+                        let start_time: DateTime<Local> = time.into();
+                        start_time.format("%b %e, %T").to_string()
+                    })
+                    .unwrap_or_else(|| "".to_string());
+                let finish_time = info_row
+                    .finish_time
+                    .map(|time| {
+                        let end_time: DateTime<Local> = time.into();
+                        end_time.format("%b %e, %T").to_string()
+                    })
+                    .unwrap_or_else(|| "".to_string());
+
+                Row::new(vec![
+                    Cell::from(alloc_id.as_str()),
+                    Cell::from(info_row.worker_count.to_string()),
+                    Cell::from(queued_time_string),
+                    Cell::from(start_time),
+                    Cell::from(finish_time),
+                ])
+            },
+            table_style,
+        );
+    }
+    pub fn handle_key(&mut self, key: Key) {
+        match key {
+            Key::Down => self.select_next_allocation(),
+            Key::Up => self.select_previous_allocation(),
+            _ => {}
+        }
+    }
+}
+
+fn create_rows<'a>(
+    allocations: impl Iterator<Item = (&'a AllocationId, &'a AllocationInfo)>,
+) -> Vec<(AllocationId, AllocationInfo)> {
+    let mut info_rows: Vec<(AllocationId, AllocationInfo)> = allocations
+        .map(|(alloc_id, info)| (alloc_id.clone(), *info))
+        .collect();
+
+    info_rows.sort_by_key(|(_, alloc_info_row)| {
+        let status_index = match get_allocation_status(alloc_info_row, SystemTime::now()) {
+            AllocationStatus::Running => 0,
+            AllocationStatus::Queued => 1,
+            AllocationStatus::Finished => 2,
+        };
+        match alloc_info_row.start_time {
+            None => (status_index, alloc_info_row.queued_time),
+            Some(start_time) => (status_index, start_time),
+        }
+    });
+
+    info_rows
+}

--- a/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/mod.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/mod.rs
@@ -1,0 +1,5 @@
+pub mod alloc_timeline_chart;
+pub mod allocations_info_table;
+pub mod queue_info_table;
+pub mod queue_params_display;
+pub mod screen;

--- a/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/queue_info_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/queue_info_table.rs
@@ -1,0 +1,105 @@
+use crate::dashboard::data::alloc_timeline::AllocationQueueInfo;
+use crate::dashboard::ui::terminal::DashboardFrame;
+use crate::dashboard::ui::widgets::table::{StatefulTable, TableColumnHeaders};
+use crate::server::autoalloc::DescriptorId;
+use chrono::{DateTime, Local};
+use termion::event::Key;
+use tui::layout::{Constraint, Rect};
+use tui::style::Style;
+use tui::widgets::{Cell, Row};
+
+#[derive(Default)]
+pub struct AllocationQueueInfoTable {
+    table: StatefulTable<QueueInfoRow>,
+}
+
+impl AllocationQueueInfoTable {
+    pub fn update(&mut self, queue_infos: Vec<(&DescriptorId, &AllocationQueueInfo)>) {
+        let rows = create_rows(queue_infos);
+        self.table.set_items(rows);
+    }
+
+    pub fn select_next_queue(&mut self) {
+        self.table.select_next_wrap();
+    }
+
+    pub fn select_previous_queue(&mut self) {
+        self.table.select_previous_wrap();
+    }
+
+    pub fn get_selected_queue_descriptor(&self) -> Option<DescriptorId> {
+        let selection = self.table.current_selection();
+        selection.map(|row| row.descriptor_id)
+    }
+
+    pub fn draw(&mut self, rect: Rect, frame: &mut DashboardFrame, table_style: Style) {
+        self.table.draw(
+            rect,
+            frame,
+            TableColumnHeaders {
+                title: "Allocation Queues <1>",
+                inline_help: "",
+                table_headers: Some(vec![
+                    "Descriptor ID",
+                    "#Allocations",
+                    "Creation Time",
+                    "Removal Time",
+                ]),
+                column_widths: vec![
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(25),
+                ],
+            },
+            |data| {
+                Row::new(vec![
+                    Cell::from(data.descriptor_id.to_string()),
+                    Cell::from(data.num_allocations.to_string()),
+                    Cell::from(data.creation_time.as_str()),
+                    Cell::from(data.removal_time.as_str()),
+                ])
+            },
+            table_style,
+        );
+    }
+
+    pub fn handle_key(&mut self, key: Key) {
+        match key {
+            Key::Down => self.select_next_queue(),
+            Key::Up => self.select_previous_queue(),
+            _ => {}
+        }
+    }
+}
+
+struct QueueInfoRow {
+    descriptor_id: DescriptorId,
+    num_allocations: u32,
+    creation_time: String,
+    removal_time: String,
+}
+
+fn create_rows(mut queues: Vec<(&DescriptorId, &AllocationQueueInfo)>) -> Vec<QueueInfoRow> {
+    queues.sort_by_key(|(_, queue_info)| queue_info.creation_time);
+    queues
+        .iter()
+        .map(|(descriptor_id, info)| {
+            let creation_time: DateTime<Local> = info.creation_time.into();
+            let removal_time = info
+                .removal_time
+                .map(|time| {
+                    let end_time: DateTime<Local> = time.into();
+                    end_time.format("%b %e, %T").to_string()
+                })
+                .unwrap_or_else(|| "".to_string());
+
+            QueueInfoRow {
+                descriptor_id: **descriptor_id,
+                num_allocations: info.allocations.len() as u32,
+                creation_time: creation_time.format("%b %e, %T").to_string(),
+                removal_time,
+            }
+        })
+        .collect()
+}

--- a/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/queue_params_display.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/queue_params_display.rs
@@ -1,0 +1,92 @@
+use crate::common::format::human_duration;
+use crate::dashboard::ui::styles::table_style_deselected;
+use crate::dashboard::ui::terminal::DashboardFrame;
+use crate::dashboard::ui::widgets::table::{StatefulTable, TableColumnHeaders};
+use crate::transfer::messages::AllocationQueueParams;
+use tako::worker::state::ServerLostPolicy;
+use tui::layout::{Constraint, Rect};
+use tui::widgets::{Cell, Row};
+
+#[derive(Default)]
+pub struct QueueParamsTable {
+    table: StatefulTable<QueueParamsDataRow>,
+}
+
+#[derive(Default, Debug)]
+struct QueueParamsDataRow {
+    pub label: &'static str,
+    pub data: String,
+}
+
+impl QueueParamsTable {
+    pub fn update(&mut self, queue_params: &AllocationQueueParams) {
+        let rows = create_rows(queue_params);
+        self.table.set_items(rows);
+    }
+
+    pub fn draw(&mut self, rect: Rect, frame: &mut DashboardFrame) {
+        self.table.draw(
+            rect,
+            frame,
+            TableColumnHeaders {
+                title: "Allocation Queue Params",
+                inline_help: "",
+                table_headers: None,
+                column_widths: vec![Constraint::Percentage(30), Constraint::Percentage(70)],
+            },
+            |data| Row::new(vec![Cell::from(data.label), Cell::from(data.data.as_str())]),
+            table_style_deselected(),
+        );
+    }
+}
+
+fn create_rows(params: &AllocationQueueParams) -> Vec<QueueParamsDataRow> {
+    vec![
+        QueueParamsDataRow {
+            label: "Workers Per Alloc: ",
+            data: params.workers_per_alloc.to_string(),
+        },
+        QueueParamsDataRow {
+            label: "Backlog: ",
+            data: params.backlog.to_string(),
+        },
+        QueueParamsDataRow {
+            label: "Time Limit: ",
+            data: human_duration(chrono::Duration::from_std(params.timelimit).unwrap()),
+        },
+        QueueParamsDataRow {
+            label: "Worker On Server Lost: ",
+            data: match params.on_server_lost {
+                ServerLostPolicy::Stop => "STOP".to_string(),
+                ServerLostPolicy::FinishRunning => "FINISH_RUNNING".to_string(),
+            },
+        },
+        QueueParamsDataRow {
+            label: "Queue Name: ",
+            data: params.name.clone().unwrap_or_default(),
+        },
+        QueueParamsDataRow {
+            label: "Additional Args: ",
+            data: params.additional_args.join(" "),
+        },
+        QueueParamsDataRow {
+            label: "Worker CPU Arg: ",
+            data: params.worker_cpu_arg.clone().unwrap_or_default(),
+        },
+        QueueParamsDataRow {
+            label: "Worker Resource Args: ",
+            data: params.worker_resources_args.join(" "),
+        },
+        QueueParamsDataRow {
+            label: "Max Worker Count: ",
+            data: params
+                .max_worker_count
+                .map(|count| count.to_string())
+                .unwrap_or_default(),
+        },
+        QueueParamsDataRow {
+            label: "Max Kept Directories: ",
+            data: params.max_kept_directories.to_string(),
+        },
+    ]
+}

--- a/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/screen.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/auto_allocator/screen.rs
@@ -1,0 +1,179 @@
+use std::default::Default;
+use std::time::SystemTime;
+use termion::event::Key;
+
+use crate::dashboard::ui::screen::Screen;
+use crate::dashboard::ui::styles::{
+    style_footer, style_header_text, table_style_deselected, table_style_selected,
+};
+use crate::dashboard::ui::terminal::DashboardFrame;
+use crate::dashboard::ui::widgets::text::draw_text;
+
+use crate::dashboard::data::alloc_timeline::AllocationQueueInfo;
+use crate::dashboard::data::DashboardData;
+use crate::dashboard::ui::screen::controller::ScreenController;
+use crate::dashboard::ui::screens::auto_allocator::alloc_timeline_chart::AllocationsChart;
+use crate::dashboard::ui::screens::auto_allocator::allocations_info_table::AllocationInfoTable;
+use crate::dashboard::ui::screens::auto_allocator::queue_info_table::AllocationQueueInfoTable;
+use crate::dashboard::ui::screens::auto_allocator::queue_params_display::QueueParamsTable;
+use crate::server::autoalloc::DescriptorId;
+use tui::layout::{Constraint, Direction, Layout, Rect};
+
+#[derive(Default)]
+pub struct AutoAllocatorScreen {
+    queue_info_table: AllocationQueueInfoTable,
+    queue_params_table: QueueParamsTable,
+    allocations_info_table: AllocationInfoTable,
+    allocations_chart: AllocationsChart,
+
+    component_in_focus: FocusedComponent,
+}
+
+enum FocusedComponent {
+    QueueParamsTable,
+    AllocationInfoTable,
+}
+
+impl Screen for AutoAllocatorScreen {
+    fn draw(&mut self, frame: &mut DashboardFrame) {
+        let layout = AutoAllocScreenLayout::new(frame);
+        draw_text(
+            "AutoAlloc Info",
+            layout.header_chunk,
+            frame,
+            style_header_text(),
+        );
+
+        let (queues_table_style, allocations_table_style) = match self.component_in_focus {
+            FocusedComponent::QueueParamsTable => {
+                (table_style_selected(), table_style_deselected())
+            }
+            FocusedComponent::AllocationInfoTable => {
+                (table_style_deselected(), table_style_selected())
+            }
+        };
+
+        self.allocations_chart.draw(layout.chart_chunk, frame);
+        self.queue_info_table
+            .draw(layout.queue_info_chunk, frame, queues_table_style);
+        self.allocations_info_table.draw(
+            layout.allocation_info_chunk,
+            frame,
+            allocations_table_style,
+        );
+        self.queue_params_table
+            .draw(layout.allocation_queue_params_chunk, frame);
+
+        draw_text(
+            "Press right_arrow to go to Cluster Overview",
+            layout.footer_chunk,
+            frame,
+            style_footer(),
+        );
+    }
+
+    fn update(&mut self, data: &DashboardData, _controller: &mut ScreenController) {
+        let queue_infos: Vec<(&DescriptorId, &AllocationQueueInfo)> =
+            data.query_allocation_queues_at(SystemTime::now()).collect();
+        self.queue_info_table.update(queue_infos);
+
+        if let Some(descriptor) = self.queue_info_table.get_selected_queue_descriptor() {
+            self.allocations_chart.update(data, descriptor);
+        }
+
+        if let Some(queue_params) = self
+            .queue_info_table
+            .get_selected_queue_descriptor()
+            .and_then(|descriptor_id| data.query_allocation_params(descriptor_id))
+        {
+            self.queue_params_table.update(queue_params)
+        }
+
+        if let Some(allocations_map) = self
+            .queue_info_table
+            .get_selected_queue_descriptor()
+            .and_then(|descriptor_id| {
+                data.query_allocations_info_at(descriptor_id, SystemTime::now())
+            })
+        {
+            self.allocations_info_table.update(allocations_map);
+        }
+    }
+
+    /// Handles key presses for the components of the screen
+    fn handle_key(&mut self, key: Key, controller: &mut ScreenController) {
+        match self.component_in_focus {
+            FocusedComponent::QueueParamsTable => self.queue_info_table.handle_key(key),
+            FocusedComponent::AllocationInfoTable => self.allocations_info_table.handle_key(key),
+        };
+
+        match key {
+            Key::Right => controller.show_cluster_overview(),
+            Key::Char('1') => {
+                self.component_in_focus = FocusedComponent::QueueParamsTable;
+                self.allocations_info_table.clear_selection();
+            }
+            Key::Char('2') => self.component_in_focus = FocusedComponent::AllocationInfoTable,
+            _ => {}
+        }
+    }
+}
+
+/**
+*  __________________________
+   |--------Header---------|
+   |        Chart          |
+   |-----------------------|
+   |  queues  |            |
+   |----------| alloc_info |
+   | q_params |            |
+   |________Footer_________|
+ **/
+struct AutoAllocScreenLayout {
+    chart_chunk: Rect,
+    allocation_queue_params_chunk: Rect,
+    header_chunk: Rect,
+    queue_info_chunk: Rect,
+    allocation_info_chunk: Rect,
+    footer_chunk: Rect,
+}
+
+impl AutoAllocScreenLayout {
+    fn new(frame: &DashboardFrame) -> Self {
+        let auto_alloc_screen_chunks = tui::layout::Layout::default()
+            .constraints(vec![
+                Constraint::Percentage(5),
+                Constraint::Percentage(40),
+                Constraint::Percentage(50),
+                Constraint::Percentage(5),
+            ])
+            .direction(Direction::Vertical)
+            .split(frame.size());
+
+        let component_area = Layout::default()
+            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .direction(Direction::Horizontal)
+            .margin(0)
+            .split(auto_alloc_screen_chunks[2]);
+
+        let queue_info_area = Layout::default()
+            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .direction(Direction::Vertical)
+            .split(component_area[0]);
+
+        Self {
+            chart_chunk: auto_alloc_screen_chunks[1],
+            header_chunk: auto_alloc_screen_chunks[0],
+            queue_info_chunk: queue_info_area[0],
+            allocation_queue_params_chunk: queue_info_area[1],
+            allocation_info_chunk: component_area[1],
+            footer_chunk: auto_alloc_screen_chunks[3],
+        }
+    }
+}
+
+impl Default for FocusedComponent {
+    fn default() -> Self {
+        FocusedComponent::QueueParamsTable
+    }
+}

--- a/crates/hyperqueue/src/dashboard/ui/screens/home/cluster_overview_chart.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/home/cluster_overview_chart.rs
@@ -7,6 +7,7 @@ use tui::text::Span;
 use tui::widgets::{Axis, Block, Borders, Chart, Dataset};
 
 use crate::dashboard::data::DashboardData;
+use crate::dashboard::ui::styles::chart_style_deselected;
 use crate::dashboard::ui::terminal::DashboardFrame;
 
 struct WorkerCountRecord {
@@ -61,6 +62,7 @@ impl ClusterOverviewChart {
             .data(&worker_counts)];
 
         let chart = Chart::new(datasets)
+            .style(chart_style_deselected())
             .block(
                 Block::default()
                     .title(Span::styled(

--- a/crates/hyperqueue/src/dashboard/ui/screens/home/screen.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/home/screen.rs
@@ -48,6 +48,7 @@ impl Screen for ClusterOverviewScreen {
                     controller.show_worker_screen(worker_id);
                 }
             }
+            Key::Left => controller.show_auto_allocator_screen(),
             _ => {}
         }
     }

--- a/crates/hyperqueue/src/dashboard/ui/screens/home/worker_utilization_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/home/worker_utilization_table.rs
@@ -1,4 +1,5 @@
 use crate::dashboard::data::DashboardData;
+use crate::dashboard::ui::styles::table_style_selected;
 use crate::dashboard::ui::terminal::DashboardFrame;
 use crate::dashboard::ui::widgets::progressbar::{
     get_progress_bar_color, render_progress_bar_at, ProgressPrintStyle,
@@ -72,6 +73,7 @@ impl WorkerUtilTable {
                     Cell::from(mem_prog_bar).style(get_progress_bar_color(mem_progress)),
                 ])
             },
+            table_style_selected(),
         );
     }
 }

--- a/crates/hyperqueue/src/dashboard/ui/screens/mod.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/mod.rs
@@ -1,2 +1,3 @@
+pub mod auto_allocator;
 pub mod home;
 pub mod worker;

--- a/crates/hyperqueue/src/dashboard/ui/screens/worker/cpu_util_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/worker/cpu_util_table.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 use tui::layout::{Constraint, Rect};
+use tui::style::Style;
 use tui::widgets::{Cell, Row, Table};
 
 use crate::dashboard::ui::styles;
@@ -15,6 +16,7 @@ pub fn render_cpu_util_table(
     rect: Rect,
     frame: &mut DashboardFrame,
     constraints: &[Constraint],
+    table_style: Style,
 ) {
     let indexed_util: Vec<(&f32, i32)> = cpu_util_list.iter().zip(1..).collect();
     let rows: Vec<Row> = indexed_util
@@ -59,7 +61,7 @@ pub fn render_cpu_util_table(
     let table = Table::new(rows)
         .block(body_block)
         .highlight_style(styles::style_table_highlight())
-        .style(styles::style_table_row())
+        .style(table_style)
         .widths(constraints);
 
     frame.render_widget(table, rect);

--- a/crates/hyperqueue/src/dashboard/ui/screens/worker/screen.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/worker/screen.rs
@@ -2,7 +2,7 @@ use std::time::SystemTime;
 use termion::event::Key;
 
 use crate::dashboard::ui::screen::Screen;
-use crate::dashboard::ui::styles::{style_footer, style_header_text};
+use crate::dashboard::ui::styles::{style_footer, style_header_text, table_style_deselected};
 use crate::dashboard::ui::terminal::DashboardFrame;
 use crate::dashboard::ui::widgets::text::draw_text;
 
@@ -62,6 +62,7 @@ impl Screen for WorkerOverviewScreen {
             layout.worker_util_chunk,
             frame,
             &cpu_usage_columns,
+            table_style_deselected(),
         );
 
         self.worker_tasks_table

--- a/crates/hyperqueue/src/dashboard/ui/screens/worker/worker_config_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/worker/worker_config_table.rs
@@ -1,3 +1,4 @@
+use crate::dashboard::ui::styles::table_style_deselected;
 use crate::dashboard::ui::terminal::DashboardFrame;
 use crate::dashboard::ui::widgets::table::{StatefulTable, TableColumnHeaders};
 use tako::messages::common::WorkerConfiguration;
@@ -32,6 +33,7 @@ impl WorkerConfigTable {
                 column_widths: vec![Constraint::Percentage(30), Constraint::Percentage(70)],
             },
             |data| Row::new(vec![Cell::from(data.label), Cell::from(data.data.as_str())]),
+            table_style_deselected(),
         );
     }
 }

--- a/crates/hyperqueue/src/dashboard/ui/screens/worker/worker_tasks_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/worker/worker_tasks_table.rs
@@ -1,5 +1,6 @@
 use crate::common::format::human_duration;
 use crate::dashboard::data::task_timeline::{DashboardTaskState, TaskInfo};
+use crate::dashboard::ui::styles::table_style_selected;
 use crate::dashboard::ui::terminal::DashboardFrame;
 use crate::dashboard::ui::widgets::table::{StatefulTable, TableColumnHeaders};
 use chrono::{DateTime, Local};
@@ -68,6 +69,7 @@ impl WorkerTasksTable {
                     Cell::from(task_row.run_time.as_str()),
                 ])
             },
+            table_style_selected(),
         );
     }
 }

--- a/crates/hyperqueue/src/dashboard/ui/styles.rs
+++ b/crates/hyperqueue/src/dashboard/ui/styles.rs
@@ -54,6 +54,18 @@ pub fn style_table_highlight() -> Style {
         .fg(Color::Black)
 }
 
-pub fn style_table_row() -> Style {
+pub fn chart_style_deselected() -> Style {
     Style::default().fg(Color::Gray).bg(Color::Black)
+}
+
+pub fn table_style_deselected() -> Style {
+    Style::default().fg(Color::Gray).bg(Color::Black)
+}
+
+pub fn table_style_selected() -> Style {
+    Style::default().fg(Color::Yellow).bg(Color::Black)
+}
+
+pub fn style_no_data() -> Style {
+    Style::default().fg(Color::Magenta).bg(Color::Black)
 }

--- a/crates/hyperqueue/src/dashboard/ui/widgets/table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/widgets/table.rs
@@ -1,4 +1,5 @@
 use tui::layout::{Alignment, Constraint, Rect};
+use tui::style::Style;
 use tui::widgets::{Paragraph, Row, Table, TableState, Wrap};
 
 use crate::dashboard::ui::styles;
@@ -94,6 +95,7 @@ impl<T> StatefulTable<T> {
         frame: &mut DashboardFrame,
         columns: TableColumnHeaders,
         row_cell_mapper: F,
+        table_style: Style,
     ) where
         T: 'a,
         F: Fn(&'a T) -> Row<'a>,
@@ -106,7 +108,7 @@ impl<T> StatefulTable<T> {
             let mut table = Table::new(rows)
                 .block(body_block)
                 .highlight_style(styles::style_table_highlight())
-                .style(styles::style_table_row())
+                .style(table_style)
                 .highlight_symbol(HIGHLIGHT)
                 .widths(&columns.column_widths);
 
@@ -119,6 +121,7 @@ impl<T> StatefulTable<T> {
             let header_text = vec![Spans::from("No data")];
             let paragraph = Paragraph::new(header_text)
                 .block(body_block)
+                .style(styles::style_no_data())
                 .alignment(Alignment::Left)
                 .wrap(Wrap { trim: true });
             frame.render_widget(paragraph, rect);

--- a/crates/hyperqueue/src/server/event/events.rs
+++ b/crates/hyperqueue/src/server/event/events.rs
@@ -31,13 +31,14 @@ pub enum MonitoringEventPayload {
     AllocationQueueRemoved(DescriptorId),
     /// Allocation was submitted into PBS/Slurm
     AllocationQueued {
+        descriptor_id: DescriptorId,
         allocation_id: AllocationId,
         worker_count: u64,
     },
     /// PBS/Slurm allocation started executing
-    AllocationStarted(AllocationId),
+    AllocationStarted(DescriptorId, AllocationId),
     /// PBS/Slurm allocation has finished executing
-    AllocationFinished(AllocationId),
+    AllocationFinished(DescriptorId, AllocationId),
 }
 
 // Keep the size of the event structure in check

--- a/crates/hyperqueue/src/server/event/storage.rs
+++ b/crates/hyperqueue/src/server/event/storage.rs
@@ -100,19 +100,39 @@ impl EventStorage {
         self.insert_event(MonitoringEventPayload::AllocationQueueRemoved(id))
     }
 
-    pub fn on_allocation_queued(&mut self, allocation_id: AllocationId, worker_count: u64) {
+    pub fn on_allocation_queued(
+        &mut self,
+        descriptor_id: DescriptorId,
+        allocation_id: AllocationId,
+        worker_count: u64,
+    ) {
         self.insert_event(MonitoringEventPayload::AllocationQueued {
+            descriptor_id,
             allocation_id,
             worker_count,
         })
     }
 
-    pub fn on_allocation_started(&mut self, allocation_id: AllocationId) {
-        self.insert_event(MonitoringEventPayload::AllocationStarted(allocation_id));
+    pub fn on_allocation_started(
+        &mut self,
+        descriptor_id: DescriptorId,
+        allocation_id: AllocationId,
+    ) {
+        self.insert_event(MonitoringEventPayload::AllocationStarted(
+            descriptor_id,
+            allocation_id,
+        ));
     }
 
-    pub fn on_allocation_finished(&mut self, allocation_id: AllocationId) {
-        self.insert_event(MonitoringEventPayload::AllocationFinished(allocation_id));
+    pub fn on_allocation_finished(
+        &mut self,
+        descriptor_id: DescriptorId,
+        allocation_id: AllocationId,
+    ) {
+        self.insert_event(MonitoringEventPayload::AllocationFinished(
+            descriptor_id,
+            allocation_id,
+        ));
     }
 
     fn insert_event(&mut self, payload: MonitoringEventPayload) {


### PR DESCRIPTION
This screen will show the allocation queues, queue info and the active and past allocations for each queue.
Currently looks like this: 


https://user-images.githubusercontent.com/9003687/156069686-661298df-fd60-4eaf-aba9-00ed6f7112b1.mov



