### PR TITLE
WIP: Enable Timeline Scrubbing

### DIFF
--- a/crates/hyperqueue/src/dashboard/data/mod.rs
+++ b/crates/hyperqueue/src/dashboard/data/mod.rs
@@ -102,9 +102,10 @@ impl DashboardData {
     pub fn query_task_history_for_worker(
         &self,
         worker_id: WorkerId,
+        until_time: SystemTime,
     ) -> impl Iterator<Item = (JobTaskId, &TaskInfo)> + '_ {
         self.job_timeline
-            .get_worker_task_history(worker_id, SystemTime::now())
+            .get_worker_task_history(worker_id, until_time)
     }
 
     /// Gets an iterator over the list of different allocation queues created before `time`.

--- a/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/alloc_timeline_chart.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/alloc_timeline_chart.rs
@@ -45,8 +45,13 @@ pub struct AllocationsChart {
 }
 
 impl AllocationsChart {
-    pub fn update(&mut self, data: &DashboardData, query_descriptor: QueueId) {
-        self.chart_data.end_time = SystemTime::now();
+    pub fn update(
+        &mut self,
+        data: &DashboardData,
+        query_descriptor: QueueId,
+        display_time: SystemTime,
+    ) {
+        self.chart_data.end_time = display_time;
 
         let mut query_time = self.chart_data.end_time - self.chart_data.view_size;
         let mut query_times = vec![];

--- a/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/allocations_info_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/allocations_info_table.rs
@@ -20,8 +20,9 @@ impl AllocationInfoTable {
     pub fn update<'a>(
         &'a mut self,
         allocation_info: impl Iterator<Item = (&'a AllocationId, &'a AllocationInfo)>,
+        display_time: SystemTime,
     ) {
-        let rows = create_rows(allocation_info);
+        let rows = create_rows(allocation_info, display_time);
         self.table.set_items(rows);
     }
 
@@ -104,13 +105,14 @@ impl AllocationInfoTable {
 
 fn create_rows<'a>(
     allocations: impl Iterator<Item = (&'a AllocationId, &'a AllocationInfo)>,
+    display_time: SystemTime,
 ) -> Vec<(AllocationId, AllocationInfo)> {
     let mut info_rows: Vec<(AllocationId, AllocationInfo)> = allocations
         .map(|(alloc_id, info)| (alloc_id.clone(), *info))
         .collect();
 
     info_rows.sort_by_key(|(_, alloc_info_row)| {
-        let status_index = match get_allocation_status(alloc_info_row, SystemTime::now()) {
+        let status_index = match get_allocation_status(alloc_info_row, display_time) {
             AllocationStatus::Running => 0,
             AllocationStatus::Queued => 1,
             AllocationStatus::Finished => 2,

--- a/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/fragment.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/fragment.rs
@@ -70,13 +70,14 @@ impl AutoAllocatorFragment {
         );
     }
 
-    pub fn update(&mut self, data: &DashboardData) {
+    pub fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
         let queue_infos: Vec<(&QueueId, &AllocationQueueInfo)> =
-            data.query_allocation_queues_at(SystemTime::now()).collect();
+            data.query_allocation_queues_at(display_time).collect();
         self.queue_info_table.update(queue_infos);
 
         if let Some(descriptor) = self.queue_info_table.get_selected_queue_descriptor() {
-            self.allocations_chart.update(data, descriptor);
+            self.allocations_chart
+                .update(data, descriptor, display_time);
         }
 
         if let Some(queue_params) = self
@@ -90,9 +91,10 @@ impl AutoAllocatorFragment {
         if let Some(allocations_map) = self
             .queue_info_table
             .get_selected_queue_descriptor()
-            .and_then(|queue_id| data.query_allocations_info_at(queue_id, SystemTime::now()))
+            .and_then(|queue_id| data.query_allocations_info_at(queue_id, display_time))
         {
-            self.allocations_info_table.update(allocations_map);
+            self.allocations_info_table
+                .update(allocations_map, display_time);
         }
     }
 

--- a/crates/hyperqueue/src/dashboard/ui/fragments/job/fragment.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/job/fragment.rs
@@ -61,14 +61,14 @@ impl JobFragment {
         );
     }
 
-    pub fn update(&mut self, data: &DashboardData) {
-        self.jobs_list.update(data);
+    pub fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
+        self.jobs_list.update(data, display_time);
 
         if let Some(job_id) = self.jobs_list.get_selected_item() {
             let task_infos: Vec<(JobTaskId, &TaskInfo)> = data
-                .query_task_history_for_job(job_id, SystemTime::now())
+                .query_task_history_for_job(job_id, display_time)
                 .collect();
-            self.job_tasks_table.update(task_infos);
+            self.job_tasks_table.update(task_infos, display_time);
             self.job_task_chart.set_job_id(job_id);
         } else {
             self.job_task_chart.clear_chart();
@@ -81,7 +81,7 @@ impl JobFragment {
             self.job_info_table.update(job_info);
         }
 
-        self.job_task_chart.update(data);
+        self.job_task_chart.update(data, display_time);
     }
 
     /// Handles key presses for the components of the screen

--- a/crates/hyperqueue/src/dashboard/ui/fragments/job/job_tasks_chart.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/job/job_tasks_chart.rs
@@ -43,10 +43,10 @@ impl JobTaskChart {
 }
 
 impl JobTaskChart {
-    pub fn update(&mut self, data: &DashboardData) {
+    pub fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
         if let Some(job_id) = self.job_id {
             let (num_running_tasks, num_failed_tasks, num_finished_tasks) =
-                get_task_counts_for_job(job_id, data, SystemTime::now());
+                get_task_counts_for_job(job_id, data, display_time);
             self.chart.set_chart_name(
                 format!("Running: {num_running_tasks}, Finished: {num_finished_tasks}, Failed: {num_failed_tasks}").as_str(),
             );
@@ -54,7 +54,7 @@ impl JobTaskChart {
             self.chart
                 .set_chart_name("Please select a Job to show Task counts");
         }
-        self.chart.update(data);
+        self.chart.update(data, display_time);
     }
 
     pub fn draw(&mut self, rect: Rect, frame: &mut DashboardFrame) {

--- a/crates/hyperqueue/src/dashboard/ui/fragments/job/jobs_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/job/jobs_table.rs
@@ -19,9 +19,9 @@ pub struct JobsTable {
 }
 
 impl JobsTable {
-    pub fn update(&mut self, data: &DashboardData) {
+    pub fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
         let jobs: Vec<(&JobId, &DashboardJobInfo)> =
-            data.query_jobs_created_before(SystemTime::now()).collect();
+            data.query_jobs_created_before(display_time).collect();
         let rows = create_rows(jobs);
         self.table.set_items(rows);
     }

--- a/crates/hyperqueue/src/dashboard/ui/fragments/overview/cluster_overview_chart.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/overview/cluster_overview_chart.rs
@@ -18,17 +18,19 @@ struct WorkerCountRecord {
 pub struct ClusterOverviewChart {
     /// Worker count records that should be currently displayed.
     worker_records: Vec<WorkerCountRecord>,
-    /// The time for which the data is plotted for.
+    /// The duration for which the data is plotted for.
     view_size: Duration,
+    /// The time until which data is plotted for.
+    end_time: SystemTime,
 }
 
 impl ClusterOverviewChart {
-    pub fn update(&mut self, data: &DashboardData) {
-        let end = SystemTime::now();
-        let mut start = end - self.view_size;
+    pub fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
+        self.end_time = display_time;
+        let mut start = self.end_time - self.view_size;
         let mut times = vec![];
 
-        while start <= end {
+        while start <= self.end_time {
             times.push(start);
             start += Duration::from_secs(1);
         }
@@ -78,8 +80,8 @@ impl ClusterOverviewChart {
                     .title("time ->")
                     .style(Style::default().fg(Color::Gray))
                     .bounds([
-                        get_time_as_secs(SystemTime::now() - self.view_size) as f64,
-                        get_time_as_secs(SystemTime::now()) as f64,
+                        get_time_as_secs(self.end_time - self.view_size) as f64,
+                        get_time_as_secs(self.end_time) as f64,
                     ]),
             )
             .y_axis(
@@ -100,6 +102,7 @@ impl Default for ClusterOverviewChart {
         Self {
             worker_records: vec![],
             view_size: Duration::from_secs(300),
+            end_time: SystemTime::now(),
         }
     }
 }

--- a/crates/hyperqueue/src/dashboard/ui/fragments/overview/fragment.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/overview/fragment.rs
@@ -1,3 +1,4 @@
+use std::time::SystemTime;
 use termion::event::Key;
 
 use crate::dashboard::ui::fragments::overview::cluster_overview_chart::ClusterOverviewChart;
@@ -32,9 +33,9 @@ impl ClusterOverviewFragment {
             .draw(layout.worker_util_table_chunk, frame);
     }
 
-    pub fn update(&mut self, data: &DashboardData) {
-        self.worker_util_table.update(data);
-        self.cluster_overview.update(data);
+    pub fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
+        self.worker_util_table.update(data, display_time);
+        self.cluster_overview.update(data, display_time);
     }
 
     /// Handles key presses for the components of the screen

--- a/crates/hyperqueue/src/dashboard/ui/fragments/overview/worker_utilization_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/overview/worker_utilization_table.rs
@@ -18,8 +18,8 @@ pub struct WorkerUtilTable {
 }
 
 impl WorkerUtilTable {
-    pub fn update(&mut self, data: &DashboardData) {
-        let overview = data.query_last_received_overviews(SystemTime::now());
+    pub fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
+        let overview = data.query_last_received_overviews(display_time);
         let rows = create_rows(overview);
         self.table.set_items(rows);
     }

--- a/crates/hyperqueue/src/dashboard/ui/screen/mod.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screen/mod.rs
@@ -1,3 +1,4 @@
+use std::time::SystemTime;
 use termion::event::Key;
 use tui::layout::Rect;
 
@@ -6,6 +7,6 @@ use crate::dashboard::ui::terminal::DashboardFrame;
 
 pub trait Screen {
     fn draw(&mut self, in_area: Rect, frame: &mut DashboardFrame);
-    fn update(&mut self, data: &DashboardData);
+    fn update(&mut self, data: &DashboardData, display_time: SystemTime);
     fn handle_key(&mut self, key: Key);
 }

--- a/crates/hyperqueue/src/dashboard/ui/screens/autoalloc_screen.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/autoalloc_screen.rs
@@ -2,6 +2,7 @@ use crate::dashboard::data::DashboardData;
 use crate::dashboard::ui::fragments::auto_allocator::fragment::AutoAllocatorFragment;
 use crate::dashboard::ui::screen::Screen;
 use crate::dashboard::ui::terminal::DashboardFrame;
+use std::time::SystemTime;
 use termion::event::Key;
 use tui::layout::Rect;
 
@@ -15,8 +16,8 @@ impl Screen for AutoAllocScreen {
         self.auto_allocator_fragment.draw(in_area, frame);
     }
 
-    fn update(&mut self, data: &DashboardData) {
-        self.auto_allocator_fragment.update(data);
+    fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
+        self.auto_allocator_fragment.update(data, display_time);
     }
 
     fn handle_key(&mut self, key: Key) {

--- a/crates/hyperqueue/src/dashboard/ui/screens/job_screen.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/job_screen.rs
@@ -3,6 +3,7 @@ use crate::dashboard::ui::fragments::job::fragment::JobFragment;
 use crate::dashboard::ui::fragments::worker::fragment::WorkerOverviewFragment;
 use crate::dashboard::ui::screen::Screen;
 use crate::dashboard::ui::terminal::DashboardFrame;
+use std::time::SystemTime;
 use termion::event::Key;
 use tui::layout::Rect;
 
@@ -26,10 +27,10 @@ impl Screen for JobScreen {
         }
     }
 
-    fn update(&mut self, data: &DashboardData) {
+    fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
         match self.active_fragment {
-            ScreenState::JobInfo => self.job_overview_fragment.update(data),
-            ScreenState::TaskWorkerDetail => self.task_runner_worker.update(data),
+            ScreenState::JobInfo => self.job_overview_fragment.update(data, display_time),
+            ScreenState::TaskWorkerDetail => self.task_runner_worker.update(data, display_time),
         }
     }
 

--- a/crates/hyperqueue/src/dashboard/ui/screens/overview_screen.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/overview_screen.rs
@@ -3,6 +3,7 @@ use crate::dashboard::ui::fragments::overview::fragment::ClusterOverviewFragment
 use crate::dashboard::ui::fragments::worker::fragment::WorkerOverviewFragment;
 use crate::dashboard::ui::screen::Screen;
 use crate::dashboard::ui::terminal::DashboardFrame;
+use std::time::SystemTime;
 use termion::event::Key;
 use tui::layout::Rect;
 
@@ -26,10 +27,10 @@ impl Screen for OverviewScreen {
         }
     }
 
-    fn update(&mut self, data: &DashboardData) {
+    fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
         match self.active_fragment {
-            ScreenState::ClusterOverview => self.cluster_overview.update(data),
-            ScreenState::WorkerInfo => self.worker_overview.update(data),
+            ScreenState::ClusterOverview => self.cluster_overview.update(data, display_time),
+            ScreenState::WorkerInfo => self.worker_overview.update(data, display_time),
         }
     }
 

--- a/crates/hyperqueue/src/dashboard/ui/screens/root_screen.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/root_screen.rs
@@ -51,6 +51,20 @@ impl TimelineScrubber {
             self.display_time = time_range.fetched_until;
         }
     }
+
+    pub fn scrub_reverse(&mut self) {
+        let past_time = self.display_time - self.scrub_duration;
+        if past_time > self.time_range.fetched_from {
+            self.display_time = past_time;
+        }
+    }
+
+    pub fn scrub_forward(&mut self) {
+        let future_time = self.display_time + self.scrub_duration;
+        if future_time < self.time_range.fetched_until {
+            self.display_time = future_time;
+        }
+    }
 }
 
 impl RootScreen {
@@ -61,7 +75,7 @@ impl RootScreen {
             .draw(|frame| {
                 let screen_state = self.current_screen;
                 let screen = self.get_current_screen_mut();
-                screen.update(data);
+                screen.update(data, timeline_scrubber.display_time);
 
                 render_screen_tabs(
                     screen_state,
@@ -92,6 +106,17 @@ impl RootScreen {
             }
             Key::Char('w') => {
                 self.current_screen = DashboardScreenState::WorkerOverview;
+            }
+            Key::Left => {
+                self.timeline_scrubber.is_live = false;
+                self.timeline_scrubber.scrub_reverse();
+            }
+            Key::Right => {
+                self.timeline_scrubber.is_live = false;
+                self.timeline_scrubber.scrub_forward();
+            }
+            Key::Char('l') => {
+                self.timeline_scrubber.is_live = true;
             }
 
             _ => {

--- a/crates/hyperqueue/src/dashboard/ui/widgets/chart.rs
+++ b/crates/hyperqueue/src/dashboard/ui/widgets/chart.rs
@@ -26,8 +26,6 @@ pub struct DashboardChart {
     end_time: SystemTime,
     /// The duration for which the data is plotted for.
     view_size: Duration,
-    /// if true, the `end_time` is always updated to current time.
-    is_live: bool,
 }
 
 #[derive(Copy, Clone)]
@@ -60,10 +58,8 @@ impl DashboardChart {
         self.chart_plotters.push(chart_plotter);
     }
 
-    pub fn update(&mut self, data: &DashboardData) {
-        if self.is_live {
-            self.end_time = SystemTime::now();
-        }
+    pub fn update(&mut self, data: &DashboardData, display_time: SystemTime) {
+        self.end_time = display_time;
         // Clears the old data, TODO: load only the new data points
         self.datasets.clear();
         let mut start = self.end_time - self.view_size;
@@ -174,7 +170,6 @@ impl Default for DashboardChart {
             dataset_styles: Default::default(),
             end_time: SystemTime::now(),
             view_size: Duration::from_secs(300),
-            is_live: true,
         }
     }
 }


### PR DESCRIPTION
This PR aims to add timeline scrubbing to the dashboard:

When it's done:

1. One will be able to press <- -> arrow keys to change the time for which the data is shown on the dashboard.
2. Press 'l' to restore dashboard back to live mode.
3. Press +, - to change the duration of data that is shown on the dashboard charts.