### PR TITLE
Handle crashing tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ inside HyperQueue tasks, please let us know.
 
 ## Fixes
 
+### Crashing tasks
+* [#449](https://github.com/It4innovations/hyperqueue/pull/449) Tasks that were present during multiple
+crashes of the workers will be canceled.
+
 ### Job submission
 * [#450](https://github.com/It4innovations/hyperqueue/pull/450) Attempts to resubmit a job with zero
 tasks will now result in an explicit error, rather than a crash of the client.

--- a/crates/hyperqueue/src/server/rpc.rs
+++ b/crates/hyperqueue/src/server/rpc.rs
@@ -104,9 +104,9 @@ impl Backend {
                         ToGatewayMessage::NewWorker(msg) => {
                             state_ref.get_mut().process_worker_new(msg)
                         }
-                        ToGatewayMessage::LostWorker(msg) => {
-                            state_ref.get_mut().process_worker_lost(msg)
-                        }
+                        ToGatewayMessage::LostWorker(msg) => state_ref
+                            .get_mut()
+                            .process_worker_lost(&state_ref, &server2, msg),
                         ToGatewayMessage::WorkerOverview(overview) => {
                             state_ref
                                 .get_mut()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1261,3 +1261,37 @@ def test_zero_custom_error_message(hq_env: HqEnv):
         == "Error: Task created an error file, but it is empty"
     )
     # print(table)
+
+
+def test_crashing_job_by_status(hq_env: HqEnv):
+    hq_env.start_server()
+    # Crashing tasks threshold is 5
+    hq_env.command(["submit", "sleep", "10"])
+    for i in range(5):
+        hq_env.start_worker()
+        wait_for_job_state(hq_env, 1, "RUNNING")
+        hq_env.kill_worker(i + 1)
+    table = list_jobs(hq_env)
+    table.check_column_value("State", 0, "CANCELED")
+
+
+def test_crashing_job_by_files(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.command(["submit", "--", "bash", "-c", "sleep 1; echo done > xyz.txt"])
+
+    # Crashing tasks threshold is 5
+    for i in range(5):
+        hq_env.start_worker()
+        wait_for_job_state(hq_env, 1, "RUNNING")
+        hq_env.kill_worker(i + 1)
+
+    hq_env.start_worker()
+    wait_for_job_state(hq_env, 1, "CANCELED")
+    time.sleep(2)
+
+    table = list_jobs(hq_env)
+    table.check_column_value("State", 0, "CANCELED")
+    try:
+        check_file_contents("xyz.txt", "done\n")
+    except Exception as e:
+        assert "No such file or directory: 'xyz.txt'" in str(e)


### PR DESCRIPTION
This PR adds a counter that remembers how many times was some task executing during a worker crash. This hints that the task may have been the source of the crash. If the counter reached too many hits, the task will be canceled to avoid endless worker-crash loops.

Closes: https://github.com/It4innovations/hyperqueue/issues/306