### PR TITLE
Serialize MonitoringEvents in Chunks

### DIFF
--- a/crates/hyperqueue/src/server/event/log/mod.rs
+++ b/crates/hyperqueue/src/server/event/log/mod.rs
@@ -6,6 +6,7 @@ pub use read::EventLogReader;
 pub use stream::{start_event_streaming, EventStreamSender};
 pub use write::EventLogWriter;
 
+use crate::server::event::MonitoringEventId;
 use bstr::BString;
 use serde::{Deserialize, Serialize};
 
@@ -23,4 +24,12 @@ fn canonical_header() -> LogFileHeader {
 struct LogFileHeader {
     header: BString,
     version: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EventChunkHeader {
+    /// The first event id in the compressed event chunk.
+    pub first_event_id: MonitoringEventId,
+    /// The compressed size in bytes of the event chunk.
+    pub chunk_length: usize,
 }

--- a/crates/hyperqueue/src/server/event/log/read.rs
+++ b/crates/hyperqueue/src/server/event/log/read.rs
@@ -1,28 +1,18 @@
 use crate::server::event::log::write::EventChunkHeader;
 use crate::server::event::log::{canonical_header, LogFileHeader};
-use crate::server::event::{MonitoringEvent, MonitoringEventId};
+use crate::server::event::MonitoringEvent;
 use anyhow::anyhow;
 use flate2::read::GzDecoder;
 use rmp_serde::decode::Error;
 use std::fs::File;
-use std::io::{Seek, SeekFrom};
+use std::io::{Cursor, ErrorKind, Seek, SeekFrom};
 use std::os::unix::fs::FileExt;
 use std::path::Path;
 
 /// Reads events from a file in a streaming fashion.
 pub struct EventLogReader {
     source: File,
-
-    event_chunks: Vec<(MonitoringEventId, EventChunk)>,
-    current_chunk_index: usize,
-
-    current_decoded_chunk: Vec<MonitoringEvent>,
-    index_in_decoded_chunk: usize,
-}
-
-struct EventChunk {
-    begin_index: usize,
-    size: usize,
+    current_chunk: GzDecoder<Cursor<Vec<u8>>>,
 }
 
 impl EventLogReader {
@@ -37,73 +27,10 @@ impl EventLogReader {
                 "Invalid HQ event log file header.\nFound: {header:?}\nExpected: {expected_header:?}"
             ));
         }
-        let event_chunks = build_index(&mut source)?;
         Ok(Self {
             source,
-            event_chunks,
-            current_chunk_index: 0,
-            current_decoded_chunk: vec![],
-            index_in_decoded_chunk: 0,
+            current_chunk: GzDecoder::new(Default::default()),
         })
-    }
-
-    /// Decodes the next event chunk, returns false if no next chunk exists.
-    fn decode_next_chunk(&mut self) -> anyhow::Result<bool> {
-        self.current_decoded_chunk.clear();
-        self.index_in_decoded_chunk = 0;
-
-        if self.current_chunk_index >= self.event_chunks.len() {
-            return Ok(false);
-        }
-
-        let chunk = &self.event_chunks[self.current_chunk_index];
-        let mut buffer = vec![0; chunk.1.size];
-        self.source
-            .read_at(&mut buffer, chunk.1.begin_index as u64)?;
-
-        let mut decoder = GzDecoder::new(&buffer[..]);
-        loop {
-            let event: Result<MonitoringEvent, Error> = rmp_serde::from_read(&mut decoder);
-            match event {
-                Ok(event) => {
-                    self.current_decoded_chunk.push(event);
-                }
-                Err(Error::InvalidMarkerRead(_)) => {
-                    // finished reading current chunk
-                    self.current_chunk_index += 1;
-                    return Ok(true);
-                }
-                Err(error) => {
-                    return Ok(false);
-                }
-            }
-        }
-    }
-}
-
-/// Read all chunk headers from the file and store them.
-fn build_index(mut events_file: &mut File) -> anyhow::Result<Vec<(MonitoringEventId, EventChunk)>> {
-    let mut chunks: Vec<(MonitoringEventId, EventChunk)> = vec![];
-    loop {
-        let header: Result<EventChunkHeader, Error> = rmp_serde::from_read(&mut events_file);
-        match header {
-            Ok(chunk) => {
-                let current = events_file.seek(SeekFrom::Current(0_i64))?;
-                chunks.push((
-                    chunk.first_event_id,
-                    EventChunk {
-                        begin_index: current as usize,
-                        size: chunk.chunk_length,
-                    },
-                ));
-                let _ = events_file.seek(SeekFrom::Current(chunk.chunk_length as i64))?;
-            }
-            //todo: if invalid marker read, ok, otherwise propagate error
-            Err(_error) => {
-                events_file.seek(SeekFrom::Start(0))?;
-                return Ok(chunks);
-            }
-        }
     }
 }
 
@@ -112,20 +39,35 @@ impl Iterator for EventLogReader {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.index_in_decoded_chunk < self.current_decoded_chunk.len() {
-            let next_event = self.current_decoded_chunk[self.index_in_decoded_chunk].clone();
-            self.index_in_decoded_chunk += 1;
-            Some(Ok(next_event))
-        } else {
-            match self.decode_next_chunk() {
-                Ok(has_more) if has_more => {
-                    let next_event =
-                        self.current_decoded_chunk[self.index_in_decoded_chunk].clone();
-                    self.index_in_decoded_chunk += 1;
-                    Some(Ok(next_event))
+        let event: Result<MonitoringEvent, Error> = rmp_serde::from_read(&mut self.current_chunk);
+        match event {
+            Ok(event) => Some(Ok(event)),
+            Err(Error::InvalidMarkerRead(error))
+                if matches!(error.kind(), ErrorKind::UnexpectedEof) =>
+            {
+                let next_header: Result<EventChunkHeader, Error> =
+                    rmp_serde::from_read(&mut self.source);
+                match next_header {
+                    Ok(chunk_header) => {
+                        let begin_index = self.source.seek(SeekFrom::Current(0_i64)).ok()?;
+                        let mut buffer = vec![0; chunk_header.chunk_length];
+                        self.source.read_at(&mut buffer, begin_index as u64).ok()?;
+                        self.current_chunk = GzDecoder::new(Cursor::new(buffer));
+                        let _ = self
+                            .source
+                            .seek(SeekFrom::Current(chunk_header.chunk_length as i64))
+                            .ok()?;
+                        self.next()
+                    }
+                    Err(Error::InvalidMarkerRead(error))
+                        if matches!(error.kind(), ErrorKind::UnexpectedEof) =>
+                    {
+                        None
+                    }
+                    Err(error) => Some(Err(error)),
                 }
-                _ => None,
             }
+            Err(error) => Some(Err(error)),
         }
     }
 }

--- a/crates/hyperqueue/src/server/event/log/read.rs
+++ b/crates/hyperqueue/src/server/event/log/read.rs
@@ -1,5 +1,4 @@
-use crate::server::event::log::write::EventChunkHeader;
-use crate::server::event::log::{canonical_header, LogFileHeader};
+use crate::server::event::log::{canonical_header, EventChunkHeader, LogFileHeader};
 use crate::server::event::MonitoringEvent;
 use anyhow::anyhow;
 use flate2::read::GzDecoder;

--- a/crates/hyperqueue/src/server/event/log/write.rs
+++ b/crates/hyperqueue/src/server/event/log/write.rs
@@ -1,18 +1,28 @@
 use crate::server::event::log::canonical_header;
-use crate::server::event::MonitoringEvent;
+use crate::server::event::{MonitoringEvent, MonitoringEventId};
 use async_compression::tokio::write::GzipEncoder;
 use async_compression::Level;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 /// Streams monitoring events into a file on disk.
 pub struct EventLogWriter {
-    file: GzipEncoder<File>,
+    file: File,
     buffer: Vec<u8>,
+
+    /// The ID of the first event in current buffer.
+    first_event_in_buffer: MonitoringEventId,
 }
 
-const BUF_MAX_SIZE: usize = 16 * 1024;
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EventChunkHeader {
+    pub first_event_id: MonitoringEventId,
+    pub chunk_length: usize,
+}
+
+pub const CHUNK_MAX_SIZE: usize = 16 * 1024;
 
 impl EventLogWriter {
     pub async fn create(path: &Path) -> anyhow::Result<Self> {
@@ -21,17 +31,21 @@ impl EventLogWriter {
         file.write_all(&header).await?;
         file.flush().await?;
 
-        let file = GzipEncoder::with_quality(file, Level::Fastest);
-
-        // Keep buffer capacity larger than max size to avoid reallocation if we overflow
-        // the buffer.
-        let buffer = Vec::with_capacity(BUF_MAX_SIZE * 2);
-        Ok(Self { file, buffer })
+        let buffer = Vec::with_capacity(CHUNK_MAX_SIZE * 2);
+        Ok(Self {
+            file,
+            buffer,
+            first_event_in_buffer: 0,
+        })
     }
 
     #[inline]
     pub async fn store(&mut self, event: MonitoringEvent) -> anyhow::Result<()> {
+        if self.buffer.is_empty() {
+            self.first_event_in_buffer = event.id;
+        }
         rmp_serde::encode::write(&mut self.buffer, &event)?;
+
         if self.is_buffer_full() {
             self.write_buffer().await?;
         }
@@ -52,14 +66,26 @@ impl EventLogWriter {
         Ok(())
     }
 
-    async fn write_buffer(&mut self) -> tokio::io::Result<()> {
-        self.file.write_all(&self.buffer).await?;
+    async fn write_buffer(&mut self) -> anyhow::Result<()> {
+        let mut buffer_gzipped =
+            GzipEncoder::with_quality(Vec::with_capacity(CHUNK_MAX_SIZE * 2), Level::Fastest);
+
+        let _ = buffer_gzipped.write_all(&self.buffer).await?;
+        let _ = buffer_gzipped.flush().await;
+        let _ = buffer_gzipped.shutdown().await;
+
+        let chunk_header = rmp_serde::encode::to_vec(&EventChunkHeader {
+            first_event_id: self.first_event_in_buffer,
+            chunk_length: buffer_gzipped.get_ref().len(),
+        })?;
+        self.file.write_all(&chunk_header).await?;
+        self.file.write_all(buffer_gzipped.get_ref()).await?;
         self.buffer.clear();
         Ok(())
     }
 
     #[inline]
     fn is_buffer_full(&self) -> bool {
-        self.buffer.len() >= BUF_MAX_SIZE
+        self.buffer.len() >= CHUNK_MAX_SIZE
     }
 }

--- a/crates/hyperqueue/src/server/event/log/write.rs
+++ b/crates/hyperqueue/src/server/event/log/write.rs
@@ -8,9 +8,10 @@ use tokio::io::AsyncWriteExt;
 
 /// Streams monitoring events into a file on disk.
 pub struct EventLogWriter {
-    file: File,
+    log_file: File,
     state: WriterState,
     uncompressed_buffer: Vec<u8>,
+    gzip_buffer: Vec<u8>,
 }
 
 /// The states the log writer can be in.
@@ -31,10 +32,12 @@ impl EventLogWriter {
         file.flush().await?;
 
         let uncompressed_buffer = Vec::with_capacity(CHUNK_MAX_SIZE * 2);
+        let gzip_buffer = Vec::with_capacity(CHUNK_MAX_SIZE * 2);
         Ok(Self {
-            file,
+            log_file: file,
             state: WriterState::EmptyChunk,
             uncompressed_buffer,
+            gzip_buffer,
         })
     }
 
@@ -42,18 +45,18 @@ impl EventLogWriter {
     pub async fn store(&mut self, event: MonitoringEvent) -> anyhow::Result<()> {
         match self.state {
             WriterState::EmptyChunk => {
+                self.write_event(&event)?;
                 self.set_state(WriterState::ChunkInProgress(event.id));
-                self.write_event(event)?;
             }
             WriterState::ChunkInProgress(first_event_id) => {
                 if self.is_buffer_full() {
-                    self.write_event(event)?;
+                    self.write_event(&event)?;
 
                     self.compress_and_write_buffer(first_event_id).await?;
                     self.uncompressed_buffer.clear();
                     self.set_state(WriterState::EmptyChunk);
                 } else {
-                    self.write_event(event)?;
+                    self.write_event(&event)?;
                 }
             }
         }
@@ -64,27 +67,24 @@ impl EventLogWriter {
         if let WriterState::ChunkInProgress(first_event_id) = self.state {
             self.compress_and_write_buffer(first_event_id).await?;
         }
-        self.file.flush().await?;
+        self.log_file.flush().await?;
         Ok(())
     }
 
     pub async fn finish(mut self) -> anyhow::Result<()> {
         self.flush().await?;
-        self.file.shutdown().await?;
+        self.log_file.shutdown().await?;
         Ok(())
     }
 
     /// Writes event to the uncompressed_buffer
-    fn write_event(&mut self, event: MonitoringEvent) -> anyhow::Result<()> {
-        rmp_serde::encode::write(&mut self.uncompressed_buffer, &event)?;
+    fn write_event(&mut self, event: &MonitoringEvent) -> anyhow::Result<()> {
+        rmp_serde::encode::write(&mut self.uncompressed_buffer, event)?;
         Ok(())
     }
 
     fn is_buffer_full(&self) -> bool {
-        if self.uncompressed_buffer.len() > CHUNK_MAX_SIZE {
-            return true;
-        }
-        false
+        self.uncompressed_buffer.len() > CHUNK_MAX_SIZE
     }
 
     /// Change the state of the writer
@@ -97,9 +97,7 @@ impl EventLogWriter {
         &mut self,
         first_event_id: MonitoringEventId,
     ) -> anyhow::Result<()> {
-        let mut buffer_gzipped =
-            GzipEncoder::with_quality(Vec::with_capacity(CHUNK_MAX_SIZE * 2), Level::Fastest);
-
+        let mut buffer_gzipped = GzipEncoder::with_quality(&mut self.gzip_buffer, Level::Fastest);
         buffer_gzipped.write_all(&self.uncompressed_buffer).await?;
         buffer_gzipped.shutdown().await?;
 
@@ -108,7 +106,7 @@ impl EventLogWriter {
             chunk_length: buffer_gzipped.get_ref().len(),
         })?;
         chunk_header.append(buffer_gzipped.get_mut());
-        self.file.write_all(&chunk_header).await?;
+        self.log_file.write_all(&chunk_header).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
This will allow us to efficiently read a range of events from the file without reading the entire file.

Dashboard needs to query only the range of events that are currently visible on it.