### PR TITLE
Use `--overlap` flag when starting HQ workers in Slurm allocations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 * [#455](https://github.com/It4innovations/hyperqueue/pull/445) Improve the quality of error messages
 produced when parsing various CLI parameters, like resources.
 
+### Automatic allocation
+* [#448](https://github.com/It4innovations/hyperqueue/pull/448) The automatic allocator will now start
+workers in multi-node Slurm allocations using `srun --overlap`. This should avoid taking up Slurm
+task resources by the started workers (if possible). If you run into any issues with using `srun`
+inside HyperQueue tasks, please let us know.
+
 ## Fixes
 
 ### Job submission

--- a/crates/hyperqueue/src/server/autoalloc/queue/slurm.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/slurm.rs
@@ -207,7 +207,7 @@ fn build_slurm_submit_script(
         script.push_str(&format!("#SBATCH {}\n", sbatch_args));
     }
 
-    let prefix = if nodes > 1 { "srun " } else { "" };
+    let prefix = if nodes > 1 { "srun --overlap " } else { "" };
     script.push_str(&format!("\n{prefix}{worker_cmd}"));
     script
 }

--- a/tests/autoalloc/test_autoalloc_slurm.py
+++ b/tests/autoalloc/test_autoalloc_slurm.py
@@ -76,7 +76,7 @@ def test_slurm_command_multinode_allocation(hq_env: HqEnv):
             commands = extract_script_commands(f.read())
             assert (
                 commands
-                == f"srun {get_hq_binary()} worker start --idle-timeout 5m \
+                == f"srun --overlap {get_hq_binary()} worker start --idle-timeout 5m \
 --manager slurm --server-dir {hq_env.server_dir}/001 --on-server-lost=finish-running"
             )
 


### PR DESCRIPTION
This should make it less likely that the resources allocated for these workers will
interfere with manual `srun` invocations executed by HQ tasks.

Fixes: https://github.com/It4innovations/hyperqueue/issues/443