### PR TITLE
Use hold submit when performing dry-run submission in PBS

### DIFF
--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -229,8 +229,8 @@ async fn dry_run_command(mut connection: ClientConnection, opts: DryRunOpts) -> 
     .await?;
 
     log::info!(
-        "A trial allocation was submitted successfully. It was immediately canceled to avoid wasting
-resources."
+        "A trial allocation was submitted successfully. It was immediately canceled to avoid \
+wasting resources."
     );
     Ok(())
 }
@@ -260,8 +260,8 @@ async fn add_queue(mut connection: ClientConnection, opts: AddQueueOpts) -> anyh
 
     if dry_run {
         log::info!(
-        "A trial allocation was submitted successfully. It was immediately canceled to avoid wasting
-resources."
+            "A trial allocation was submitted successfully. It was immediately canceled to avoid \
+wasting resources."
         );
     }
 

--- a/crates/hyperqueue/src/server/autoalloc/descriptor/mod.rs
+++ b/crates/hyperqueue/src/server/autoalloc/descriptor/mod.rs
@@ -166,6 +166,13 @@ impl AllocationSubmissionResult {
 
 pub type AllocationStatusMap = Map<AllocationId, AutoAllocResult<AllocationStatus>>;
 
+pub enum SubmitMode {
+    /// Submit an allocation in a normal way.
+    Submit,
+    /// Submit an allocation only to test queue parameters.
+    DryRun,
+}
+
 /// Handler that can communicate with some allocation queue (e.g. PBS/Slurm queue)
 pub trait QueueHandler {
     /// Submit an allocation that will start the corresponding number of workers.
@@ -178,6 +185,7 @@ pub trait QueueHandler {
         descriptor_id: DescriptorId,
         queue_info: &QueueInfo,
         worker_count: u64,
+        mode: SubmitMode,
     ) -> Pin<Box<dyn Future<Output = AutoAllocResult<AllocationSubmissionResult>>>>;
 
     /// Get statuses of a set of existing allocations.

--- a/crates/hyperqueue/src/server/autoalloc/descriptor/slurm.rs
+++ b/crates/hyperqueue/src/server/autoalloc/descriptor/slurm.rs
@@ -21,7 +21,7 @@ use crate::server::autoalloc::descriptor::{
 };
 use crate::server::autoalloc::state::AllocationStatus;
 use crate::server::autoalloc::{
-    Allocation, AllocationId, AutoAllocResult, DescriptorId, QueueInfo,
+    Allocation, AllocationId, AutoAllocResult, DescriptorId, QueueInfo, SubmitMode,
 };
 
 pub struct SlurmHandler {
@@ -41,6 +41,7 @@ impl QueueHandler for SlurmHandler {
         descriptor_id: DescriptorId,
         queue_info: &QueueInfo,
         worker_count: u64,
+        _mode: SubmitMode,
     ) -> Pin<Box<dyn Future<Output = AutoAllocResult<AllocationSubmissionResult>>>> {
         let queue_info = queue_info.clone();
         let timelimit = queue_info.timelimit;

--- a/crates/hyperqueue/src/server/autoalloc/mod.rs
+++ b/crates/hyperqueue/src/server/autoalloc/mod.rs
@@ -15,7 +15,7 @@ pub type AutoAllocResult<T> = anyhow::Result<T>;
 
 pub use descriptor::pbs::PbsHandler;
 pub use descriptor::slurm::SlurmHandler;
-pub use descriptor::{QueueDescriptor, QueueHandler, QueueInfo};
+pub use descriptor::{QueueDescriptor, QueueHandler, QueueInfo, SubmitMode};
 pub use process::prepare_descriptor_cleanup;
 pub use state::{
     Allocation, AllocationEvent, AllocationEventHolder, AllocationId, AllocationStatus,

--- a/crates/hyperqueue/src/server/client/autoalloc.rs
+++ b/crates/hyperqueue/src/server/client/autoalloc.rs
@@ -2,7 +2,7 @@ use crate::common::manager::info::ManagerType;
 use crate::common::serverdir::ServerDir;
 use crate::server::autoalloc::{
     prepare_descriptor_cleanup, Allocation, AllocationStatus, DescriptorId, PbsHandler,
-    QueueDescriptor, QueueHandler, QueueInfo, RateLimiter, SlurmHandler,
+    QueueDescriptor, QueueHandler, QueueInfo, RateLimiter, SlurmHandler, SubmitMode,
 };
 use crate::server::state::StateRef;
 use crate::transfer::messages::{
@@ -245,7 +245,7 @@ async fn try_submit_allocation(
     let queue_info = create_queue_info(params);
 
     let allocation = handler
-        .submit_allocation(0, &queue_info, worker_count as u64)
+        .submit_allocation(0, &queue_info, worker_count as u64, SubmitMode::DryRun)
         .await
         .map_err(|e| anyhow::anyhow!("Could not submit allocation: {:?}", e))?;
 


### PR DESCRIPTION
This avoids allocating resources for the dry-run submission needlessly.