### PR TITLE
Allow setting idle timeout for workers started by the automatic allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dev
 
+## New features
+
+### Automatic allocation
+* [#457](https://github.com/It4innovations/hyperqueue/pull/457) You can now specify the idle timeout
+for workers started by the automatic allocator using the `--idle-timeout` flag of the `hq alloc add` command.
+
 ## Changes
 
 ### CLI

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -189,6 +189,7 @@ pub fn create_queue_info(params: AllocationQueueParams) -> QueueInfo {
         worker_resources_args,
         max_worker_count,
         on_server_lost,
+        idle_timeout,
     } = params;
     QueueInfo::new(
         backlog,
@@ -199,6 +200,7 @@ pub fn create_queue_info(params: AllocationQueueParams) -> QueueInfo {
         worker_cpu_arg,
         worker_resources_args,
         max_worker_count,
+        idle_timeout,
     )
 }
 
@@ -1537,6 +1539,7 @@ mod tests {
                     None,
                     vec![],
                     max_worker_count,
+                    None,
                 ),
                 RateLimiter::new(
                     limiter_delays,

--- a/crates/hyperqueue/src/server/autoalloc/queue/common.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/common.rs
@@ -139,7 +139,10 @@ pub fn build_worker_args(
         ManagerType::Slurm => "slurm",
     };
 
-    let duration = humantime::format_duration(get_default_worker_idle_time()).to_string();
+    let idle_timeout = queue_info
+        .idle_timeout
+        .unwrap_or_else(get_default_worker_idle_time);
+    let duration = humantime::format_duration(idle_timeout).to_string();
     let mut args = format!(
         "{} worker start --idle-timeout {} --manager {} --server-dir {}",
         hq_path.display(),

--- a/crates/hyperqueue/src/server/autoalloc/queue/mod.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/mod.rs
@@ -22,6 +22,7 @@ pub struct QueueInfo {
     worker_cpu_arg: Option<String>,
     worker_resource_args: Vec<String>,
     max_worker_count: Option<u32>,
+    idle_timeout: Option<Duration>,
 }
 
 impl QueueInfo {
@@ -35,6 +36,7 @@ impl QueueInfo {
         worker_cpu_arg: Option<String>,
         worker_resource_args: Vec<String>,
         max_worker_count: Option<u32>,
+        idle_timeout: Option<Duration>,
     ) -> Self {
         Self {
             backlog,
@@ -45,6 +47,7 @@ impl QueueInfo {
             worker_resource_args,
             max_worker_count,
             on_server_lost,
+            idle_timeout,
         }
     }
 

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -427,6 +427,7 @@ mod tests {
                 None,
                 vec![],
                 None,
+                None,
             ),
             None,
             Box::new(NullHandler),

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -189,6 +189,7 @@ pub struct AllocationQueueParams {
     pub worker_cpu_arg: Option<String>,
     pub worker_resources_args: Vec<String>,
     pub max_worker_count: Option<u32>,
+    pub idle_timeout: Option<Duration>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/docs/deployment/allocation.md
+++ b/docs/deployment/allocation.md
@@ -86,6 +86,10 @@ creating a new allocation queue:
     If you do not pass any resources, they will be detected automatically (same as it works with
     `hq worker start`).
 
+- `--idle-timeout <duration>` [Idle timeout](worker.md#idle-timeout) for workers started by the
+automatic allocator. We suggest that you do not use a long duration for this parameter, as it can
+result in wasting precious allocation time.
+
 - `--name <name>` Name of the allocation queue. Will be used to name allocations. Serves for debug purposes only.
 
 [^1]: You can use various [shortcuts](../cli/shortcuts.md#duration) for the duration value.


### PR DESCRIPTION
Fixes: https://github.com/It4innovations/hyperqueue/issues/456