### PR TITLE
Terminate all executing tasks when a worker ends abruptly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,7 @@ dependencies = [
  "humantime",
  "indicatif",
  "jemallocator",
+ "libc",
  "log",
  "nom",
  "nom-supreme",

--- a/crates/hyperqueue/Cargo.toml
+++ b/crates/hyperqueue/Cargo.toml
@@ -50,7 +50,7 @@ async-compression = { version = "0.3.8", features = ["tokio", "gzip"] }
 flate2 = { version = "1.0.23", features = ["default"] }
 psutil = "3.2.1"
 rand = { version = "0.8", features = ["small_rng"] }
-
+libc = "0.2.126"
 
 # Tako
 tako = { path = "../tako" }

--- a/tests/pyapi/__init__.py
+++ b/tests/pyapi/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Tuple
 
 from hyperqueue.client import Client
 from hyperqueue.job import Job
@@ -14,7 +14,3 @@ def prepare_job_client(
         hq_env.start_worker()
     client = Client(hq_env.server_dir)
     return (Job(**job_args), client)
-
-
-def bash(command: str) -> List[str]:
-    return ["bash", "-c", command]

--- a/tests/pyapi/test_cluster.py
+++ b/tests/pyapi/test_cluster.py
@@ -1,4 +1,5 @@
 import pytest
+
 from hyperqueue.cluster import LocalCluster
 from hyperqueue.job import Job
 

--- a/tests/pyapi/test_dependencies.py
+++ b/tests/pyapi/test_dependencies.py
@@ -1,6 +1,8 @@
+from utils.job import bash
+
 from ..conftest import HqEnv
 from ..utils import wait_for_job_state
-from . import bash, prepare_job_client
+from . import prepare_job_client
 
 
 def test_single_dep(hq_env: HqEnv):

--- a/tests/pyapi/test_function.py
+++ b/tests/pyapi/test_function.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from hyperqueue.client import Client, FailedJobsException, PythonEnv
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -2,6 +2,8 @@ import time
 from pathlib import Path
 
 import pytest
+from utils.job import bash
+
 from hyperqueue.client import FailedJobsException
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job
@@ -10,7 +12,7 @@ from ..conftest import HqEnv
 from ..utils import wait_for_job_state
 from ..utils.io import check_file_contents
 from ..utils.table import parse_multiline_cell
-from . import bash, prepare_job_client
+from . import prepare_job_client
 
 
 def test_submit_empty_job(hq_env: HqEnv):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,4 @@ isort==5.10.1
 iso8601==1.0.0
 schema==0.7.5
 maturin==0.12.6
+psutil==5.8.0

--- a/tests/utils/io.py
+++ b/tests/utils/io.py
@@ -1,3 +1,7 @@
 def check_file_contents(path: str, content):
+    assert read_file(path) == str(content)
+
+
+def read_file(path: str) -> str:
     with open(path) as f:
-        assert f.read() == str(content)
+        return f.read()

--- a/tests/utils/job.py
+++ b/tests/utils/job.py
@@ -21,3 +21,17 @@ def list_jobs(hq_env: HqEnv, all=True, filters: List[str] = None) -> Table:
         args.extend(["--filter", ",".join(filters)])
 
     return hq_env.command(args, as_table=True)
+
+
+def bash(command: str) -> List[str]:
+    """
+    Returns commands that will run the specified command as a bash script.
+    """
+    return ["bash", "-c", command]
+
+
+def python(command: str) -> List[str]:
+    """
+    Returns commands that will run the specified command as a Python script.
+    """
+    return ["python3", "-c", command]


### PR DESCRIPTION
This PR uses `DEATHSIG` (suggested [here](https://github.com/It4innovations/hyperqueue/issues/431#issuecomment-1163842887)) to make sure that if a worker crashes, its running tasks will be terminated.

This introduces a constant overhead, but it's only noticeable only for very short tasks (sub 1 ms).

Fixes: https://github.com/It4innovations/hyperqueue/issues/431