### PR TITLE
Add local cluster to python API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - uses: messense/maturin-action@v1
+        env:
+          CARGO_PROFILE_RELEASE_PANIC: unwind
+          CARGO_PROFILE_RELEASE_STRIP: none
         with:
           maturin-version: latest
           manylinux: 2014

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,10 +1358,13 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "hyperqueue",
+ "log",
  "pyo3",
  "pyo3-asyncio",
  "pythonize",
  "serde",
+ "tempdir",
+ "termcolor",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ default-members = [
 lto = true
 codegen-units = 1
 opt-level = 3
-# TODO: disable panic = "abort" for pyhq build
 panic = "abort"
 strip = "debuginfo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,10 @@ default-members = [
     "crates/tako"
 ]
 
-[profile.dev]
-panic = "abort"
-
 [profile.release]
 lto = true
 codegen-units = 1
 opt-level = 3
+# TODO: disable panic = "abort" for pyhq build
 panic = "abort"
 strip = "debuginfo"

--- a/crates/hyperqueue/src/client/commands/server.rs
+++ b/crates/hyperqueue/src/client/commands/server.rs
@@ -1,5 +1,6 @@
 use crate::client::globalsettings::GlobalSettings;
 use crate::client::server::client_stop_server;
+use crate::common::utils::network::get_hostname;
 use crate::common::utils::time::ArgDuration;
 use crate::rpc_call;
 use crate::server::bootstrap::{
@@ -73,9 +74,7 @@ pub async fn command_server(gsettings: &GlobalSettings, opts: ServerOpts) -> any
 
 async fn start_server(gsettings: &GlobalSettings, opts: ServerStartOpts) -> anyhow::Result<()> {
     let server_cfg = ServerConfig {
-        host: opts
-            .host
-            .unwrap_or_else(|| gethostname::gethostname().into_string().unwrap()),
+        host: get_hostname(opts.host),
         idle_timeout: opts.idle_timeout.map(|x| x.unpack()),
         client_port: opts.client_port,
         worker_port: opts.worker_port,

--- a/crates/hyperqueue/src/common/utils/mod.rs
+++ b/crates/hyperqueue/src/common/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod controlflow;
 pub mod fs;
+pub mod network;
 pub mod str;
 pub mod time;

--- a/crates/hyperqueue/src/common/utils/network.rs
+++ b/crates/hyperqueue/src/common/utils/network.rs
@@ -1,0 +1,7 @@
+pub fn get_hostname(preferred: Option<String>) -> String {
+    preferred.unwrap_or_else(|| {
+        gethostname::gethostname()
+            .into_string()
+            .expect("Invalid hostname")
+    })
+}

--- a/crates/hyperqueue/src/server/bootstrap.rs
+++ b/crates/hyperqueue/src/server/bootstrap.rs
@@ -19,7 +19,6 @@ use crate::server::rpc::Backend;
 use crate::server::state::StateRef;
 use crate::transfer::auth::generate_key;
 use crate::transfer::connection::{ClientConnection, HqConnection};
-use std::rc::Rc;
 use std::time::Duration;
 
 enum ServerStatus {
@@ -104,10 +103,10 @@ async fn get_server_status(server_directory: &Path) -> crate::Result<ServerStatu
     Ok(ServerStatus::Online(record))
 }
 
-async fn initialize_server(
+pub async fn initialize_server(
     gsettings: &GlobalSettings,
     server_cfg: ServerConfig,
-) -> anyhow::Result<(impl Future<Output = anyhow::Result<()>>, Rc<Notify>)> {
+) -> anyhow::Result<(impl Future<Output = anyhow::Result<()>>, Arc<Notify>)> {
     let server_directory = gsettings.server_directory();
 
     let client_listener = TcpListener::bind(SocketAddr::new(
@@ -148,7 +147,7 @@ async fn initialize_server(
         .printer()
         .print_server_record(server_directory, &record);
 
-    let end_flag = Rc::new(Notify::new());
+    let end_flag = Arc::new(Notify::new());
     let end_flag_check = end_flag.clone();
     let end_flag_ret = end_flag.clone();
 
@@ -268,11 +267,11 @@ mod tests {
     use cli_table::ColorChoice;
     use std::future::Future;
     use std::path::Path;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     pub async fn init_test_server(
         tmp_dir: &Path,
-    ) -> (impl Future<Output = anyhow::Result<()>>, Rc<Notify>) {
+    ) -> (impl Future<Output = anyhow::Result<()>>, Arc<Notify>) {
         // Create global settings with CliOutput
         let gsettings = GlobalSettings::new(
             tmp_dir.to_path_buf(),

--- a/crates/hyperqueue/src/server/client/mod.rs
+++ b/crates/hyperqueue/src/server/client/mod.rs
@@ -1,4 +1,3 @@
-use std::rc::Rc;
 use std::sync::Arc;
 
 use futures::{Sink, SinkExt, Stream, StreamExt};
@@ -34,7 +33,7 @@ pub async fn handle_client_connections(
     tako_ref: Backend,
     server_dir: ServerDir,
     listener: TcpListener,
-    end_flag: Rc<Notify>,
+    end_flag: Arc<Notify>,
     key: Arc<SecretKey>,
 ) {
     let group = TaskGroup::default();
@@ -60,7 +59,7 @@ async fn handle_client(
     server_dir: ServerDir,
     state_ref: StateRef,
     tako_ref: Backend,
-    end_flag: Rc<Notify>,
+    end_flag: Arc<Notify>,
     key: Arc<SecretKey>,
 ) -> crate::Result<()> {
     log::debug!("New client connection");
@@ -81,7 +80,7 @@ pub async fn client_rpc_loop<
     server_dir: ServerDir,
     state_ref: StateRef,
     tako_ref: Backend,
-    end_flag: Rc<Notify>,
+    end_flag: Arc<Notify>,
 ) {
     while let Some(message_result) = rx.next().await {
         match message_result {

--- a/crates/hyperqueue/src/worker/bootstrap.rs
+++ b/crates/hyperqueue/src/worker/bootstrap.rs
@@ -1,0 +1,144 @@
+use std::future::Future;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context};
+use tokio::net::lookup_host;
+use tokio::sync::Notify;
+use tokio::task::LocalSet;
+
+use tako::common::error::DsError;
+use tako::messages::common::WorkerConfiguration;
+use tako::worker::rpc::run_worker;
+use tako::WorkerId;
+
+use crate::common::manager::info::{ManagerInfo, ManagerType};
+use crate::common::manager::{pbs, slurm};
+use crate::common::serverdir::ServerDir;
+use crate::worker::start::{HqTaskLauncher, WORKER_EXTRA_PROCESS_PID};
+use crate::worker::streamer::StreamerRef;
+
+pub type WorkerStopFlag = Arc<Notify>;
+
+pub struct InitializedWorker {
+    pub id: WorkerId,
+    pub configuration: WorkerConfiguration,
+    pub stop_flag: WorkerStopFlag,
+}
+
+pub async fn initialize_worker(
+    server_directory: &Path,
+    configuration: WorkerConfiguration,
+) -> anyhow::Result<(impl Future<Output = Result<(), DsError>>, InitializedWorker)> {
+    log::info!("Starting hyperqueue worker {}", env!("CARGO_PKG_VERSION"));
+    let server_dir = ServerDir::open(server_directory).context("Cannot load server directory")?;
+    let record = server_dir.read_access_record().with_context(|| {
+        format!(
+            "Cannot load access record from {:?}",
+            server_dir.access_filename()
+        )
+    })?;
+    let server_address = format!("{}:{}", record.host(), record.worker_port());
+    log::info!("Connecting to: {}", server_address);
+
+    std::fs::create_dir_all(&configuration.work_dir)?;
+    std::fs::create_dir_all(&configuration.log_dir)?;
+
+    let server_addr = lookup_host(&server_address)
+        .await?
+        .next()
+        .expect("Invalid server address");
+
+    log::debug!("Starting streamer ...");
+    let (streamer_ref, streamer_future) = StreamerRef::start(
+        Duration::from_secs(10),
+        server_addr,
+        record.tako_secret_key().clone(),
+    );
+
+    log::debug!("Starting Tako worker ...");
+    let ((worker_id, configuration), worker_future) = run_worker(
+        server_addr,
+        configuration,
+        Some(record.tako_secret_key().clone()),
+        Box::new(HqTaskLauncher::new(streamer_ref)),
+    )
+    .await?;
+
+    let stop_flag = Arc::new(Notify::new());
+    let worker = InitializedWorker {
+        id: worker_id,
+        configuration,
+        stop_flag: stop_flag.clone(),
+    };
+
+    let future = async move {
+        let local_set = LocalSet::new();
+        local_set
+            .run_until(async move {
+                tokio::select! {
+                    res = worker_future => res,
+                    () = streamer_future => { Ok(()) },
+                    () = stop_flag.notified() => { Ok(()) }
+                }
+            })
+            .await
+    };
+    Ok((future, worker))
+}
+
+/// Utility function that adds common data to an already created worker configuration.
+pub fn finalize_configuration(conf: &mut WorkerConfiguration) {
+    conf.extra.insert(
+        WORKER_EXTRA_PROCESS_PID.to_string(),
+        std::process::id().to_string(),
+    );
+}
+
+pub fn try_get_pbs_info() -> anyhow::Result<ManagerInfo> {
+    log::debug!("Detecting PBS environment");
+
+    std::env::var("PBS_ENVIRONMENT")
+        .map_err(|_| anyhow!("PBS_ENVIRONMENT not found. The process is not running under PBS"))?;
+
+    let manager_job_id =
+        std::env::var("PBS_JOBID").expect("PBS_JOBID not found in environment variables");
+
+    let time_limit = match pbs::get_remaining_timelimit(&manager_job_id) {
+        Ok(time_limit) => Some(time_limit),
+        Err(error) => {
+            log::warn!("Cannot get time-limit from PBS: {error:?}");
+            None
+        }
+    };
+
+    log::info!("PBS environment detected");
+
+    Ok(ManagerInfo::new(
+        ManagerType::Pbs,
+        manager_job_id,
+        time_limit,
+    ))
+}
+
+pub fn try_get_slurm_info() -> anyhow::Result<ManagerInfo> {
+    log::debug!("Detecting SLURM environment");
+
+    let manager_job_id = std::env::var("SLURM_JOB_ID")
+        .or_else(|_| std::env::var("SLURM_JOBID"))
+        .map_err(|_| {
+            anyhow!("SLURM_JOB_ID/SLURM_JOBID not found. The process is not running under SLURM")
+        })?;
+
+    let duration = slurm::get_remaining_timelimit(&manager_job_id)
+        .expect("Could not get remaining time from scontrol");
+
+    log::info!("SLURM environment detected");
+
+    Ok(ManagerInfo::new(
+        ManagerType::Slurm,
+        manager_job_id,
+        Some(duration),
+    ))
+}

--- a/crates/hyperqueue/src/worker/mod.rs
+++ b/crates/hyperqueue/src/worker/mod.rs
@@ -1,3 +1,4 @@
+pub mod bootstrap;
 pub mod hwdetect;
 pub mod parser;
 pub mod start;

--- a/crates/pyhq/Cargo.toml
+++ b/crates/pyhq/Cargo.toml
@@ -15,7 +15,7 @@ name = "hyperqueue"
 crate-type = ["cdylib"]
 
 [dependencies]
-hyperqueue_core = { path = "../hyperqueue", package = "hyperqueue" }
+hyperqueue = { path = "../hyperqueue" }
 pyo3 = { version = "0.15", features = ["extension-module", "abi3", "abi3-py36", "anyhow"] }
 pyo3-asyncio = { version = "0.15", features = ["tokio-runtime", "attributes"] }
 pythonize = "0.15"

--- a/crates/pyhq/Cargo.toml
+++ b/crates/pyhq/Cargo.toml
@@ -12,7 +12,7 @@ name = "hyperqueue"
 # Downstream Rust code (including code in `bin/`, `examples/`, and `tests/`) will not be able
 # to `use string_sum;` unless the "rlib" or "lib" crate type is also included, e.g.:
 # crate-type = ["cdylib", "rlib"]
-crate-type = ["cdylib", "lib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 hyperqueue_core = { path = "../hyperqueue", package = "hyperqueue" }

--- a/crates/pyhq/Cargo.toml
+++ b/crates/pyhq/Cargo.toml
@@ -12,16 +12,19 @@ name = "hyperqueue"
 # Downstream Rust code (including code in `bin/`, `examples/`, and `tests/`) will not be able
 # to `use string_sum;` unless the "rlib" or "lib" crate type is also included, e.g.:
 # crate-type = ["cdylib", "rlib"]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
-hyperqueue = { path = "../hyperqueue" }
-pyo3 = { version = "0.15.1", features = ["extension-module", "abi3", "abi3-py36", "anyhow"] }
-pyo3-asyncio = { version = "0.15.0", features = ["tokio-runtime", "attributes"] }
-pythonize = "0.15.0"
-serde = "1.0.130"
-tokio = "1.17.0"
-anyhow = "1.0.44"
+hyperqueue_core = { path = "../hyperqueue", package = "hyperqueue" }
+pyo3 = { version = "0.15", features = ["extension-module", "abi3", "abi3-py36", "anyhow"] }
+pyo3-asyncio = { version = "0.15", features = ["tokio-runtime", "attributes"] }
+pythonize = "0.15"
+serde = "1.0"
+tokio = "1.17"
+anyhow = "1.0"
+termcolor = "1.1"
+log = "0.4"
+tempdir = "0.3.7"
 
 [package.metadata.maturin]
 python-source = "python"

--- a/crates/pyhq/python/hyperqueue/client.py
+++ b/crates/pyhq/python/hyperqueue/client.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Dict, Optional, Sequence
 
-from .ffi.connection import Connection, JobId, TaskId
+from .ffi.client import ClientConnection, JobId, TaskId
 from .job import Job
 from .task.function import PythonEnv
 
@@ -15,7 +15,7 @@ class Client:
         self, path: Optional[Path] = None, python_env: Optional[PythonEnv] = None
     ):
         path = str(path) if path else None
-        self.connection = Connection(path)
+        self.connection = ClientConnection(path)
         if python_env is None:
             python_env = PythonEnv()
         self.python_env = python_env

--- a/crates/pyhq/python/hyperqueue/cluster/__init__.py
+++ b/crates/pyhq/python/hyperqueue/cluster/__init__.py
@@ -1,13 +1,35 @@
+import dataclasses
+import multiprocessing
 from pathlib import Path
 from typing import Optional
 
+from ..client import Client
 from ..ffi.cluster import Cluster
 
 
+@dataclasses.dataclass
+class WorkerConfig:
+    # If None, use all available cores
+    cores: Optional[int] = None
+
+
 class LocalCluster:
-    def __init__(self, server_dir: Optional[Path] = None):
+    def __init__(
+        self,
+        server_dir: Optional[Path] = None,
+        worker_config: Optional[WorkerConfig] = None,
+    ):
         self.cluster = Cluster(server_dir)
-        print(self.cluster.server_dir)
+        if worker_config is not None:
+            self.start_worker(worker_config)
+
+    def start_worker(self, config: WorkerConfig = None):
+        config = config if config is not None else WorkerConfig()
+        cores = config.cores or multiprocessing.cpu_count()
+        self.cluster.add_worker(cores)
+
+    def client(self) -> Client:
+        return Client(self.cluster.server_dir)
 
     def stop(self):
         self.cluster.stop()

--- a/crates/pyhq/python/hyperqueue/cluster/__init__.py
+++ b/crates/pyhq/python/hyperqueue/cluster/__init__.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from typing import Optional
+
+from ..ffi.cluster import Cluster
+
+
+class LocalCluster:
+    def __init__(self, server_dir: Optional[Path] = None):
+        self.cluster = Cluster(server_dir)
+        print(self.cluster.server_dir)
+
+    def stop(self):
+        self.cluster.stop()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()

--- a/crates/pyhq/python/hyperqueue/ffi/__init__.py
+++ b/crates/pyhq/python/hyperqueue/ffi/__init__.py
@@ -1,2 +1,4 @@
+from .. import hyperqueue as ffi  # noqa
+
 JobId = int
 TaskId = int

--- a/crates/pyhq/python/hyperqueue/ffi/client.py
+++ b/crates/pyhq/python/hyperqueue/ffi/client.py
@@ -1,20 +1,20 @@
 from typing import Dict, List, Optional, Sequence
 
-from .. import hyperqueue as ffi
+from . import ffi
 from . import JobId, TaskId
 from .protocol import JobDescription
 
 
-class HqContext:
+class HqClientContext:
     """
     Opaque class returned from `connect_to_server`.
     Should be passed to FFI methods that require it.
     """
 
 
-class Connection:
+class ClientConnection:
     def __init__(self, directory: Optional[str] = None):
-        self.ctx: HqContext = ffi.connect_to_server(directory)
+        self.ctx: HqClientContext = ffi.connect_to_server(directory)
 
     def submit_job(self, job_description: JobDescription) -> JobId:
         return ffi.submit_job(self.ctx, job_description)

--- a/crates/pyhq/python/hyperqueue/ffi/client.py
+++ b/crates/pyhq/python/hyperqueue/ffi/client.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Optional, Sequence
 
-from . import ffi
-from . import JobId, TaskId
+from . import JobId, TaskId, ffi
 from .protocol import JobDescription
 
 

--- a/crates/pyhq/python/hyperqueue/ffi/cluster.py
+++ b/crates/pyhq/python/hyperqueue/ffi/cluster.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from . import ffi
+
+
+class HqClusterContext:
+    """
+    Opaque class returned from `cluster_start`.
+    Should be passed to FFI methods that require it.
+    """
+
+
+class Cluster:
+    def __init__(self, directory: Optional[str] = None):
+        self.directory = directory
+        self.ctx: HqClusterContext = ffi.cluster_start(directory)
+
+    @property
+    def server_dir(self) -> str:
+        return self.ctx.server_dir
+
+    def stop(self):
+        return ffi.cluster_stop(self.ctx)

--- a/crates/pyhq/python/hyperqueue/ffi/cluster.py
+++ b/crates/pyhq/python/hyperqueue/ffi/cluster.py
@@ -15,9 +15,12 @@ class Cluster:
         self.directory = directory
         self.ctx: HqClusterContext = ffi.cluster_start(directory)
 
+    def add_worker(self, cores: int):
+        self.ctx.add_worker(cores)
+
     @property
     def server_dir(self) -> str:
         return self.ctx.server_dir
 
     def stop(self):
-        return ffi.cluster_stop(self.ctx)
+        return self.ctx.stop()

--- a/crates/pyhq/src/client/job.rs
+++ b/crates/pyhq/src/client/job.rs
@@ -1,15 +1,15 @@
-use hyperqueue_core::client::resources::parse_cpu_request;
-use hyperqueue_core::client::status::Status;
-use hyperqueue_core::common::arraydef::IntArray;
-use hyperqueue_core::common::utils::fs::get_current_dir;
-use hyperqueue_core::server::job::JobTaskState;
-use hyperqueue_core::tako::messages::common::{ProgramDefinition, StdioDef};
-use hyperqueue_core::transfer::messages::{
+use hyperqueue::client::resources::parse_cpu_request;
+use hyperqueue::client::status::Status;
+use hyperqueue::common::arraydef::IntArray;
+use hyperqueue::common::utils::fs::get_current_dir;
+use hyperqueue::server::job::JobTaskState;
+use hyperqueue::tako::messages::common::{ProgramDefinition, StdioDef};
+use hyperqueue::transfer::messages::{
     FromClientMessage, IdSelector, JobDescription as HqJobDescription, JobDetailRequest, PinMode,
     SubmitRequest, TaskDescription as HqTaskDescription, TaskIdSelector, TaskSelector,
     TaskStatusSelector, TaskWithDependencies, ToClientMessage, WaitForJobsRequest,
 };
-use hyperqueue_core::{rpc_call, tako, JobTaskCount};
+use hyperqueue::{rpc_call, tako, JobTaskCount};
 use pyo3::{PyResult, Python};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/pyhq/src/client/mod.rs
+++ b/crates/pyhq/src/client/mod.rs
@@ -1,0 +1,2 @@
+pub mod job;
+pub mod server;

--- a/crates/pyhq/src/client/server.rs
+++ b/crates/pyhq/src/client/server.rs
@@ -1,9 +1,9 @@
 use pyo3::{Py, PyResult, Python};
 use std::path::PathBuf;
 
-use hyperqueue_core::client::default_server_directory_path;
-use hyperqueue_core::server::bootstrap::get_client_connection;
-use hyperqueue_core::transfer::messages::FromClientMessage;
+use hyperqueue::client::default_server_directory_path;
+use hyperqueue::server::bootstrap::get_client_connection;
+use hyperqueue::transfer::messages::FromClientMessage;
 
 use crate::utils::error::ToPyResult;
 use crate::{borrow_mut, run_future, ClientContextPtr, HqClientContext};

--- a/crates/pyhq/src/cluster/mod.rs
+++ b/crates/pyhq/src/cluster/mod.rs
@@ -1,0 +1,32 @@
+use crate::cluster::server::RunningServer;
+use std::path::{Path, PathBuf};
+use tempdir::TempDir;
+
+pub mod server;
+
+pub struct Cluster {
+    server: Option<RunningServer>,
+    server_dir: PathBuf,
+}
+
+impl Cluster {
+    pub fn start(server_dir: Option<PathBuf>) -> anyhow::Result<Self> {
+        let server_dir = server_dir.unwrap_or_else(|| TempDir::new("hq").unwrap().into_path());
+        let server = RunningServer::start(server_dir.clone())?;
+        Ok(Self {
+            server: Some(server),
+            server_dir,
+        })
+    }
+
+    pub fn server_dir(&self) -> &Path {
+        &self.server_dir
+    }
+
+    pub fn stop(&mut self) {
+        self.server
+            .take()
+            .expect("Attempting to stop an already stopped server")
+            .stop();
+    }
+}

--- a/crates/pyhq/src/cluster/server.rs
+++ b/crates/pyhq/src/cluster/server.rs
@@ -1,7 +1,7 @@
-use hyperqueue_core::client::globalsettings::GlobalSettings;
-use hyperqueue_core::client::output::cli::CliOutput;
-use hyperqueue_core::common::utils::network::get_hostname;
-use hyperqueue_core::server::bootstrap::{initialize_server, ServerConfig};
+use hyperqueue::client::globalsettings::GlobalSettings;
+use hyperqueue::client::output::cli::CliOutput;
+use hyperqueue::common::utils::network::get_hostname;
+use hyperqueue::server::bootstrap::{initialize_server, ServerConfig};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread::JoinHandle;

--- a/crates/pyhq/src/cluster/server.rs
+++ b/crates/pyhq/src/cluster/server.rs
@@ -1,5 +1,6 @@
 use hyperqueue_core::client::globalsettings::GlobalSettings;
 use hyperqueue_core::client::output::cli::CliOutput;
+use hyperqueue_core::common::utils::network::get_hostname;
 use hyperqueue_core::server::bootstrap::{initialize_server, ServerConfig};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -27,7 +28,7 @@ impl RunningServer {
                 Box::new(CliOutput::new(termcolor::ColorChoice::Never)),
             );
             let config = ServerConfig {
-                host: "localhost".to_string(),
+                host: get_hostname(None),
                 idle_timeout: None,
                 client_port: None,
                 worker_port: None,

--- a/crates/pyhq/src/cluster/server.rs
+++ b/crates/pyhq/src/cluster/server.rs
@@ -1,0 +1,69 @@
+use hyperqueue_core::client::globalsettings::GlobalSettings;
+use hyperqueue_core::client::output::cli::CliOutput;
+use hyperqueue_core::server::bootstrap::{initialize_server, ServerConfig};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use tokio::sync::Notify;
+use tokio::task::LocalSet;
+
+pub struct RunningServer {
+    thread: JoinHandle<()>,
+    stop_flag: Arc<Notify>,
+}
+
+impl RunningServer {
+    pub fn start(server_dir: PathBuf) -> anyhow::Result<Self> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<anyhow::Result<Arc<Notify>>>();
+
+        let thread = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Cannot create Tokio runtime");
+
+            let settings = GlobalSettings::new(
+                server_dir,
+                Box::new(CliOutput::new(termcolor::ColorChoice::Never)),
+            );
+            let config = ServerConfig {
+                host: "localhost".to_string(),
+                idle_timeout: None,
+                client_port: None,
+                worker_port: None,
+                event_buffer_size: 100,
+                event_log_path: None,
+            };
+
+            let main_future = async move {
+                let set = LocalSet::new();
+
+                set.run_until(async move {
+                    match initialize_server(&settings, config).await {
+                        Ok((future, end_flag)) => {
+                            tx.send(Ok(end_flag)).unwrap();
+                            if let Err(error) = future.await {
+                                log::error!("HyperQueue server ended with error: {error:?}");
+                            }
+                        }
+                        Err(error) => {
+                            tx.send(Err(error)).unwrap();
+                        }
+                    }
+                })
+                .await;
+            };
+            runtime.block_on(main_future);
+        });
+        let stop_flag = rx
+            .blocking_recv()
+            .expect("Could not receive response from server")?;
+        Ok(Self { thread, stop_flag })
+    }
+
+    pub fn stop(self) {
+        log::info!("Attempting to stop server");
+        self.stop_flag.notify_one();
+        self.thread.join().expect("Server did not stop correctly");
+    }
+}

--- a/crates/pyhq/src/cluster/worker.rs
+++ b/crates/pyhq/src/cluster/worker.rs
@@ -1,0 +1,75 @@
+use std::path::Path;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use hyperqueue_core::common::utils::network::get_hostname;
+use tokio::task::LocalSet;
+
+use hyperqueue_core::tako::common::resources::{CpuId, ResourceDescriptor};
+use hyperqueue_core::tako::messages::common::WorkerConfiguration;
+use hyperqueue_core::tako::worker::state::ServerLostPolicy;
+use hyperqueue_core::worker::bootstrap::{finalize_configuration, initialize_worker};
+
+pub struct RunningWorker {
+    #[allow(unused)]
+    thread: JoinHandle<()>,
+}
+
+impl RunningWorker {
+    pub fn start(server_dir: &Path, cores: usize) -> anyhow::Result<Self> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<anyhow::Result<()>>();
+
+        let server_dir = server_dir.to_path_buf();
+        let thread = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Cannot create Tokio runtime");
+
+            let worker_dir = server_dir.join("worker");
+            let work_dir = worker_dir.join("workdir");
+            let log_dir = worker_dir.join("logs");
+            let mut configuration = WorkerConfiguration {
+                resources: ResourceDescriptor {
+                    cpus: vec![vec![CpuId::from(cores as u32)]],
+                    generic: vec![],
+                },
+                listen_address: Default::default(),
+                hostname: get_hostname(None),
+                work_dir,
+                log_dir,
+                heartbeat_interval: Duration::from_secs(10),
+                send_overview_interval: None,
+                idle_timeout: None,
+                time_limit: None,
+                on_server_lost: ServerLostPolicy::Stop,
+                extra: Default::default(),
+            };
+            finalize_configuration(&mut configuration);
+
+            log::info!("Starting worker: {configuration:?}");
+
+            let main_future = async move {
+                let set = LocalSet::new();
+                set.run_until(async move {
+                    match initialize_worker(&server_dir, configuration).await {
+                        Ok((future, _)) => {
+                            tx.send(Ok(())).unwrap();
+                            if let Err(error) = future.await {
+                                log::error!("HyperQueue worker ended with error: {error:?}");
+                            }
+                        }
+                        Err(error) => {
+                            tx.send(Err(error)).unwrap();
+                        }
+                    }
+                })
+                .await;
+            };
+            runtime.block_on(main_future);
+        });
+        rx.blocking_recv()
+            .expect("Could not receive response from worker")?;
+        Ok(Self { thread })
+    }
+}

--- a/crates/pyhq/src/cluster/worker.rs
+++ b/crates/pyhq/src/cluster/worker.rs
@@ -2,13 +2,13 @@ use std::path::Path;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use hyperqueue_core::common::utils::network::get_hostname;
+use hyperqueue::common::utils::network::get_hostname;
 use tokio::task::LocalSet;
 
-use hyperqueue_core::tako::common::resources::{CpuId, ResourceDescriptor};
-use hyperqueue_core::tako::messages::common::WorkerConfiguration;
-use hyperqueue_core::tako::worker::state::ServerLostPolicy;
-use hyperqueue_core::worker::bootstrap::{finalize_configuration, initialize_worker};
+use hyperqueue::tako::common::resources::{CpuId, ResourceDescriptor};
+use hyperqueue::tako::messages::common::WorkerConfiguration;
+use hyperqueue::tako::worker::state::ServerLostPolicy;
+use hyperqueue::worker::bootstrap::{finalize_configuration, initialize_worker};
 
 pub struct RunningWorker {
     #[allow(unused)]

--- a/crates/pyhq/src/lib.rs
+++ b/crates/pyhq/src/lib.rs
@@ -71,21 +71,22 @@ impl HqClusterContext {
     pub fn server_dir(&self) -> String {
         self.cluster.server_dir().to_string_lossy().into_owned()
     }
-}
 
-type ClusterContextPtr = Py<HqClusterContext>;
+    pub fn stop(&mut self) {
+        self.cluster.stop();
+    }
+
+    pub fn add_worker(&mut self, cores: usize) -> PyResult<()> {
+        self.cluster.add_worker(cores)?;
+        Ok(())
+    }
+}
 
 #[pyfunction]
 fn cluster_start(_py: Python, path: Option<String>) -> PyResult<HqClusterContext> {
     let path: Option<PathBuf> = path.map(|p| p.into());
     let cluster = Cluster::start(path)?;
     Ok(HqClusterContext { cluster })
-}
-
-#[pyfunction]
-fn cluster_stop(py: Python, ctx: ClusterContextPtr) {
-    let mut ctx = borrow_mut!(py, ctx);
-    ctx.cluster.stop();
 }
 
 #[pymodule]
@@ -109,7 +110,6 @@ fn hyperqueue(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<HqClusterContext>()?;
 
     m.add_function(wrap_pyfunction!(cluster_start, m)?)?;
-    m.add_function(wrap_pyfunction!(cluster_stop, m)?)?;
 
     Ok(())
 }

--- a/crates/pyhq/src/lib.rs
+++ b/crates/pyhq/src/lib.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::runtime::Builder;
 
-use hyperqueue_core::transfer::connection::ClientConnection;
+use hyperqueue::transfer::connection::ClientConnection;
 
 use crate::cluster::Cluster;
 use crate::utils::run_future;

--- a/crates/pyhq/src/lib.rs
+++ b/crates/pyhq/src/lib.rs
@@ -1,59 +1,91 @@
 use pyo3::types::PyModule;
-use pyo3::{pyclass, pyfunction, pymodule, FromPyObject};
+use pyo3::{pyclass, pyfunction, pymethods, pymodule, FromPyObject};
 use pyo3::{wrap_pyfunction, Py, PyResult, Python};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use tokio::runtime::Builder;
 
-use hyperqueue::transfer::connection::ClientConnection;
+use hyperqueue_core::transfer::connection::ClientConnection;
 
-use crate::job::{get_error_messages_impl, submit_job_impl, wait_for_jobs_impl, JobDescription};
-use crate::server::{connect_to_server_impl, stop_server_impl};
+use crate::cluster::Cluster;
 use crate::utils::run_future;
+use client::job::{get_error_messages_impl, submit_job_impl, wait_for_jobs_impl, JobDescription};
+use client::server::{connect_to_server_impl, stop_server_impl};
 
-mod job;
+mod client;
+pub mod cluster;
 mod marshal;
-mod server;
 mod utils;
 
+// Client code
 /// Opaque object that is returned by `connect_to_server` and then passed from the Python side
 /// to various Rust functions.
 #[pyclass]
-struct HqContext {
+struct HqClientContext {
     connection: ClientConnection,
 }
 
-type ContextPtr = Py<HqContext>;
+type ClientContextPtr = Py<HqClientContext>;
 
 type PyJobId = u32;
 type PyTaskId = u32;
 
 #[pyfunction]
-fn connect_to_server(py: Python, directory: Option<String>) -> PyResult<ContextPtr> {
+fn connect_to_server(py: Python, directory: Option<String>) -> PyResult<ClientContextPtr> {
     connect_to_server_impl(py, directory)
 }
 
 #[pyfunction]
-fn stop_server(py: Python, ctx: ContextPtr) -> PyResult<()> {
+fn stop_server(py: Python, ctx: ClientContextPtr) -> PyResult<()> {
     stop_server_impl(py, ctx)
 }
 
 #[pyfunction]
-fn submit_job(py: Python, ctx: ContextPtr, job: JobDescription) -> PyResult<PyJobId> {
+fn submit_job(py: Python, ctx: ClientContextPtr, job: JobDescription) -> PyResult<PyJobId> {
     submit_job_impl(py, ctx, job)
 }
 
 #[pyfunction]
-fn wait_for_jobs(py: Python, ctx: ContextPtr, job_ids: Vec<PyJobId>) -> PyResult<u32> {
+fn wait_for_jobs(py: Python, ctx: ClientContextPtr, job_ids: Vec<PyJobId>) -> PyResult<u32> {
     wait_for_jobs_impl(py, ctx, job_ids)
 }
 
 #[pyfunction]
 fn get_error_messages(
     py: Python,
-    ctx: ContextPtr,
+    ctx: ClientContextPtr,
     job_ids: Vec<PyJobId>,
 ) -> PyResult<HashMap<PyJobId, HashMap<PyTaskId, String>>> {
     get_error_messages_impl(py, ctx, job_ids)
+}
+
+// Server code
+#[pyclass]
+struct HqClusterContext {
+    cluster: Cluster,
+}
+
+#[pymethods]
+impl HqClusterContext {
+    #[getter]
+    pub fn server_dir(&self) -> String {
+        self.cluster.server_dir().to_string_lossy().into_owned()
+    }
+}
+
+type ClusterContextPtr = Py<HqClusterContext>;
+
+#[pyfunction]
+fn cluster_start(_py: Python, path: Option<String>) -> PyResult<HqClusterContext> {
+    let path: Option<PathBuf> = path.map(|p| p.into());
+    let cluster = Cluster::start(path)?;
+    Ok(HqClusterContext { cluster })
+}
+
+#[pyfunction]
+fn cluster_stop(py: Python, ctx: ClusterContextPtr) {
+    let mut ctx = borrow_mut!(py, ctx);
+    ctx.cluster.stop();
 }
 
 #[pymodule]
@@ -63,16 +95,21 @@ fn hyperqueue(_py: Python, m: &PyModule) -> PyResult<()> {
     builder.enable_all();
     pyo3_asyncio::tokio::init(builder);
 
-    m.add_class::<HqContext>()?;
+    // Client
+    m.add_class::<HqClientContext>()?;
 
-    // Server
     m.add_function(wrap_pyfunction!(connect_to_server, m)?)?;
     m.add_function(wrap_pyfunction!(stop_server, m)?)?;
 
-    // Jobs
     m.add_function(wrap_pyfunction!(submit_job, m)?)?;
     m.add_function(wrap_pyfunction!(wait_for_jobs, m)?)?;
     m.add_function(wrap_pyfunction!(get_error_messages, m)?)?;
+
+    // Cluster
+    m.add_class::<HqClusterContext>()?;
+
+    m.add_function(wrap_pyfunction!(cluster_start, m)?)?;
+    m.add_function(wrap_pyfunction!(cluster_stop, m)?)?;
 
     Ok(())
 }

--- a/crates/pyhq/src/marshal.rs
+++ b/crates/pyhq/src/marshal.rs
@@ -3,7 +3,6 @@
 use std::ops::{Deref, DerefMut};
 use std::time::Duration;
 
-use hyperqueue::JobId;
 use pyo3::types::{PyFloat, PyInt};
 use pyo3::{FromPyObject, PyAny, PyResult};
 use pythonize::depythonize;

--- a/crates/pyhq/src/utils/error.rs
+++ b/crates/pyhq/src/utils/error.rs
@@ -1,4 +1,4 @@
-use hyperqueue::common::error::HqError;
+use hyperqueue_core::common::error::HqError;
 use pyo3::exceptions::PyException;
 use pyo3::{PyErr, Python};
 

--- a/crates/pyhq/src/utils/error.rs
+++ b/crates/pyhq/src/utils/error.rs
@@ -1,4 +1,4 @@
-use hyperqueue_core::common::error::HqError;
+use hyperqueue::common::error::HqError;
 use pyo3::exceptions::PyException;
 use pyo3::{PyErr, Python};
 

--- a/crates/tako/src/common/resources/descriptor.rs
+++ b/crates/tako/src/common/resources/descriptor.rs
@@ -49,6 +49,7 @@ pub struct GenericResourceDescriptor {
     pub kind: GenericResourceDescriptorKind,
 }
 
+/// (Node0(Cpu0, Cpu1), Node1(Cpu2, Cpu3), ...)
 pub type CpusDescriptor = Vec<Vec<CpuId>>;
 
 pub fn cpu_descriptor_from_socket_size(

--- a/tests/pyapi/binding/test_server.py
+++ b/tests/pyapi/binding/test_server.py
@@ -1,11 +1,11 @@
-from hyperqueue.ffi.connection import Connection
+from hyperqueue.ffi.client import ClientConnection
 
 from ...conftest import HqEnv
 
 
 def test_stop_server(hq_env: HqEnv):
     process = hq_env.start_server()
-    connection = Connection(hq_env.server_dir)
+    connection = ClientConnection(hq_env.server_dir)
     connection.stop_server()
     process.wait(timeout=5)
     hq_env.check_process_exited(process)

--- a/tests/pyapi/test_cluster.py
+++ b/tests/pyapi/test_cluster.py
@@ -1,0 +1,6 @@
+from hyperqueue.cluster import LocalCluster
+
+
+def test_create_cluster():
+    with LocalCluster():
+        pass

--- a/tests/pyapi/test_cluster.py
+++ b/tests/pyapi/test_cluster.py
@@ -1,6 +1,39 @@
+import pytest
+
 from hyperqueue.cluster import LocalCluster
+from hyperqueue.job import Job
+
+from ..utils.io import check_file_contents
 
 
-def test_create_cluster():
+def test_cluster_create():
     with LocalCluster():
         pass
+
+
+def test_cluster_stop_twice():
+    cluster = LocalCluster()
+    cluster.stop()
+
+    with pytest.raises(BaseException):
+        cluster.stop()
+
+
+def test_cluster_create_client():
+    with LocalCluster() as cluster:
+        client = cluster.client()
+        job = Job()
+        job.program(["hostname"])
+        client.submit(job)
+
+
+def test_cluster_add_worker():
+    with LocalCluster() as cluster:
+        cluster.start_worker()
+        client = cluster.client()
+        job = Job()
+        job.program(["echo", "hello"], stdout="out.txt")
+        job_id = client.submit(job)
+        client.wait_for_jobs([job_id])
+
+        check_file_contents("out.txt", "hello\n")


### PR DESCRIPTION
This PR adds the possibility to create a local cluster (server + worker) directly from the Python API. Both the server and the worker(s) run inside the same process, in different threads.