### PR TITLE
Add `GenericResourceDescriptorKind` with an explicit set of indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,35 @@
 ## New features
 
 ### CLI
-* You can now specify the server directory using the `HQ_SERVER_DIR` environment variable.
+* [#423](https://github.com/It4innovations/hyperqueue/pull/423) You can now specify the server
+directory using the `HQ_SERVER_DIR` environment variable.
+### Resource management
+* [#427](https://github.com/It4innovations/hyperqueue/pull/427) A new specifier has been added to
+  specify **indexed pool** resources for workers as a set of individual resource indices.
+    ```bash
+    $ hq worker start --resource "gpus=list(1,3,8)"
+    ```
+
+## Changes
+
+### Resource management
+* [#427](https://github.com/It4innovations/hyperqueue/pull/427) (**Backwards incompatible change**)
+The environment variable `HQ_RESOURCE_INDICES_<resource-name>`, which is passed to tasks with
+[resource requests](https://it4innovations.github.io/hyperqueue/stable/jobs/gresources/#resource-request),
+has been renamed to `HQ_RESOURCE_VALUES_<resource-name>`.
+* [#427](https://github.com/It4innovations/hyperqueue/pull/427) (**Backwards incompatible change**)
+  The specifier for specifying **indexed pool** resources for workers as a range has been renamed from
+  `indices` to `range`.
+
+    ```bash
+    # before
+    $ hq worker start --resource "gpus=indices(1-3)"
+    # now
+    $ hq worker start --resource "gpus=range(1-3)"
+    ```
+* [#427](https://github.com/It4innovations/hyperqueue/pull/427) The
+[generic resource](https://it4innovations.github.io/hyperqueue/stable/jobs/gresources/)
+documentation has been rewritten and improved.
 
 # v0.10.0
 

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -43,7 +43,6 @@ use colored::Colorize;
 use std::collections::BTreeSet;
 use std::fs::File;
 use tako::gateway::{LostWorkerReason, ResourceRequest};
-use tako::resources::GenericResourceKindSum;
 use tako::Map;
 
 pub const TASK_COLOR_CANCELED: Colorization = Colorization::Magenta;
@@ -1129,9 +1128,7 @@ fn resources_summary(resources: &ResourceDescriptor, multiline: bool) -> String 
 
     let special_format = |descriptor: &GenericResourceDescriptor| -> Option<String> {
         if descriptor.name == MEM_RESOURCE_NAME {
-            if let GenericResourceDescriptorKind::Sum(GenericResourceKindSum { size }) =
-                descriptor.kind
-            {
+            if let GenericResourceDescriptorKind::Sum { size } = descriptor.kind {
                 return Some(human_size(size));
             }
         }
@@ -1151,7 +1148,7 @@ fn resources_summary(resources: &ResourceDescriptor, multiline: bool) -> String 
             result.push_str(&format!(
                 "; {} {}",
                 &descriptor.name,
-                special_format(descriptor).unwrap_or_else(|| descriptor.kind.size().to_string())
+                special_format(descriptor).unwrap_or_else(|| descriptor.kind.to_string())
             ));
         }
     }
@@ -1193,14 +1190,14 @@ mod tests {
         assert_eq!(resources_summary(&d, true), "5x2 1x6 cpus");
 
         let generic = vec![
-            GenericResourceDescriptor::indices("Aaa", 0, 9),
-            GenericResourceDescriptor::indices("Ccc", 1, 132),
+            GenericResourceDescriptor::range("Aaa", 0, 9),
+            GenericResourceDescriptor::range("Ccc", 1, 132),
             GenericResourceDescriptor::sum("Bbb", 100_000_000),
         ];
         let d = ResourceDescriptor::new(vec![vec![0, 1].to_ids()], generic);
         assert_eq!(
             resources_summary(&d, true),
-            "1x2 cpus\nAaa: Indices(0-9)\nBbb: Sum(100000000)\nCcc: Indices(1-132)"
+            "1x2 cpus\nAaa: Range(0-9)\nBbb: Sum(100000000)\nCcc: Range(1-132)"
         );
     }
 

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -446,16 +446,20 @@ fn format_generic_resource(resource: &GenericResourceDescriptor) -> serde_json::
     json!({
         "name": resource.name,
         "kind": match &resource.kind {
-            GenericResourceDescriptorKind::Indices(_) => "indices",
-            GenericResourceDescriptorKind::Sum(_) => "sum",
+            GenericResourceDescriptorKind::List { .. } => "list",
+            GenericResourceDescriptorKind::Range { .. } => "range",
+            GenericResourceDescriptorKind::Sum { .. } => "sum",
         },
         "params": match &resource.kind {
-            GenericResourceDescriptorKind::Indices(params) => json!({
-                "start": params.start,
-                "end": params.end
+            GenericResourceDescriptorKind::List { values } => json!({
+                "values": values,
             }),
-            GenericResourceDescriptorKind::Sum(params) => json!({
-                "size": params.size
+            GenericResourceDescriptorKind::Range { start, end } => json!({
+                "start": start,
+                "end": end
+            }),
+            GenericResourceDescriptorKind::Sum { size } => json!({
+                "size": size
             }),
         }
     })

--- a/crates/hyperqueue/src/worker/hwdetect.rs
+++ b/crates/hyperqueue/src/worker/hwdetect.rs
@@ -49,7 +49,7 @@ pub fn detect_generic_resources() -> anyhow::Result<Vec<GenericResourceDescripto
     if let Ok(count) = read_linux_gpu_count() {
         if count > 0 {
             log::debug!("Gpus detected: {}", count);
-            generic.push(GenericResourceDescriptor::indices(
+            generic.push(GenericResourceDescriptor::range(
                 GPU_RESOURCE_NAME,
                 0,
                 count as u32 - 1,

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -245,7 +245,7 @@ fn insert_resources_into_env(ctx: &LaunchContext, program: &mut ProgramDefinitio
                     .insert("CUDA_DEVICE_ORDER".into(), "PCI_BUS_ID".into());
             }
             program.env.insert(
-                format!("HQ_RESOURCE_INDICES_{}", resource_name).into(),
+                format!("HQ_RESOURCE_VALUES_{}", resource_name).into(),
                 indices.into(),
             );
         }

--- a/crates/tako/benches/benchmarks/worker.rs
+++ b/crates/tako/benches/benchmarks/worker.rs
@@ -5,7 +5,6 @@ use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion};
 use tako::internal::messages::worker::ComputeTaskMsg;
 use tako::internal::worker::rqueue::ResourceWaitQueue;
 use tako::launcher::{LaunchContext, StopReason, TaskLaunchData, TaskLauncher, TaskResult};
-use tako::resources::GenericResourceKindIndices;
 use tako::resources::ResourceMap;
 use tako::resources::{
     CpuRequest, GenericResourceDescriptor, GenericResourceDescriptorKind, GenericResourceRequest,
@@ -162,10 +161,10 @@ fn create_resource_queue(num_cpus: u32) -> ResourceWaitQueue {
             cpus: vec![(0..num_cpus).collect::<Vec<_>>().to_ids()],
             generic: vec![GenericResourceDescriptor {
                 name: "GPU".to_string(),
-                kind: GenericResourceDescriptorKind::Indices(GenericResourceKindIndices {
+                kind: GenericResourceDescriptorKind::Range {
                     start: 0.into(),
                     end: 8.into(),
-                }),
+                },
             }],
         },
         &ResourceMap::from_vec(vec!["GPU".to_string()]),

--- a/crates/tako/src/internal/common/resources/mod.rs
+++ b/crates/tako/src/internal/common/resources/mod.rs
@@ -10,8 +10,7 @@ pub use allocation::{
     ResourceAllocation,
 };
 pub use descriptor::{
-    CpusDescriptor, GenericResourceDescriptor, GenericResourceDescriptorKind,
-    GenericResourceKindSum, ResourceDescriptor,
+    CpusDescriptor, GenericResourceDescriptor, GenericResourceDescriptorKind, ResourceDescriptor,
 };
 pub use request::{CpuRequest, GenericResourceRequest, ResourceRequest, TimeRequest};
 

--- a/crates/tako/src/internal/tests/test_scheduler_sn.rs
+++ b/crates/tako/src/internal/tests/test_scheduler_sn.rs
@@ -564,7 +564,7 @@ fn test_generic_resource_assign2() {
         (
             10,
             None,
-            vec![GenericResourceDescriptor::indices("Res0", 1, 10)],
+            vec![GenericResourceDescriptor::range("Res0", 1, 10)],
         ),
         // Worker 101
         (10, None, vec![]),
@@ -573,7 +573,7 @@ fn test_generic_resource_assign2() {
             10,
             None,
             vec![
-                GenericResourceDescriptor::indices("Res0", 1, 10),
+                GenericResourceDescriptor::range("Res0", 1, 10),
                 GenericResourceDescriptor::sum("Res1", 1000_000),
             ],
         ),
@@ -644,7 +644,7 @@ fn test_generic_resource_balance1() {
         (
             10,
             None,
-            vec![GenericResourceDescriptor::indices("Res0", 1, 10)],
+            vec![GenericResourceDescriptor::range("Res0", 1, 10)],
         ),
         // Worker 101
         (10, None, vec![]),
@@ -653,7 +653,7 @@ fn test_generic_resource_balance1() {
             10,
             None,
             vec![
-                GenericResourceDescriptor::indices("Res0", 1, 10),
+                GenericResourceDescriptor::range("Res0", 1, 10),
                 GenericResourceDescriptor::sum("Res1", 1000_000),
             ],
         ),
@@ -697,7 +697,7 @@ fn test_generic_resource_balance2() {
         (
             10,
             None,
-            vec![GenericResourceDescriptor::indices("Res0", 1, 10)],
+            vec![GenericResourceDescriptor::range("Res0", 1, 10)],
         ),
         // Worker 101
         (10, None, vec![]),
@@ -706,7 +706,7 @@ fn test_generic_resource_balance2() {
             10,
             None,
             vec![
-                GenericResourceDescriptor::indices("Res0", 1, 10),
+                GenericResourceDescriptor::range("Res0", 1, 10),
                 GenericResourceDescriptor::sum("Res1", 1000_000),
             ],
         ),

--- a/crates/tako/src/internal/worker/pool.rs
+++ b/crates/tako/src/internal/worker/pool.rs
@@ -94,12 +94,17 @@ impl ResourcePool {
                 .expect("Internal error, resource name not received")
                 .as_num() as usize;
             generic_resources[idx] = match &descriptor.kind {
-                GenericResourceDescriptorKind::Indices(idx) => GenericResourcePool::Indices(
-                    (idx.start.as_num()..=idx.end.as_num())
-                        .map(|id| id.into())
-                        .collect(),
-                ),
-                GenericResourceDescriptorKind::Sum(v) => GenericResourcePool::Sum(v.size),
+                GenericResourceDescriptorKind::List { values } => {
+                    GenericResourcePool::Indices(values.clone())
+                }
+                GenericResourceDescriptorKind::Range { start, end } => {
+                    GenericResourcePool::Indices(
+                        (start.as_num()..=end.as_num())
+                            .map(|id| id.into())
+                            .collect(),
+                    )
+                }
+                GenericResourceDescriptorKind::Sum { size } => GenericResourcePool::Sum(*size),
             }
         }
 
@@ -604,10 +609,10 @@ mod tests {
     fn test_pool_generic_resources() {
         let cpus = cpu_descriptor_from_socket_size(1, 4);
         let generic = vec![
-            GenericResourceDescriptor::indices("Res0", 5, 100),
+            GenericResourceDescriptor::range("Res0", 5, 100),
             GenericResourceDescriptor::sum("Res1", 100_000_000),
-            GenericResourceDescriptor::indices("Res2", 0, 1),
-            GenericResourceDescriptor::indices("Res3", 0, 1),
+            GenericResourceDescriptor::range("Res2", 0, 1),
+            GenericResourceDescriptor::range("Res3", 0, 1),
         ];
         let descriptor = ResourceDescriptor::new(cpus, generic);
 

--- a/crates/tako/src/internal/worker/rqueue.rs
+++ b/crates/tako/src/internal/worker/rqueue.rs
@@ -305,9 +305,9 @@ mod tests {
     fn test_rqueue_generic_resource1_priorities() {
         let cpus = cpu_descriptor_from_socket_size(1, 4);
         let generic = vec![
-            GenericResourceDescriptor::indices("Res0", 1, 20),
+            GenericResourceDescriptor::range("Res0", 1, 20),
             GenericResourceDescriptor::sum("Res1", 100_000_000),
-            GenericResourceDescriptor::indices("Res2", 1, 50),
+            GenericResourceDescriptor::range("Res2", 1, 50),
         ];
         let descriptor = ResourceDescriptor::new(cpus, generic);
         let mut rq = RB::new(ResourceWaitQueue::new(
@@ -329,9 +329,9 @@ mod tests {
     fn test_rqueue_generic_resource2_priorities() {
         let cpus = cpu_descriptor_from_socket_size(1, 4);
         let generic = vec![
-            GenericResourceDescriptor::indices("Res0", 1, 20),
+            GenericResourceDescriptor::range("Res0", 1, 20),
             GenericResourceDescriptor::sum("Res1", 100_000_000),
-            GenericResourceDescriptor::indices("Res2", 1, 50),
+            GenericResourceDescriptor::range("Res2", 1, 50),
         ];
         let descriptor = ResourceDescriptor::new(cpus, generic);
 
@@ -359,9 +359,9 @@ mod tests {
     fn test_rqueue_generic_resource3_priorities() {
         let cpus = cpu_descriptor_from_socket_size(1, 4);
         let generic = vec![
-            GenericResourceDescriptor::indices("Res0", 1, 20),
+            GenericResourceDescriptor::range("Res0", 1, 20),
             GenericResourceDescriptor::sum("Res1", 100_000_000),
-            GenericResourceDescriptor::indices("Res2", 1, 50),
+            GenericResourceDescriptor::range("Res2", 1, 50),
         ];
         let descriptor = ResourceDescriptor::new(cpus, generic);
 

--- a/crates/tako/src/lib.rs
+++ b/crates/tako/src/lib.rs
@@ -32,14 +32,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub mod resources {
     pub use crate::internal::common::resources::{
         CpuId, CpuRequest, GenericResourceAmount, GenericResourceDescriptor,
-        GenericResourceDescriptorKind, GenericResourceKindSum, GenericResourceRequest, NumOfCpus,
-        NumOfNodes, ResourceAllocation, ResourceDescriptor, ResourceRequest, TimeRequest,
+        GenericResourceDescriptorKind, GenericResourceRequest, NumOfCpus, NumOfNodes,
+        ResourceAllocation, ResourceDescriptor, ResourceRequest, TimeRequest,
     };
 
     pub use crate::internal::common::resources::map::ResourceMap;
 
     pub use crate::internal::common::resources::descriptor::{
-        cpu_descriptor_from_socket_size, CpusDescriptor, GenericResourceKindIndices,
+        cpu_descriptor_from_socket_size, CpusDescriptor,
     };
 }
 

--- a/docs/jobs/gresources.md
+++ b/docs/jobs/gresources.md
@@ -1,41 +1,125 @@
 ## Generic resource management
 
-Generic resource management serves for defining resources of workers and possibility to define requirements of these resources by tasks.
-Some resources are auto-detected (GPUs in the current version); however, the user may define its own resources.
+Generic resource management serves for defining arbitrary resources provided by workers and
+also corresponding **resource requests** required by tasks. HyperQueue will take care of matching
+task resource requests so that only workers that can fulfill them will be able to execute such tasks.
 
-In the current version, there are two kind of resource pools:
+Some generic resources are [automatically detected](#automatically-detected-resources); however,
+users may also define their own resources.
 
-* Indexed pool: A resource pool where each resource is identified by a non-negative integer and when a task asks for `N` such resources, then  `N` indices are reserved only for these task. An example: GPUs.
-* Sum pool: A resource pool where worker only guarantees the following: The sum of resource requests of *running* tasks does not exceed the size of the pool.
+!!! important
 
+    Generic resources in HyperQueue exist on a purely logical level. They can correspond to physical
+    things (like GPUs), but it is the responsibility of the user to make sure that this correspondence
+    makes sense. HyperQueue by itself does not attach any semantics to generic resources, they are
+    just numbers used for scheduling.
 
-## Defining resources
+## Worker resources
 
-``hq worker start --resource <NAME1>=<DEF1> --resource <NAME2>=<DEF2> ...`` where `NAMEi` is a string name of the `i`-th resource and `DEFi` is a definition of the `i-th` resource that have to one of the following format:
+Each worker can have several generic resources attached. Each generic resource is a **resource pool**
+identified by a name. A resource pool represents some resources provided by a worker; each task can
+then ask for a part of resources contained in that pool.
 
-* ``indices(<START>-<END>)`` - where ``START`` and ``END`` are non-negative integers. It define indexed pool in range START-END.
-* ``sum(<SIZE>)`` - where ``SIZE`` is a size of the sum pool.
+There are two kind of resource pools:
 
+* **Indexed pool**: This pool represents an enumerated set of resources represented by integers.
+Each resource has its own identity. Tasks do not ask for specific values from the set, they just specify
+how many resources do they require and HyperQueue will allocate the specified amount of resources
+from the pool for each task.
 
-## Automatically detected resources
+    This pool is useful for resources that have their own identity, for example individual GPU or
+    FPGA accelerators.
 
-* Nvidia GPUs is automatically detected under resource name "gpus"
+    HyperQueue guarantees that no individual resource from the indexed pool is allocated to more than
+    a single task at any given time and that a task will not be executed on a worker if it does not
+    currently have enough individual resources to fulfill the [resource request](#resource-request)
+    of the task.
 
+* **Sum pool**: This pool represents a resource that has a certain size which be split into individual
+tasks. A typical example is memory; if a worker has `2000` bytes of memory, it can serve e.g. four
+tasks, if each task asks for `500` bytes of memory.
+
+    HyperQueue guarantees that the sum of resource request sizes of *running* tasks on a worker does
+    not exceed the total size of the sum pool.
+
+### Specifying worker resources
+
+You can specify the resource pools of a worker when you start it:
+
+```
+$ hq worker start --resource "<NAME1>=<DEF1>" --resource "<NAME2>=<DEF2>" ...
+```
+where `NAMEi` is a name (string ) of the `i`-th resource pool and `DEFi` is a definition of the
+`i-th` resource pool. You can define resource pools using one of the following formats:
+
+* ``list(<VALUE0>,<VALUE1>,...,<VALUEN>)`` where ``VALUEi`` is a non-negative integer. This will
+create an indexed pool containing the specified values.
+* ``range(<START>-<END>)`` where ``START`` and ``END`` are non-negative integers. This will create
+an indexed pool with numbers in the inclusive range `[START, END]`.
+* ``sum(<SIZE>)`` where ``SIZE`` is a positive integer. This will create a sum pool with the given
+size.
+
+!!! tip
+
+    You might encounter a problem in your shell when you try to specify worker resources, because
+    the definition contains parentheses (`()`). In that case just wrap the resource definition in
+    quotes, like this:
+
+    ```bash
+    $ hq worker start --resources "foo=sum(5)"
+    ```
+
+### Automatically detected resources
+
+* Nvidia GPUs that are available when a worker is started are automatically detected under the resource
+name `gpus`.
 
 ## Resource request
 
-When a job is submitted, resource requests may be defined as follows:
+When you submit a job, you can define a **resource requests** with the `--resource` flag:
 
-``hq submit --resource <NAME1>=<AMOUNT1> <NAME1>=<AMOUNT1> ...``
+```bash
+$ hq submit --resource <NAME1>=<AMOUNT1> --resources <NAME2>=<AMOUNT2> ...
+```
 
-Where ``NAME`` is a string name of the requested resource and the amount is a positive integer defining the size of the request.
+Where `NAME` is a name of the requested resource and the `AMOUNT` is a positive integer defining the
+size of the request.
 
-When the task is executed the following variables are created:
+Tasks with such resource requests will only be executed on workers that fulfill all the specified
+task requests.
 
-* ``HQ_RESOURCE_REQUEST_<NAME>`` that contains the amount of request resources
-* ``HQ_RESOURCE_INDICES_<NAME>`` if resource pool is an indexed pool then this variable contains comma-separated indices allocated for the task.
+!!! important
 
-Special case: In case of resource ``gpus``, HQ also creates variables:
+    Notice that task resource requests always ask for an amount of resources required by a task,
+    regardless whether that resource corresponds to an indexed or a sum pool on workers.
 
-* ``CUDA_DEVICE_ORDER`` set to value ``PCI_BUS_ID``
-* ``CUDA_VISIBLE_DEVICES`` set to the same value as ``HQ_RESOURCE_INDICES_gpus``
+    For example, let's say that a worker has an indexed pool of GPUs:
+    ```bash
+    $ hq worker start --resource "gpus=range(1-3)"
+    ```
+    And we create two jobs, each with a single task. The first job wants 1 GPU, the second one wants
+    two GPUs.
+
+    ```bash
+    $ hq submit --resource gpus=1 ...
+    $ hq submit --resource gpus=2 ...
+    ```
+
+    Then the first job can be allocated e.g. the GPU `2` and the second job can be allocated the GPUs
+    `1` and `3`. 
+
+### Resource environment variables
+When a task that has resource requests is executed, the following variables are passed to it for
+each resource request named `<NAME>`:
+
+* `HQ_RESOURCE_REQUEST_<NAME>` contains the amount of requested resources.
+* `HQ_RESOURCE_VALUES_<NAME>` contains the specific resource values allocated for the task as a
+comma-separated list. This variable is only filled for indexed resource pool.
+
+!!! tip
+
+    HQ has a special case for a resource named `gpus`. For that resource, it will also pass the following
+    environment variables to the spawned task:
+
+    * `CUDA_DEVICE_ORDER` set to the value `PCI_BUS_ID`
+    * `CUDA_VISIBLE_DEVICES` set to the same value as `HQ_RESOURCE_VALUES_gpus`

--- a/tests/autoalloc/test_autoalloc_pbs.py
+++ b/tests/autoalloc/test_autoalloc_pbs.py
@@ -416,7 +416,9 @@ def test_pbs_pass_cpu_and_resources_to_worker(hq_env: HqEnv):
                 "--resource",
                 "x=sum(100)",
                 "--resource",
-                "y=indices(1-4)",
+                "y=range(1-4)",
+                "--resource",
+                "z=list(1,2,4)",
             ],
         )
         wait_until(lambda: os.path.exists(path))
@@ -445,7 +447,9 @@ def test_pbs_pass_cpu_and_resources_to_worker(hq_env: HqEnv):
             "--resource",
             '"x=sum(100)"',
             "--resource",
-            '"y=indices(1-4)"',
+            '"y=range(1-4)"',
+            "--resource",
+            '"z=list(1,2,4)"',
             "--on-server-lost=finish-running",
         ]
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -2,34 +2,36 @@ import time
 
 from .conftest import HqEnv
 from .utils import wait_for_job_state
+from .utils.job import default_task_output
 
 
-def test_worker_resources(hq_env: HqEnv):
+def test_worker_resources_display(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.start_worker(
         cpus=4,
         args=[
             "--resource",
-            "potato=indices(1-12)",
+            "potato=range(1-12)",
             "--resource",
             "fairy=sum(1000_1000)",
+            "--resource",
+            "shark=list(1,3,5,2)",
         ],
     )
     table = hq_env.command(["worker", "list"], as_table=True)
     assert table.get_column_value("Resources") == [
-        "1x4 cpus; fairy 10001000; potato 12"
+        "1x4 cpus; fairy Sum(10001000); potato Range(1-12); shark List(1,3,5,2)"
     ]
 
     table = hq_env.command(["worker", "info", "1"], as_table=True)
     assert (
         table.get_row_value("Resources")
-        == "1x4 cpus\nfairy: Sum(10001000)\npotato: Indices(1-12)"
+        == "1x4 cpus\nfairy: Sum(10001000)\npotato: Range(1-12)\nshark: List(1,3,5,2)"
     )
 
 
-def test_task_resources1(hq_env: HqEnv):
+def test_task_resources_ignore_worker_without_resource(hq_env: HqEnv):
     hq_env.start_server()
-    hq_env.start_worker(cpus=4)
 
     hq_env.command(
         [
@@ -38,44 +40,65 @@ def test_task_resources1(hq_env: HqEnv):
             "fairy=1",
             "--resource",
             "potato=1000_000",
+            "hostname",
+        ]
+    )
+
+    def check_unscheduled():
+        time.sleep(0.5)
+        table = hq_env.command(["job", "info", "1"], as_table=True)
+        assert table.get_row_value("State") == "WAITING"
+
+    hq_env.start_worker(cpus=4)
+    check_unscheduled()
+
+    hq_env.start_worker(cpus=4, args=["--resource", "fairy=sum(1000)"])
+    check_unscheduled()
+
+    hq_env.start_worker(
+        cpus=4, args=["--resource", "fairy=sum(2)", "--resource", "potato=sum(500)"]
+    )
+    check_unscheduled()
+
+
+def test_task_resources_allocate(hq_env: HqEnv):
+    hq_env.start_server()
+
+    hq_env.command(
+        [
+            "submit",
+            "--resource",
+            "fairy=1000",
+            "--resource",
+            "potato=1",
             "--",
             "bash",
             "-c",
-            "echo $HQ_RESOURCE_REQUEST_fairy:$HQ_RESOURCE_REQUEST_potato"  # no comma here
-            ":$HQ_RESOURCE_INDICES_fairy:$HQ_RESOURCE_INDICES_potato",
+            "echo $HQ_RESOURCE_REQUEST_fairy:$HQ_RESOURCE_REQUEST_potato"  # no comma
+            ":$HQ_RESOURCE_VALUES_fairy:$HQ_RESOURCE_VALUES_potato",
         ]
     )
-    time.sleep(0.4)
-    table = hq_env.command(["job", "info", "1"], as_table=True)
-    assert table.get_row_value("State") == "WAITING"
-    assert (
-        table.get_row_value("Resources") == "cpus: 1 compact\nfairy: 1\npotato: 1000000"
-    )
-
-    hq_env.start_worker(cpus=4, args=["--resource", "potato=sum(2000_000)"])
-    time.sleep(0.4)
-    assert table.get_row_value("State") == "WAITING"
 
     hq_env.start_worker(
         cpus=4,
         args=[
             "--resource",
-            "potato=sum(2000_000)",
+            "fairy=sum(2000_000)",
             "--resource",
-            "fairy=indices(30-35)",
+            "potato=range(30-35)",
         ],
     )
     wait_for_job_state(hq_env, 1, "FINISHED")
 
-    with open("job-1/0.stdout") as f:
+    with open(default_task_output()) as f:
         f_count, p_count, f_idx, p_idx = f.read().rstrip().split(":")
-        assert f_count == "1"
-        assert p_count == "1000000"
-        assert 30 <= int(f_idx) <= 35
-        assert p_idx == ""
+        assert f_count == "1000"
+        assert p_count == "1"
+        assert f_idx == ""
+        assert 30 <= int(p_idx) <= 35
 
 
-def test_task_resources2(hq_env: HqEnv):
+def test_task_resources_range_multiple_allocated_values(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.start_worker(cpus=4)
 
@@ -88,17 +111,15 @@ def test_task_resources2(hq_env: HqEnv):
             "--",
             "bash",
             "-c",
-            "sleep 1; echo $HQ_RESOURCE_REQUEST_fairy:$HQ_RESOURCE_INDICES_fairy",
+            "sleep 1; echo $HQ_RESOURCE_REQUEST_fairy:$HQ_RESOURCE_VALUES_fairy",
         ]
     )
-    hq_env.start_worker(
-        cpus=4, args=["--resource", "--resource", "fairy=indices(31-36)"]
-    )
+    hq_env.start_worker(cpus=4, args=["--resource", "--resource", "fairy=range(31-36)"])
     wait_for_job_state(hq_env, 1, "FINISHED")
 
     all_values = []
     for i in range(1, 4):
-        with open(f"job-1/{i}.stdout") as f:
+        with open(default_task_output(task_id=i)) as f:
             rq, indices = f.read().rstrip().split(":")
             assert rq == "2"
             values = [int(x) for x in indices.split(",")]
@@ -108,7 +129,7 @@ def test_task_resources2(hq_env: HqEnv):
     assert len(set(all_values)) == 6
 
 
-def test_worker_resource_mem(hq_env: HqEnv):
+def test_worker_resource_hwdetect_mem(hq_env: HqEnv):
     hq_env.start_server()
     resources = hq_env.command(["worker", "hwdetect"])
 


### PR DESCRIPTION
This PR Introduces a new `GenericResourceDescriptorKind` which stores a list of arbitrary numbers.

Backward incompatible changes:
1) `indices` was renamed to `range` in specifying worker resources.
2) `HQ_RESOURCE_INDICES_<resource name>` was renamed to `HQ_RESOURCE_VALUES_<resource name>`