### PR TITLE
Relax pyhq dependencies

### DIFF
--- a/crates/pyhq/pyproject.toml
+++ b/crates/pyhq/pyproject.toml
@@ -11,11 +11,11 @@ classifiers = [
 requires-python = ">=3.6"
 description = "HyperQueue Python API"
 dependencies = [
-    "cloudpickle==2.0",
+    "cloudpickle>=2.0,<3",
     "tqdm>=4.60,<5"
 ]
 
 [project.optional-dependencies]
 all = [
-    "pydot==1.4.2"
+    "pydot>=1.4,<2"
 ]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -21,7 +21,7 @@ cargo test
 cargo build --all
 
 # Build Python binding
-maturin develop --manifest-path crates/pyhq/Cargo.toml
+maturin develop --manifest-path crates/pyhq/Cargo.toml --extras all
 
 # Test Python code
 python -m pytest tests -n32


### PR DESCRIPTION
This makes it possible to use the Python API on Python 3.10+.