### PR TITLE
Pin nedoc and mkdocs-nedoc-plugin dependency versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,5 @@ mkdocs-git-revision-date-localized-plugin==0.10.0
 mike==1.1.2
 requests==2.26.0
 jinja2==3.0.3
-nedoc @ git+https://github.com/spirali/nedoc
-mkdocs-nedoc-plugin @ git+https://github.com/kobzol/mkdocs-nedoc-plugin
+nedoc @ git+https://github.com/spirali/nedoc@6994f657be3c110a4b3be6df99682206e1b1181e
+mkdocs-nedoc-plugin @ git+https://github.com/kobzol/mkdocs-nedoc-plugin@8be5cd5018cb99bd1100360d66821a7a85ce7021


### PR DESCRIPTION
This fixes wrong code blocks rendered in documentation because of invalid `pygments` dependency version.