### PR TITLE
Update documentation for v0.11.0

### DIFF
--- a/docs/deployment/allocation.md
+++ b/docs/deployment/allocation.md
@@ -74,13 +74,13 @@ creating a new allocation queue:
     === "PBS"
     
         ```bash
-        $ hq alloc add pbs --time-limit 1h --cpus 4x4 --resource "gpu=indices(1-2)" -- -qqprod -AAccount1
+        $ hq alloc add pbs --time-limit 1h --cpus 4x4 --resource "gpu=range(1-2)" -- -qqprod -AAccount1
         ```
     
     === "Slurm"
     
         ``` bash
-        $ hq alloc add slurm --time-limit 1h --cpus 4x4 --resource "gpu=indices(1-2)" -- --partition=p1
+        $ hq alloc add slurm --time-limit 1h --cpus 4x4 --resource "gpu=range(1-2)" -- --partition=p1
         ```
     
     If you do not pass any resources, they will be detected automatically (same as it works with


### PR DESCRIPTION
The release v0.11.0 renamed "indices" to "range", see https://github.com/It4innovations/hyperqueue/releases/tag/v0.11.0