### PR TITLE
Upload hyperqueue Python releases to public PyPi repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,4 +183,4 @@ jobs:
       - name: Install twine
         run: python -m pip install twine
       - name: Upload wheel
-        run: python -m twine upload -r testpypi --username __token__ --password ${{ secrets.PYPI_UPLOAD_TOKEN }}  archive-pyhq/*
+        run: python -m twine upload --username __token__ --password ${{ secrets.PYPI_UPLOAD_TOKEN }} archive-pyhq/*


### PR DESCRIPTION
I already changed the Pypi upload token in secrets.