### PR TITLE
Fix: Resubmit empty task(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Dev
+
+## Fixes
+
+## Job submission
+* [#450](https://github.com/It4innovations/hyperqueue/pull/450) Attempts to resubmit a job with zero
+tasks will now result in an explicit error, rather than a crash of the client.
+
 # v0.11.0
 
 ## New features

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -168,6 +168,13 @@ pub async fn handle_resubmit(
                                 }
                             })
                             .collect();
+
+                        if ids.is_empty() {
+                            return ToClientMessage::Error(
+                                "Filtered task(s) are empty, can't submit empty job".to_string(),
+                            );
+                        }
+
                         ids.sort_unstable();
                         JobDescription::Array {
                             ids: IntArray::from_ids(ids),

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -623,6 +623,18 @@ def test_job_resubmit_all(hq_env: HqEnv):
     table.check_row_value("Tasks", "3; Ids: 2, 7, 9")
 
 
+def test_job_resubmit_empty(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.command(["submit", "--array=2,7,9", "--", "/bin/hostname"])
+    hq_env.start_workers(2, cpus=1)
+    wait_for_job_state(hq_env, 1, "FINISHED")
+
+    try:
+        hq_env.command(["job", "resubmit", "--filter=canceled", "1"], as_table=True)
+    except Exception as e:
+        assert "Filtered task(s) are empty, can't submit empty job" in str(e)
+
+
 def test_job_priority(hq_env: HqEnv, tmp_path):
     hq_env.start_server()
     hq_env.command(


### PR DESCRIPTION
Currently while trying to resubmit a job that has 0 tasks (filters) causes a panic. This PR handles this as a error.