### PR TITLE
Use special formatting for the built-in "mem" resource

### DIFF
--- a/crates/hyperqueue/src/common/format.rs
+++ b/crates/hyperqueue/src/common/format.rs
@@ -18,11 +18,11 @@ pub fn human_size(size: u64) -> String {
     if size < 2048 {
         format!("{} B", size)
     } else if size < 2 * 1024 * 1024 {
-        format!("{} KiB", size / 1024)
+        format!("{:.2} KiB", size as f64 / 1024.0)
     } else if size < 2 * 1024 * 1024 * 1024 {
-        format!("{} MiB", size / (1024 * 1024))
+        format!("{:.2} MiB", size as f64 / (1024 * 1024) as f64)
     } else {
-        format!("{} GiB", size / (1024 * 1024 * 1024))
+        format!("{:.2} GiB", size as f64 / (1024 * 1024 * 1024) as f64)
     }
 }
 
@@ -43,9 +43,9 @@ mod tests {
         assert_eq!(human_size(0).as_str(), "0 B");
         assert_eq!(human_size(1).as_str(), "1 B");
         assert_eq!(human_size(1230).as_str(), "1230 B");
-        assert_eq!(human_size(300_000).as_str(), "292 KiB");
-        assert_eq!(human_size(50_000_000).as_str(), "47 MiB");
-        assert_eq!(human_size(500_250_000_000).as_str(), "465 GiB");
+        assert_eq!(human_size(300_000).as_str(), "292.97 KiB");
+        assert_eq!(human_size(50_000_000).as_str(), "47.68 MiB");
+        assert_eq!(human_size(500_250_000_000).as_str(), "465.89 GiB");
     }
 
     #[test]

--- a/crates/tako/src/common/resources/descriptor.rs
+++ b/crates/tako/src/common/resources/descriptor.rs
@@ -1,5 +1,5 @@
 use crate::common::resources::{CpuId, GenericResourceAmount, GenericResourceIndex, NumOfCpus};
-use crate::common::{Map, Set};
+use crate::common::Set;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -47,6 +47,28 @@ impl std::fmt::Display for GenericResourceDescriptorKind {
 pub struct GenericResourceDescriptor {
     pub name: String,
     pub kind: GenericResourceDescriptorKind,
+}
+
+impl GenericResourceDescriptor {
+    pub fn indices<Index: Into<GenericResourceIndex>>(
+        name: &str,
+        start: Index,
+        end: Index,
+    ) -> Self {
+        GenericResourceDescriptor {
+            name: name.to_string(),
+            kind: GenericResourceDescriptorKind::Indices(GenericResourceKindIndices {
+                start: start.into(),
+                end: end.into(),
+            }),
+        }
+    }
+    pub fn sum(name: &str, size: GenericResourceAmount) -> Self {
+        GenericResourceDescriptor {
+            name: name.to_string(),
+            kind: GenericResourceDescriptorKind::Sum(GenericResourceKindSum { size }),
+        }
+    }
 }
 
 /// (Node0(Cpu0, Cpu1), Node1(Cpu2, Cpu3), ...)
@@ -120,41 +142,6 @@ impl ResourceDescriptor {
         }
         Ok(())
     }
-
-    pub fn summary(&self, multiline: bool) -> String {
-        let mut result = if self.cpus.len() == 1 {
-            format!("1x{} cpus", self.cpus[0].len())
-        } else {
-            let mut counts = Map::<usize, usize>::default();
-            for group in &self.cpus {
-                *counts.entry(group.len()).or_default() += 1;
-            }
-            let mut counts: Vec<_> = counts.into_iter().collect();
-            counts.sort_unstable();
-            format!(
-                "{} cpus",
-                counts
-                    .iter()
-                    .map(|(cores, count)| format!("{}x{}", count, cores))
-                    .collect::<Vec<_>>()
-                    .join(" ")
-            )
-        };
-        if multiline {
-            for descriptor in &self.generic {
-                result.push_str(&format!("\n{}: {}", &descriptor.name, descriptor.kind));
-            }
-        } else {
-            for descriptor in &self.generic {
-                result.push_str(&format!(
-                    "; {} {}",
-                    &descriptor.name,
-                    descriptor.kind.size()
-                ));
-            }
-        }
-        result
-    }
 }
 
 #[cfg(test)]
@@ -169,67 +156,6 @@ mod tests {
                 Default::default(),
             )
         }
-    }
-
-    impl GenericResourceDescriptor {
-        pub fn indices<Index: Into<GenericResourceIndex>>(
-            name: &str,
-            start: Index,
-            end: Index,
-        ) -> Self {
-            GenericResourceDescriptor {
-                name: name.to_string(),
-                kind: GenericResourceDescriptorKind::Indices(GenericResourceKindIndices {
-                    start: start.into(),
-                    end: end.into(),
-                }),
-            }
-        }
-        pub fn sum(name: &str, size: GenericResourceAmount) -> Self {
-            GenericResourceDescriptor {
-                name: name.to_string(),
-                kind: GenericResourceDescriptorKind::Sum(GenericResourceKindSum { size }),
-            }
-        }
-    }
-
-    #[test]
-    fn test_resources_to_summary() {
-        let d = ResourceDescriptor::new(vec![vec![0].to_ids()], Vec::new());
-        assert_eq!(&d.summary(false), "1x1 cpus");
-
-        let d = ResourceDescriptor::new(vec![vec![0, 1, 2].to_ids()], Vec::new());
-        assert_eq!(&d.summary(true), "1x3 cpus");
-
-        let d = ResourceDescriptor::new(
-            vec![vec![0, 1, 2, 4].to_ids(), vec![10, 11, 12, 14].to_ids()],
-            Vec::new(),
-        );
-        assert_eq!(&d.summary(true), "2x4 cpus");
-
-        let d = ResourceDescriptor::new(
-            vec![
-                vec![0, 1].to_ids(),
-                vec![10, 11].to_ids(),
-                vec![20, 21].to_ids(),
-                vec![30, 31].to_ids(),
-                vec![40, 41].to_ids(),
-                vec![50, 51, 52, 53, 54, 55].to_ids(),
-            ],
-            Vec::new(),
-        );
-        assert_eq!(&d.summary(true), "5x2 1x6 cpus");
-
-        let generic = vec![
-            GenericResourceDescriptor::indices("Aaa", 0, 9),
-            GenericResourceDescriptor::indices("Ccc", 1, 132),
-            GenericResourceDescriptor::sum("Bbb", 100_000_000),
-        ];
-        let d = ResourceDescriptor::new(vec![vec![0, 1].to_ids()], generic);
-        assert_eq!(
-            &d.summary(true),
-            "1x2 cpus\nAaa: Indices(0-9)\nBbb: Sum(100000000)\nCcc: Indices(1-132)"
-        );
     }
 
     #[test]


### PR DESCRIPTION
See tests for the new format.

I'm not sure if we should also use the format in the multi-line output, since then it would not show `Sum(...)`.