### PR TITLE
Refactor worker idle timeout

### DIFF
--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -142,15 +142,15 @@ pub async fn start_hq_worker(
         ended: None,
     });
     let local_set = LocalSet::new();
-    local_set
+    let result = local_set
         .run_until(async move {
             tokio::select! {
-                () = worker_future => {}
-                () = streamer_future => {}
+                res = worker_future => res,
+                () = streamer_future => { Ok(()) }
             }
         })
         .await;
-    Ok(())
+    result.map_err(|e| e.into())
 }
 
 pub async fn get_worker_list(

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -227,6 +227,12 @@ impl Output for CliOutput {
                             reason: LostWorkerReason::Stopped,
                             ..
                         }) => "STOPPED".cell().foreground_color(Some(Color::Magenta)),
+                        Some(WorkerExitInfo {
+                            reason: LostWorkerReason::TimeLimitReached,
+                            ..
+                        }) => "TIME LIMIT REACHED"
+                            .cell()
+                            .foreground_color(Some(Color::Cyan)),
                     },
                     worker.configuration.hostname.cell(),
                     worker.configuration.resources.summary(false).cell(),

--- a/crates/hyperqueue/src/client/output/quiet.rs
+++ b/crates/hyperqueue/src/client/output/quiet.rs
@@ -43,6 +43,10 @@ impl Output for Quiet {
                     ..
                 }) => "IDLE TIMEOUT",
                 Some(WorkerExitInfo {
+                    reason: LostWorkerReason::TimeLimitReached,
+                    ..
+                }) => "TIME LIMIT REACHED",
+                Some(WorkerExitInfo {
                     reason: LostWorkerReason::Stopped,
                     ..
                 }) => "STOPPED",

--- a/crates/hyperqueue/src/server/state.rs
+++ b/crates/hyperqueue/src/server/state.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use tako::messages::gateway::{
-    CancelTasks, FromGatewayMessage, LostWorkerMessage, LostWorkerReason, NewWorkerMessage,
-    TaskFailedMessage, TaskState, TaskUpdate, ToGatewayMessage,
+    CancelTasks, FromGatewayMessage, LostWorkerMessage, NewWorkerMessage, TaskFailedMessage,
+    TaskState, TaskUpdate, ToGatewayMessage,
 };
 
 use crate::server::autoalloc::AutoAllocState;
@@ -219,12 +219,7 @@ impl State {
     pub fn process_worker_lost(&mut self, msg: LostWorkerMessage) {
         log::debug!("Worker lost id={}", msg.worker_id);
         let worker = self.workers.get_mut(&msg.worker_id).unwrap();
-        worker.set_offline_state(match msg.reason {
-            LostWorkerReason::Stopped => LostWorkerReason::Stopped,
-            LostWorkerReason::ConnectionLost => LostWorkerReason::ConnectionLost,
-            LostWorkerReason::HeartbeatLost => LostWorkerReason::HeartbeatLost,
-            LostWorkerReason::IdleTimeout => LostWorkerReason::IdleTimeout,
-        });
+        worker.set_offline_state(msg.reason.clone());
         for task_id in msg.running_tasks {
             let job = self.get_job_mut_by_tako_task_id(task_id).unwrap();
             job.set_waiting_state(task_id);

--- a/crates/tako/src/messages/common.rs
+++ b/crates/tako/src/messages/common.rs
@@ -96,6 +96,17 @@ pub struct WorkerConfiguration {
     pub extra: Map<String, String>,
 }
 
+/// This function is used from both the server and the worker to keep the same values
+/// in the worker configuration without the need for repeated configuration exchange.
+pub fn sync_worker_configuration(
+    configuration: &mut WorkerConfiguration,
+    server_idle_timeout: Option<Duration>,
+) {
+    if configuration.idle_timeout.is_none() {
+        configuration.idle_timeout = server_idle_timeout;
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
 pub struct CpuStats {
     pub cpu_per_core_percent_usage: Vec<f32>,

--- a/crates/tako/src/messages/gateway.rs
+++ b/crates/tako/src/messages/gateway.rs
@@ -198,6 +198,7 @@ pub enum LostWorkerReason {
     ConnectionLost,
     HeartbeatLost,
     IdleTimeout,
+    TimeLimitReached,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/tako/src/messages/worker.rs
+++ b/crates/tako/src/messages/worker.rs
@@ -26,6 +26,7 @@ pub struct WorkerRegistrationResponse {
     pub worker_id: WorkerId,
     pub worker_addresses: Map<WorkerId, String>,
     pub resource_names: Vec<String>,
+    pub server_idle_timeout: Option<Duration>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -142,6 +143,12 @@ pub struct WorkerOverview {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub enum WorkerStopReason {
+    IdleTimeout,
+    TimeLimitReached,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 //#[serde(tag = "op")]
 pub enum FromWorkerMessage {
     TaskFinished(TaskFinishedMsg),
@@ -151,4 +158,5 @@ pub enum FromWorkerMessage {
     StealResponse(StealResponseMsg),
     Overview(WorkerOverview),
     Heartbeat,
+    Stop(WorkerStopReason),
 }

--- a/crates/tako/src/server/worker.rs
+++ b/crates/tako/src/server/worker.rs
@@ -37,13 +37,11 @@ pub struct Worker {
 
     // COLD DATA move it into a box (?)
     pub last_heartbeat: std::time::Instant,
-    pub last_occupied: std::time::Instant,
     pub configuration: WorkerConfiguration,
 }
 
 impl fmt::Debug for Worker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        //let task_ids : Vec<_> = self.tasks.iter().map(|r| r.get().id.to_string()).collect();
         f.debug_struct("Worker")
             .field("id", &self.id)
             .field("resources", &self.configuration.resources)
@@ -171,7 +169,6 @@ impl Worker {
             tasks: Default::default(),
             flags: WorkerFlags::empty(),
             last_heartbeat: now,
-            last_occupied: now,
         }
     }
 }


### PR DESCRIPTION
Changes:
- Worker will now exit with error code 1 if a connection error occurs.
- Worker will now gracefully end its connection with the server if idle timeout happens or time limit is reached.
- Idle timeout is now handled on the worker, not on the server.
- Rare race condition in idle timeout has been resolved.