### PR TITLE
Start HQ worker on all allocation nodes in PBS allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # DEV
 
 ## New features
@@ -30,6 +29,12 @@ to make sure that OpenMP pins its threads to the exact cores allocated by HyperQ
 ### CLI
 * The `--pin` boolean option for submitting jobs has been changed to take a value. You can get the
 original behaviour by specifying `--pin=taskset`.
+
+## Fixes
+
+### Automatic allocation
+- PBS allocations using multiple workers will now correctly spawn a HyperQueue worker on all
+allocated nodes.
 
 # 0.9.0
 

--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use clap::Parser;
 
 use crate::client::commands::worker::ArgServerLostPolicy;
@@ -226,6 +227,10 @@ async fn add_queue(mut connection: ClientConnection, opts: AddQueueOpts) -> anyh
             (ManagerType::Pbs, args_to_params(params), !no_dry_run)
         }
         AddQueueCommand::Slurm(params) => {
+            if params.workers_per_alloc > 1 {
+                bail!("Multiple workers per allocation is currently unsupported for SLURM.");
+            }
+
             let no_dry_run = params.no_dry_run;
             (ManagerType::Slurm, args_to_params(params), !no_dry_run)
         }

--- a/tests/autoalloc/conftest.py
+++ b/tests/autoalloc/conftest.py
@@ -1,0 +1,46 @@
+import functools
+import inspect
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from ..conftest import run_hq_env
+
+PBS_AVAILABLE = shutil.which("qsub") is not None
+PBS_TIMEOUT = 5 * 60
+
+
+@pytest.fixture(autouse=False, scope="function")
+def pbs_hq_env(request):
+    # We cannot create server directory in /tmp, because it wouldn't be available to compute nodes
+    testname = request.node.name
+    now = datetime.now()
+    directory = (
+        Path.home() / ".hq-pytest" / f"{testname}-{now.strftime('%d-%m-%y-%H-%M-%S')}"
+    )
+    directory.mkdir(parents=True, exist_ok=False)
+    with run_hq_env(directory) as env:
+        try:
+            yield env
+        finally:
+            env.stop_server()
+
+
+def pbs_test(fn):
+    signature = inspect.signature(fn)
+    if "hq_env" in signature.parameters:
+        raise Exception(
+            "Do not use the `hq_env` fixture with `pbs_test`. Use `pbs_hq_env` instead."
+        )
+
+    @pytest.mark.skipif(
+        not PBS_AVAILABLE, reason="This test can be run only if PBS is available"
+    )
+    @pytest.mark.pbs
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapped

--- a/tests/autoalloc/test_autoalloc_slurm.py
+++ b/tests/autoalloc/test_autoalloc_slurm.py
@@ -2,6 +2,8 @@ import json
 import os
 from os.path import dirname, join
 
+import pytest
+
 from ..conftest import HqEnv
 from ..utils.wait import wait_until
 from .utils import (
@@ -12,19 +14,30 @@ from .utils import (
 )
 
 
-def test_add_slurm_queue(hq_env: HqEnv):
+def test_slurm_add_queue(hq_env: HqEnv):
     hq_env.start_server()
     output = add_queue(
         hq_env,
         manager="slurm",
         name="foo",
         backlog=5,
-        workers_per_alloc=2,
     )
     assert "Allocation queue 1 successfully created" in output
 
     info = hq_env.command(["alloc", "list"], as_table=True)
     info.check_column_value("ID", 0, "1")
+
+
+def test_slurm_add_queue_multiple_workers(hq_env: HqEnv):
+    hq_env.start_server()
+    with pytest.raises(BaseException):
+        add_queue(
+            hq_env,
+            manager="slurm",
+            name="foo",
+            backlog=5,
+            workers_per_alloc=2,
+        )
 
 
 def test_slurm_queue_sbatch_args(hq_env: HqEnv):

--- a/tests/autoalloc/utils.py
+++ b/tests/autoalloc/utils.py
@@ -36,6 +36,17 @@ def extract_script_args(script: str, prefix: str) -> List[str]:
     ]
 
 
+def extract_script_commands(script: str) -> str:
+    """
+    Returns all non-empty lines as text from `script` that do not start with a bash comment (`#`).
+    """
+    return "\n".join(
+        line.strip()
+        for line in script.splitlines(keepends=False)
+        if not line.startswith("#") and line.strip()
+    )
+
+
 def add_queue(
     hq_env: HqEnv,
     manager="pbs",

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
-python_files = utils/*.py test_*.py
+addopts = --strict-markers
+markers =
+    pbs: run test only if PBS is available


### PR DESCRIPTION
Previously, workers were spawned only on the first node.