### PR TITLE
Use chumsky and ariadne for better error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Dev
 
+## Changes
+
+### CLI
+* [#455](https://github.com/It4innovations/hyperqueue/pull/445) Improve the quality of error messages
+produced when parsing various CLI parameters, like resources.
+
 ## Fixes
 
-## Job submission
+### Job submission
 * [#450](https://github.com/It4innovations/hyperqueue/pull/450) Attempts to resubmit a job with zero
 tasks will now result in an explicit error, rather than a crash of the client.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,15 +42,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
-name = "ariadne"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1cb2a2046bea8ce5e875551f5772024882de0b540c7f93dfc5d6cf1ca8b030c"
-dependencies = [
- "yansi",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,7 +826,6 @@ name = "hyperqueue"
 version = "0.11.0"
 dependencies = [
  "anyhow",
- "ariadne",
  "async-compression",
  "atty",
  "bincode",
@@ -2427,12 +2417,6 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +40,15 @@ name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+
+[[package]]
+name = "ariadne"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1cb2a2046bea8ce5e875551f5772024882de0b540c7f93dfc5d6cf1ca8b030c"
+dependencies = [
+ "yansi",
+]
 
 [[package]]
 name = "arrayvec"
@@ -164,6 +182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d02796e4586c6c41aeb68eae9bfb4558a522c35f1430c14b40136c3706e09e4"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +281,28 @@ dependencies = [
  "once_cell",
  "terminal_size",
  "winapi",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
+dependencies = [
+ "getrandom",
+ "lazy_static",
+ "proc-macro-hack",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -365,6 +414,12 @@ dependencies = [
  "cfg-if",
  "lazy_static",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "csv"
@@ -780,6 +835,7 @@ name = "hyperqueue"
 version = "0.11.0"
 dependencies = [
  "anyhow",
+ "ariadne",
  "async-compression",
  "atty",
  "bincode",
@@ -787,6 +843,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "chumsky",
  "clap 3.1.18",
  "clap_complete",
  "cli-table",
@@ -801,6 +858,7 @@ dependencies = [
  "hex",
  "humantime",
  "indicatif",
+ "insta",
  "jemallocator",
  "log",
  "nom",
@@ -881,6 +939,20 @@ dependencies = [
  "quote",
  "syn",
  "unindent",
+]
+
+[[package]]
+name = "insta"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126dd76ebfe2561486a1bd6738a33d2029ffb068a99ac446b7f8c77b2e58dbc"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "similar",
 ]
 
 [[package]]
@@ -982,6 +1054,12 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -1749,6 +1827,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +1855,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "slab"
@@ -1955,6 +2051,15 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2313,6 +2418,21 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/crates/hyperqueue/Cargo.toml
+++ b/crates/hyperqueue/Cargo.toml
@@ -50,7 +50,8 @@ async-compression = { version = "0.3.8", features = ["tokio", "gzip"] }
 flate2 = { version = "1.0.23", features = ["default"] }
 psutil = "3.2.1"
 rand = { version = "0.8", features = ["small_rng"] }
-
+chumsky = "0.8.0"
+ariadne = "0.1.5"
 
 # Tako
 tako = { path = "../tako" }
@@ -60,6 +61,7 @@ jemallocator = { version = "0.5", optional = true }
 
 [dev-dependencies]
 derive_builder = "0.11"
+insta = "1.15.0"
 
 [features]
 default = ["jemalloc"]

--- a/crates/hyperqueue/Cargo.toml
+++ b/crates/hyperqueue/Cargo.toml
@@ -51,7 +51,6 @@ flate2 = { version = "1.0.23", features = ["default"] }
 psutil = "3.2.1"
 rand = { version = "0.8", features = ["small_rng"] }
 chumsky = "0.8.0"
-ariadne = "0.1.5"
 
 # Tako
 tako = { path = "../tako" }

--- a/crates/hyperqueue/src/common/mod.rs
+++ b/crates/hyperqueue/src/common/mod.rs
@@ -7,6 +7,7 @@ pub mod format;
 pub mod idcounter;
 pub mod manager;
 pub mod parser;
+pub mod parser2;
 pub mod placeholders;
 pub mod rpc;
 pub mod serverdir;

--- a/crates/hyperqueue/src/common/parser2.rs
+++ b/crates/hyperqueue/src/common/parser2.rs
@@ -1,0 +1,202 @@
+use ariadne::{Color, Fmt, Label, Report, ReportKind, Source};
+use chumsky::error::Simple;
+use chumsky::primitive::end;
+use chumsky::Parser;
+
+// Parsing infrastructure
+pub struct ParseResult<'a, T> {
+    input: &'a str,
+    pub result: Result<T, Vec<Simple<char>>>,
+}
+
+impl<'a, T> ParseResult<'a, T> {
+    fn new(input: &'a str, result: Result<T, Vec<Simple<char>>>) -> Self {
+        Self { input, result }
+    }
+
+    pub fn into_cli_result(self) -> anyhow::Result<T> {
+        self.result
+            .map_err(|errors| anyhow::anyhow!("{}", format_errors_cli(self.input, errors)))
+    }
+
+    pub fn into_debug_result(self) -> anyhow::Result<T> {
+        self.result
+            .map_err(|errors| anyhow::anyhow!("{:?}", errors))
+    }
+
+    #[track_caller]
+    pub fn unwrap(self) -> T {
+        self.result.unwrap()
+    }
+}
+
+pub trait CharParser<T>: Parser<char, T, Error = Simple<char>> + Sized {
+    fn parse_text<'a>(&self, input: &'a str) -> ParseResult<'a, T> {
+        ParseResult::new(input, self.parse(input))
+    }
+}
+impl<T, P> CharParser<T> for P where P: Parser<char, T, Error = Simple<char>> {}
+
+pub fn format_errors_cli(input: &str, errors: Vec<Simple<char>>) -> String {
+    use std::io::Write;
+
+    let mut error: Vec<u8> = vec![];
+
+    for e in errors {
+        let msg = if let chumsky::error::SimpleReason::Custom(msg) = e.reason() {
+            msg.clone()
+        } else {
+            format!(
+                "{}{}, expected {}",
+                if e.found().is_some() {
+                    "Unexpected token"
+                } else {
+                    "Unexpected end of input"
+                },
+                if let Some(label) = e.label() {
+                    format!(" while parsing {}", label)
+                } else {
+                    String::new()
+                },
+                if e.expected().len() == 0 {
+                    "something else".to_string()
+                } else {
+                    e.expected()
+                        .map(|expected| match expected {
+                            Some(expected) => expected.to_string(),
+                            None => "end of input".to_string(),
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                },
+            )
+        };
+
+        let report = Report::build(ReportKind::Error, (), e.span().start)
+            .with_message(msg)
+            .with_label(
+                Label::new(e.span())
+                    .with_message(match e.reason() {
+                        chumsky::error::SimpleReason::Custom(msg) => msg.clone(),
+                        _ => format!(
+                            "Unexpected {}",
+                            e.found()
+                                .map(|c| format!("token {}", c.fg(Color::Red)))
+                                .unwrap_or_else(|| "end of input".to_string())
+                        ),
+                    })
+                    .with_color(Color::Red),
+            );
+
+        let report = match e.reason() {
+            chumsky::error::SimpleReason::Unclosed { span, delimiter } => report.with_label(
+                Label::new(span.clone())
+                    .with_message(format!(
+                        "Unclosed delimiter {}",
+                        delimiter.fg(Color::Yellow)
+                    ))
+                    .with_color(Color::Yellow),
+            ),
+            chumsky::error::SimpleReason::Unexpected => report,
+            chumsky::error::SimpleReason::Custom(_) => report,
+        };
+
+        if !input.is_empty() {
+            report
+                .finish()
+                .write(Source::from(input), &mut error)
+                .unwrap();
+        } else {
+            writeln!(&mut error, "Input is empty").unwrap();
+        }
+    }
+    String::from_utf8(error).expect(
+        "A parsing error has occurred and \
+HyperQueue was unable to format it. This is a bug in HyperQueue, please report it if you see it.",
+    )
+}
+
+// Common parsers
+fn parse_integer_string() -> impl CharParser<String> {
+    let digit = chumsky::primitive::filter(|c: &char| c.is_digit(10));
+    let underscore = chumsky::primitive::just('_');
+    let digit_or_underscore = underscore.or(digit.clone()).repeated();
+
+    digit
+        .chain(digit_or_underscore)
+        .map(|chars| {
+            chars
+                .into_iter()
+                .filter(|c| c.is_digit(10))
+                .collect::<String>()
+        })
+        .labelled("number")
+}
+
+/// Parse 4-byte integer.
+pub fn parse_u32() -> impl CharParser<u32> {
+    parse_integer_string().try_map(|p, span| {
+        p.parse::<u32>()
+            .map_err(|_| Simple::custom(span, "Cannot parse as 4-byte unsigned integer"))
+    })
+}
+
+/// Parse 8-byte integer.
+pub fn parse_u64() -> impl CharParser<u64> {
+    parse_integer_string().try_map(|p, span| {
+        p.parse::<u64>()
+            .map_err(|_| Simple::custom(span, "Cannot parse as 8-byte unsigned integer"))
+    })
+}
+
+/// Return a parser that will fail if there is any input following the text parsed by the
+/// provided parser.
+pub fn all_consuming<T>(parser: impl CharParser<T>) -> impl CharParser<T> {
+    parser.then_ignore(end())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_u32() {
+        assert_eq!(parse_u32().parse_text("0").unwrap(), 0);
+        assert_eq!(parse_u32().parse_text("1").unwrap(), 1);
+        assert_eq!(parse_u32().parse_text("1019").unwrap(), 1019);
+    }
+
+    fn expect_parser_error<T: std::fmt::Debug>(parser: impl CharParser<T>, input: &str) -> String {
+        let error = parser.parse_text(input).into_debug_result().unwrap_err();
+        format!("{:?}", error)
+    }
+
+    #[test]
+    fn test_parse_u32_empty() {
+        insta::assert_debug_snapshot!(expect_parser_error(parse_u32(), ""), @r###""[Simple { span: 0..0, reason: Unexpected, expected: {}, found: None, label: Some(\"number\") }]""###);
+    }
+
+    #[test]
+    fn test_parse_u32_invalid() {
+        insta::assert_debug_snapshot!(expect_parser_error(parse_u32(), "x"), @r###""[Simple { span: 0..1, reason: Unexpected, expected: {}, found: Some('x'), label: Some(\"number\") }]""###);
+    }
+
+    #[test]
+    fn test_parse_u32_underscores() {
+        assert_eq!(parse_u32().parse_text("0_1").unwrap(), 1);
+        assert_eq!(parse_u32().parse_text("1_").unwrap(), 1);
+        assert_eq!(parse_u32().parse_text("100_100").unwrap(), 100100);
+        assert_eq!(parse_u32().parse_text("123_456_789").unwrap(), 123456789);
+    }
+
+    #[test]
+    fn test_parse_u32_repeated_underscore() {
+        assert_eq!(parse_u32().parse_text("1___0__0_0").unwrap(), 1000);
+    }
+
+    #[test]
+    fn test_parse_u32_starts_with_underscore() {
+        insta::assert_debug_snapshot!(expect_parser_error(parse_u32(), "_"), @r###""[Simple { span: 0..1, reason: Unexpected, expected: {}, found: Some('_'), label: Some(\"number\") }]""###);
+        insta::assert_debug_snapshot!(expect_parser_error(parse_u32(), "_1"), @r###""[Simple { span: 0..1, reason: Unexpected, expected: {}, found: Some('_'), label: Some(\"number\") }]""###);
+    }
+}

--- a/crates/hyperqueue/src/common/utils/time.rs
+++ b/crates/hyperqueue/src/common/utils/time.rs
@@ -2,7 +2,6 @@ use std::time::{Duration, SystemTime};
 
 use anyhow::anyhow;
 use chrono::TimeZone;
-use chumsky::error::Simple;
 use chumsky::prelude::just;
 use chumsky::Parser;
 
@@ -40,7 +39,7 @@ fn parse_hms_time_inner() -> impl CharParser<Duration> {
         ((hours, Some(minutes)), Some(seconds)) => Ok(Duration::from_secs(
             hours as u64 * 3600 + minutes as u64 * 60 + seconds as u64,
         )),
-        _ => Err(Simple::custom(span, "Invalid time specification")),
+        _ => Err(ParseError::custom(span, "Invalid time specification")),
     })
     .labelled("time in [[HH:]MM:]SS format")
 }
@@ -56,7 +55,7 @@ pub fn now_monotonic() -> std::time::Instant {
     std::time::Instant::now()
 }
 
-use crate::common::parser2::{all_consuming, parse_u32, CharParser};
+use crate::common::parser2::{all_consuming, parse_u32, CharParser, ParseError};
 #[cfg(test)]
 pub use mock_time::now_monotonic;
 

--- a/crates/hyperqueue/src/common/utils/time.rs
+++ b/crates/hyperqueue/src/common/utils/time.rs
@@ -2,12 +2,9 @@ use std::time::{Duration, SystemTime};
 
 use anyhow::anyhow;
 use chrono::TimeZone;
-use nom::character::complete::char;
-use nom::combinator::{map_res, opt};
-use nom::sequence::{preceded, tuple};
-use nom_supreme::ParserExt;
-
-use crate::common::parser::{consume_all, p_u32, NomResult};
+use chumsky::error::Simple;
+use chumsky::prelude::just;
+use chumsky::Parser;
 
 // Allows specifying humantime format (2h, 3m, etc.)
 crate::arg_wrapper!(ArgDuration, Duration, humantime::parse_duration);
@@ -29,31 +26,29 @@ pub fn local_to_system_time(datetime: chrono::NaiveDateTime) -> SystemTime {
     chrono::Local.from_local_datetime(&datetime).unwrap().into()
 }
 
-fn p_hms_time(input: &str) -> NomResult<Duration> {
-    map_res(
-        tuple((
-            p_u32,
-            opt(preceded(char(':'), p_u32)),
-            opt(preceded(char(':'), p_u32)),
-        ))
-        .context("[[HH:]MM:]SS value"),
-        |parsed| match parsed {
-            (seconds, None, None) => Ok(Duration::from_secs(seconds as u64)),
-            (minutes, Some(seconds), None) => {
-                Ok(Duration::from_secs(minutes as u64 * 60 + seconds as u64))
-            }
-            (hours, Some(minutes), Some(seconds)) => Ok(Duration::from_secs(
-                hours as u64 * 3600 + minutes as u64 * 60 + seconds as u64,
-            )),
-            _ => Err(anyhow!("Invalid time specification")),
-        },
-    )(input)
+fn parse_hms_time_inner() -> impl CharParser<Duration> {
+    let digits = parse_u32();
+    let time2 = just(':').ignore_then(parse_u32()).or_not();
+    let time3 = just(':').ignore_then(parse_u32()).or_not();
+
+    let time = digits.then(time2).then(time3);
+    time.try_map(|parsed, span| match parsed {
+        ((seconds, None), None) => Ok(Duration::from_secs(seconds as u64)),
+        ((minutes, Some(seconds)), None) => {
+            Ok(Duration::from_secs(minutes as u64 * 60 + seconds as u64))
+        }
+        ((hours, Some(minutes)), Some(seconds)) => Ok(Duration::from_secs(
+            hours as u64 * 3600 + minutes as u64 * 60 + seconds as u64,
+        )),
+        _ => Err(Simple::custom(span, "Invalid time specification")),
+    })
+    .labelled("time in [[HH:]MM:]SS format")
 }
 
 /// Parses time strings in the format [[hh:]mm:]ss.
 /// Individual time values may be zero padded.
 pub fn parse_hms_time(input: &str) -> anyhow::Result<Duration> {
-    consume_all(p_hms_time, input)
+    all_consuming(parse_hms_time_inner()).parse_text(input)
 }
 
 #[cfg(not(test))]
@@ -61,6 +56,7 @@ pub fn now_monotonic() -> std::time::Instant {
     std::time::Instant::now()
 }
 
+use crate::common::parser2::{all_consuming, parse_u32, CharParser};
 #[cfg(test)]
 pub use mock_time::now_monotonic;
 
@@ -100,44 +96,64 @@ pub mod mock_time {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::utils::time::{p_hms_time, parse_hms_time};
-    use crate::tests::utils::check_parse_error;
+    use crate::common::parser2::{all_consuming, CharParser};
+    use crate::common::utils::time::parse_hms_time_inner;
+    use crate::tests::utils::expect_parser_error;
 
     #[test]
     fn parse_hms_seconds() {
-        let duration = parse_hms_time("01").unwrap();
+        let duration = parse_hms_time_inner().parse_text("01").unwrap();
         assert_eq!(duration.as_secs(), 1);
 
-        let duration = parse_hms_time("1").unwrap();
+        let duration = parse_hms_time_inner().parse_text("1").unwrap();
         assert_eq!(duration.as_secs(), 1);
     }
 
     #[test]
     fn parse_hms_minutes() {
-        let duration = parse_hms_time("1:1").unwrap();
+        let duration = parse_hms_time_inner().parse_text("1:1").unwrap();
         assert_eq!(duration.as_secs(), 1 * 60 + 1);
 
-        let duration = parse_hms_time("80:02").unwrap();
+        let duration = parse_hms_time_inner().parse_text("80:02").unwrap();
         assert_eq!(duration.as_secs(), 80 * 60 + 2);
     }
 
     #[test]
     fn parse_hms_hours() {
-        let duration = parse_hms_time("1:1:1").unwrap();
+        let duration = parse_hms_time_inner().parse_text("1:1:1").unwrap();
         assert_eq!(duration.as_secs(), 1 * 3600 + 1 * 60 + 1);
 
-        let duration = parse_hms_time("02:03:04").unwrap();
+        let duration = parse_hms_time_inner().parse_text("02:03:04").unwrap();
         assert_eq!(duration.as_secs(), 2 * 3600 + 3 * 60 + 4);
     }
 
     #[test]
-    fn parse_hms_error() {
-        check_parse_error(
-            p_hms_time,
-            "x",
-            r#"Parse error
-expected [[HH:]MM:]SS value at character 0: "x"
-expected integer at character 0: "x""#,
-        );
+    fn parse_hms_no_number() {
+        insta::assert_snapshot!(expect_parser_error(parse_hms_time_inner(), "x"), @r###"
+        Unexpected token found while attempting to parse number, expected something else:
+          x
+          |
+          --- Unexpected token `x`
+        "###);
+    }
+
+    #[test]
+    fn parse_hms_trailing_colon() {
+        insta::assert_snapshot!(expect_parser_error(all_consuming(parse_hms_time_inner()), "12:"), @r###"
+        Unexpected end of input found while attempting to parse number, expected something else:
+          12:
+             |
+             --- Unexpected end of input
+        "###);
+    }
+
+    #[test]
+    fn parse_hms_minutes_no_number() {
+        insta::assert_snapshot!(expect_parser_error(all_consuming(parse_hms_time_inner()), "12:x"), @r###"
+        Unexpected token found while attempting to parse number, expected something else:
+          12:x
+             |
+             --- Unexpected token `x`
+        "###);
     }
 }

--- a/crates/hyperqueue/src/tests/utils.rs
+++ b/crates/hyperqueue/src/tests/utils.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use tokio::task::{JoinHandle, LocalSet};
 
 use crate::common::parser::{consume_all, NomResult};
+use crate::common::parser2::CharParser;
 use crate::server::state::StateRef;
 
 pub fn check_parse_error<F: FnMut(&str) -> NomResult<O>, O>(
@@ -17,6 +18,11 @@ pub fn check_parse_error<F: FnMut(&str) -> NomResult<O>, O>(
         }
         _ => panic!("The parser should have failed"),
     }
+}
+
+pub fn expect_parser_error<T: std::fmt::Debug>(parser: impl CharParser<T>, input: &str) -> String {
+    let error = parser.parse_text(input).unwrap_err();
+    format!("{:?}", error)
 }
 
 pub async fn run_concurrent<

--- a/crates/hyperqueue/src/worker/parser.rs
+++ b/crates/hyperqueue/src/worker/parser.rs
@@ -1,6 +1,8 @@
 use crate::arg_wrapper;
-use crate::common::parser2::{all_consuming, parse_u32, parse_u64, CharParser};
-use chumsky::error::Simple;
+use crate::common::parser2::{
+    all_consuming, parse_exact_string, parse_named_string, parse_u32, parse_u64, CharParser,
+    ParseError,
+};
 use chumsky::primitive::just;
 use chumsky::text::{whitespace, TextParser};
 use chumsky::Parser;
@@ -70,36 +72,33 @@ arg_wrapper!(
 /// The list must be non-empty and it has to contain uniaue values.
 /// Example: `list(1, 2)`.
 fn parse_resource_list() -> impl CharParser<GenericResourceDescriptorKind> {
-    let start = just("list").then(just('(').padded());
+    let start = parse_exact_string("list").padded().then(just('(').padded());
     let end = just(')').padded();
 
     let indices = parse_u32()
         .separated_by(just(',').padded())
-        .delimited_by(start, end)
-        .labelled("list indices");
-    indices
-        .try_map(|indices, span| {
-            if indices.is_empty() {
-                Err(Simple::custom(
-                    span,
-                    "List has to contain at least a single element",
-                ))
-            } else {
-                GenericResourceDescriptorKind::list(indices).map_err(|error| match error {
-                    DescriptorError::GenericResourceListItemsNotUnique => {
-                        Simple::custom(span, "List items have to be unique")
-                    }
-                })
-            }
-        })
-        .labelled("list resource")
+        .delimited_by(start, end);
+    indices.try_map(|indices, span| {
+        if indices.is_empty() {
+            Err(ParseError::custom(
+                span,
+                "List has to contain at least a single element",
+            ))
+        } else {
+            GenericResourceDescriptorKind::list(indices).map_err(|error| match error {
+                DescriptorError::GenericResourceListItemsNotUnique => {
+                    ParseError::custom(span, "List items have to be unique")
+                }
+            })
+        }
+    })
 }
 
 /// Parses a range resource.
 /// The start of the range must be smaller or equal to the end.
 /// Example: `range(1-5)`.
 fn parse_resource_range() -> impl CharParser<GenericResourceDescriptorKind> {
-    let start = just("range").then(just('(').padded());
+    let start = parse_exact_string("range").then(just('(').padded());
     let end = just(')').padded();
 
     let range = parse_u32()
@@ -112,7 +111,7 @@ fn parse_resource_range() -> impl CharParser<GenericResourceDescriptorKind> {
         .delimited_by(start, end)
         .try_map(|(start, end), span| {
             if start > end {
-                Err(Simple::custom(
+                Err(ParseError::custom(
                     span,
                     "Start must be greater or equal to end",
                 ))
@@ -123,38 +122,39 @@ fn parse_resource_range() -> impl CharParser<GenericResourceDescriptorKind> {
                 })
             }
         })
-        .labelled("range resource")
 }
 
 /// Parse a sum resource.
 /// Example: `sum(100)`.
 fn parse_resource_sum() -> impl CharParser<GenericResourceDescriptorKind> {
-    let start = just("sum").then(just('(').padded());
+    let start = parse_exact_string("sum").then(just('(').padded());
     let end = just(')').padded();
 
     let value = parse_u64()
         .labelled("sum")
         .map(|size| GenericResourceDescriptorKind::Sum { size });
 
-    value.delimited_by(start, end).labelled("sum resource")
+    value.delimited_by(start, end)
 }
 
 /// Parses a resource definition, which consists of a name and a resource kind.
 /// Example: `mem=list(1,2)`, `disk=sum(10)`, `foo=range(1-2)`.
 fn parse_resource_definition_inner() -> impl CharParser<GenericResourceDescriptor> {
-    let name = chumsky::text::ident()
-        .repeated()
+    let name = parse_named_string("identifier")
         .padded()
-        .collect::<String>();
-    let equal = just('=').padded_by(whitespace());
-    let kind = (parse_resource_list()
-        .or(parse_resource_range())
-        .or(parse_resource_sum()))
-    .labelled("Resource kind");
+        .labelled("resource name");
+    let equal = just('=').padded();
+    let kind = chumsky::primitive::choice((
+        parse_resource_list(),
+        parse_resource_range(),
+        parse_resource_sum(),
+    ))
+    .labelled("resource kind");
 
     name.then_ignore(equal)
         .then(kind)
         .map(|(name, kind)| GenericResourceDescriptor { name, kind })
+        .labelled("resource definition")
 }
 
 fn parse_resource_definition(input: &str) -> anyhow::Result<GenericResourceDescriptor> {
@@ -275,7 +275,7 @@ mod test {
     #[test]
     fn test_parse_resource_def_list_non_unique() {
         insta::assert_snapshot!(expect_parser_error(parse_resource_definition_inner(), "mem=list(1,2,1)"), @r###"
-        Unexpected end of input found while attempting to parse list resource, expected something else:
+        Unexpected end of input found while attempting to parse resource kind, expected something else:
           mem=list(1,2,1)
               |
               --- List items have to be unique
@@ -285,7 +285,7 @@ mod test {
     #[test]
     fn test_parse_resource_def_list_empty() {
         insta::assert_snapshot!(expect_parser_error(parse_resource_definition_inner(), "mem=list()"), @r###"
-        Unexpected end of input found while attempting to parse list resource, expected something else:
+        Unexpected end of input found while attempting to parse resource kind, expected something else:
           mem=list()
               |
               --- List has to contain at least a single element
@@ -301,7 +301,20 @@ mod test {
                 assert_eq!(start.as_num(), 10);
                 assert_eq!(end.as_num(), 123);
             }
-            _ => panic!("Wrong result"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn test_parse_resource_def_range_whitespace() {
+        let rd = parse_resource_definition("  gpu  =  range  ( 10 -  123 ) ").unwrap();
+        assert_eq!(rd.name, "gpu");
+        match rd.kind {
+            GenericResourceDescriptorKind::Range { start, end } => {
+                assert_eq!(start.as_num(), 10);
+                assert_eq!(end.as_num(), 123);
+            }
+            _ => panic!(),
         }
     }
 
@@ -328,7 +341,7 @@ mod test {
     #[test]
     fn test_parse_resource_def_start_larger_than_end() {
         insta::assert_snapshot!(expect_parser_error(parse_resource_definition_inner(), "gpu=range(5-3)"), @r###"
-        Unexpected end of input found while attempting to parse range resource, expected something else:
+        Unexpected end of input found while attempting to parse resource kind, expected something else:
           gpu=range(5-3)
               |
               --- Start must be greater or equal to end
@@ -338,6 +351,18 @@ mod test {
     #[test]
     fn test_parse_resource_def_sum() {
         let rd = parse_resource_definition("mem=sum(1000_3000_2000)").unwrap();
+        assert_eq!(rd.name, "mem");
+        assert!(matches!(
+            rd.kind,
+            GenericResourceDescriptorKind::Sum {
+                size: 1000_3000_2000
+            }
+        ));
+    }
+
+    #[test]
+    fn test_parse_resource_def_sum_whitespace() {
+        let rd = parse_resource_definition("   mem  = sum ( 1000_3000_2000 ) ").unwrap();
         assert_eq!(rd.name, "mem");
         assert!(matches!(
             rd.kind,
@@ -370,47 +395,55 @@ mod test {
     #[test]
     fn test_parse_resource_def_empty() {
         insta::assert_snapshot!(expect_parser_error(parse_resource_definition_inner(), ""), @r###"
-        Unexpected end of input found while attempting to parse Resource kind, expected something else:
-          gpu=range(5-3)
-              |
-              --- Start must be greater or equal to end
+        Unexpected end of input found while attempting to parse resource name, expected identifier:
+        (the input was empty)
         "###);
     }
 
     #[test]
     fn test_parse_resource_def_number() {
         insta::assert_snapshot!(expect_parser_error(parse_resource_definition_inner(), "1"), @r###"
-        Unexpected end of input found while attempting to parse Resource kind, expected something else:
-          gpu=range(5-3)
-              |
-              --- Start must be greater or equal to end
+        Unexpected token found while attempting to parse resource name, expected identifier:
+          1
+          |
+          --- Unexpected token `1`
         "###);
     }
 
     #[test]
     fn test_parse_resource_def_missing_value() {
         insta::assert_snapshot!(expect_parser_error(parse_resource_definition_inner(), "x="), @r###"
-        Unexpected end of input found while attempting to parse Resource kind, expected something else:
-          gpu=range(5-3)
-              |
-              --- Start must be greater or equal to end
+        Unexpected end of input found while attempting to parse resource kind, expected list or range or sum:
+          x=
+            |
+            --- Unexpected end of input
+        "###);
+    }
+
+    #[test]
+    fn test_parse_resource_def_invalid_resource_kind() {
+        insta::assert_snapshot!(expect_parser_error(parse_resource_definition_inner(), "x=foo"), @r###"
+        Unexpected token found while attempting to parse resource kind, expected list or range or sum:
+          x=foo
+            |
+            --- Unexpected token `foo`
         "###);
     }
 
     #[test]
     fn test_parse_resource_def_numeric_value() {
         insta::assert_snapshot!(expect_parser_error(parse_resource_definition_inner(), "x=1"), @r###"
-        Unexpected end of input found while attempting to parse Resource kind, expected something else:
-          gpu=range(5-3)
-              |
-              --- Start must be greater or equal to end
+        Unexpected token found while attempting to parse resource kind, expected list or range or sum:
+          x=1
+            |
+            --- Unexpected token `1`
         "###);
     }
 
     #[test]
     fn test_parse_resource_def_only_sum() {
         insta::assert_snapshot!(expect_parser_error(parse_resource_definition_inner(), "x=sum"), @r###"
-        Unexpected end of input found while attempting to parse sum resource, expected (:
+        Unexpected end of input found while attempting to parse resource kind, expected ( or list or range:
           x=sum
                |
                --- Unexpected end of input

--- a/crates/tako/src/internal/common/resources/descriptor.rs
+++ b/crates/tako/src/internal/common/resources/descriptor.rs
@@ -21,6 +21,7 @@ pub enum GenericResourceDescriptorKind {
     },
     Range {
         start: GenericResourceIndex,
+        // end is inclusive
         end: GenericResourceIndex,
     },
     // TODO: Named(Vec<String>),
@@ -30,7 +31,7 @@ pub enum GenericResourceDescriptorKind {
 }
 
 impl GenericResourceDescriptorKind {
-    pub fn list(mut values: Vec<GenericResourceIndex>) -> Result<Self, DescriptorError> {
+    pub fn list(mut values: Vec<u32>) -> Result<Self, DescriptorError> {
         let count = values.len();
         values.sort_unstable();
         values.dedup();
@@ -38,7 +39,9 @@ impl GenericResourceDescriptorKind {
         if values.len() < count {
             Err(DescriptorError::GenericResourceListItemsNotUnique)
         } else {
-            Ok(GenericResourceDescriptorKind::List { values })
+            Ok(GenericResourceDescriptorKind::List {
+                values: values.into_iter().map(|idx| idx.into()).collect(),
+            })
         }
     }
 
@@ -75,15 +78,10 @@ pub struct GenericResourceDescriptor {
 }
 
 impl GenericResourceDescriptor {
-    pub fn list<Index: Into<GenericResourceIndex>>(
-        name: &str,
-        values: Vec<Index>,
-    ) -> Result<Self, DescriptorError> {
+    pub fn list(name: &str, values: Vec<u32>) -> Result<Self, DescriptorError> {
         Ok(GenericResourceDescriptor {
             name: name.to_string(),
-            kind: GenericResourceDescriptorKind::list(
-                values.into_iter().map(|idx| idx.into()).collect(),
-            )?,
+            kind: GenericResourceDescriptorKind::list(values)?,
         })
     }
     pub fn range<Index: Into<GenericResourceIndex>>(name: &str, start: Index, end: Index) -> Self {

--- a/crates/tako/src/internal/common/resources/mod.rs
+++ b/crates/tako/src/internal/common/resources/mod.rs
@@ -10,7 +10,8 @@ pub use allocation::{
     ResourceAllocation,
 };
 pub use descriptor::{
-    CpusDescriptor, GenericResourceDescriptor, GenericResourceDescriptorKind, ResourceDescriptor,
+    CpusDescriptor, DescriptorError, GenericResourceDescriptor, GenericResourceDescriptorKind,
+    ResourceDescriptor,
 };
 pub use request::{CpuRequest, GenericResourceRequest, ResourceRequest, TimeRequest};
 

--- a/crates/tako/src/lib.rs
+++ b/crates/tako/src/lib.rs
@@ -40,7 +40,7 @@ pub mod resources {
     pub use crate::internal::common::resources::map::ResourceMap;
 
     pub use crate::internal::common::resources::descriptor::{
-        cpu_descriptor_from_socket_size, CpusDescriptor,
+        cpu_descriptor_from_socket_size, CpusDescriptor, DescriptorError,
     };
 }
 

--- a/tests/pyapi/test_cluster.py
+++ b/tests/pyapi/test_cluster.py
@@ -1,4 +1,5 @@
 import pytest
+
 from hyperqueue.cluster import LocalCluster
 from hyperqueue.job import Job
 

--- a/tests/pyapi/test_function.py
+++ b/tests/pyapi/test_function.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from hyperqueue.client import Client, FailedJobsException, PythonEnv
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -2,6 +2,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from hyperqueue.client import FailedJobsException
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job


### PR DESCRIPTION
This PR ports most user-facing parsers from `nom` to `chumsky`, with the main motivation to improve error messages. You can check the new output in tests.

I didn't port client resource requests in this PR, since they are pending on resource variants.

![image](https://user-images.githubusercontent.com/4539057/176681678-983b6f80-8a88-4565-8abc-b9c759434a1e.png)