### PR TITLE
Update Rust used in CI to `1.64.0`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.59.0
+          toolchain: 1.64.0
           override: true
 
       - uses: Swatinem/rust-cache@v1
@@ -69,7 +69,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.59.0
+          toolchain: 1.64.0
           override: true
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.59.0
+          toolchain: 1.64.0
           override: true
 
       - uses: Swatinem/rust-cache@v1
@@ -101,7 +101,7 @@ jobs:
           uses: actions-rs/toolchain@v1
           with:
             profile: minimal
-            toolchain: 1.59.0
+            toolchain: 1.64.0
             override: true
 
         - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.59.0
+          toolchain: 1.64.0
           override: true
           components: clippy, rustfmt
 

--- a/crates/pyhq/src/lib.rs
+++ b/crates/pyhq/src/lib.rs
@@ -1,3 +1,7 @@
+// This lint is currently buggy and doesn't work properly with procedural macros (#[pyfunction]).
+// Re-check in version 1.65.0.
+#![allow(clippy::borrow_deref_ref)]
+
 use pyo3::types::PyModule;
 use pyo3::{pyclass, pyfunction, pymethods, pymodule, FromPyObject, PyAny};
 use pyo3::{wrap_pyfunction, Py, PyResult, Python};


### PR DESCRIPTION
We need at least `1.64.0` to support workspace dependencies.