### PR TITLE
Check worker lifespan in allocation failure management

### DIFF
--- a/crates/hyperqueue/src/client/autoalloc.rs
+++ b/crates/hyperqueue/src/client/autoalloc.rs
@@ -6,9 +6,7 @@ impl AllocationState {
             AllocationState::Finished {
                 disconnected_workers,
                 ..
-            } => disconnected_workers
-                .values()
-                .any(|reason| reason.is_failure()),
+            } => disconnected_workers.all_crashed(),
             AllocationState::Invalid { failed, .. } => *failed,
             AllocationState::Queued | AllocationState::Running { .. } => false,
         }

--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -1,4 +1,5 @@
 use anyhow::bail;
+use chrono::Utc;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -116,6 +117,7 @@ pub async fn start_hq_worker(
     gsettings.printer().print_worker_info(WorkerInfo {
         id: worker.id,
         configuration: worker.configuration,
+        started: Utc::now(),
         ended: None,
     });
     future.await.map_err(|e| e.into())

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -32,6 +32,7 @@ use tako::program::StdioDef;
 use tako::resources::{ResourceDescriptor, ResourceDescriptorItem, ResourceDescriptorKind};
 
 use crate::client::output::common::{resolve_task_paths, TaskToPathsMap};
+use crate::client::output::json::format_datetime;
 use crate::client::output::Verbosity;
 use crate::common::utils::str::{pluralize, select_plural, truncate_middle};
 use crate::worker::start::WORKER_EXTRA_PROCESS_PID;
@@ -269,6 +270,7 @@ impl Output for CliOutput {
         let WorkerInfo {
             id,
             configuration,
+            started,
             ended: _ended,
         } = worker_info;
 
@@ -276,6 +278,7 @@ impl Output for CliOutput {
         let rows = vec![
             vec!["Worker ID".cell().bold(true), id.cell()],
             vec!["Hostname".cell().bold(true), configuration.hostname.cell()],
+            vec!["Started".cell().bold(true), format_datetime(started).cell()],
             vec![
                 "Data provider".cell().bold(true),
                 configuration.listen_address.cell(),

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -410,6 +410,7 @@ fn format_worker_info(worker_info: WorkerInfo) -> serde_json::Value {
                 on_server_lost,
                 extra: _,
             },
+        started,
         ended,
     } = worker_info;
 
@@ -426,6 +427,7 @@ fn format_worker_info(worker_info: WorkerInfo) -> serde_json::Value {
             "resources": format_resource_descriptor(&resources),
             "on_server_lost": crate::common::format::server_lost_policy_to_str(&on_server_lost),
         }),
+        "started": format_datetime(started),
         "ended": ended.map(|info| json!({
             "at": format_datetime(info.ended_at)
         }))

--- a/crates/hyperqueue/src/server/autoalloc/mod.rs
+++ b/crates/hyperqueue/src/server/autoalloc/mod.rs
@@ -15,5 +15,5 @@ pub type AutoAllocResult<T> = anyhow::Result<T>;
 
 pub use process::try_submit_allocation;
 pub use queue::QueueInfo;
-pub use service::{create_autoalloc_service, AutoAllocService};
+pub use service::{create_autoalloc_service, AutoAllocService, LostWorkerDetails};
 pub use state::{Allocation, AllocationId, AllocationState, QueueId};

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -5,7 +5,6 @@ use std::time::SystemTime;
 use futures::future::join_all;
 use tempdir::TempDir;
 
-use tako::gateway::LostWorkerReason;
 use tako::WorkerId;
 use tako::{Map, Set};
 
@@ -21,7 +20,7 @@ use crate::server::autoalloc::estimator::{
 use crate::server::autoalloc::queue::pbs::PbsHandler;
 use crate::server::autoalloc::queue::slurm::SlurmHandler;
 use crate::server::autoalloc::queue::{AllocationExternalStatus, QueueHandler, SubmitMode};
-use crate::server::autoalloc::service::AutoAllocMessage;
+use crate::server::autoalloc::service::{AutoAllocMessage, LostWorkerDetails};
 use crate::server::autoalloc::state::{
     AllocationState, AutoAllocState, QueueState, RateLimiter, RateLimiterStatus,
 };
@@ -81,12 +80,12 @@ async fn handle_message(
                 .get_queue_id_by_allocation(&manager_info.allocation_id)
                 .map(RefreshReason::UpdateQueue)
         }
-        AutoAllocMessage::WorkerLost(id, manager_info, reason) => {
+        AutoAllocMessage::WorkerLost(id, manager_info, details) => {
             log::debug!(
                 "Removing worker {id} from allocation {}",
                 manager_info.allocation_id
             );
-            on_worker_lost(state_ref, autoalloc, id, &manager_info, reason);
+            on_worker_lost(state_ref, autoalloc, id, &manager_info, details);
             autoalloc
                 .get_queue_id_by_allocation(&manager_info.allocation_id)
                 .map(RefreshReason::UpdateQueue)
@@ -428,7 +427,7 @@ async fn refresh_queue_allocations(
                             id,
                             queue,
                             &allocation_id,
-                            Some(status),
+                            AllocationSyncReason::AllocationExternalChange(status),
                         ),
                         _ => {}
                     },
@@ -493,7 +492,7 @@ fn on_worker_lost(
     state: &mut AutoAllocState,
     worker_id: WorkerId,
     manager_info: &ManagerInfo,
-    reason: LostWorkerReason,
+    worker_details: LostWorkerDetails,
 ) {
     let (queue, queue_id, allocation_id) =
         get_or_return!(get_data_from_worker(state, worker_id, manager_info));
@@ -513,8 +512,14 @@ fn on_worker_lost(
             if !connected_workers.remove(&worker_id) {
                 log::warn!("Worker {worker_id} has disconnected multiple times!");
             }
-            disconnected_workers.insert(worker_id, reason);
-            sync_allocation_status(state_ref, queue_id, queue, &allocation_id, None);
+            disconnected_workers.on_worker_lost(worker_id, worker_details);
+            sync_allocation_status(
+                state_ref,
+                queue_id,
+                queue,
+                &allocation_id,
+                AllocationSyncReason::WorkerLost,
+            );
         }
         AllocationState::Finished { .. } => {
             log::warn!(
@@ -531,12 +536,17 @@ fn on_worker_lost(
     }
 }
 
+enum AllocationSyncReason {
+    WorkerLost,
+    AllocationExternalChange(AllocationExternalStatus),
+}
+
 fn sync_allocation_status(
     state_ref: &StateRef,
     queue_id: QueueId,
     queue: &mut QueueState,
     allocation_id: &str,
-    external_status: Option<AllocationExternalStatus>,
+    sync_reason: AllocationSyncReason,
 ) {
     let allocation = get_or_return!(queue.get_allocation_mut(allocation_id));
 
@@ -547,79 +557,80 @@ fn sync_allocation_status(
 
     let action: Option<Action> = {
         // Unexpected end of allocation
-        if let Some(status) = external_status {
-            let (connected, disconnected) = match &mut allocation.status {
-                AllocationState::Queued => (Default::default(), Default::default()),
-                AllocationState::Running {
-                    connected_workers,
-                    disconnected_workers,
-                    ..
-                } => (
-                    std::mem::take(connected_workers),
-                    std::mem::take(disconnected_workers),
-                ),
-                AllocationState::Finished { .. } | AllocationState::Invalid { .. } => {
-                    // The allocation was already finished before
-                    return;
+        match sync_reason {
+            AllocationSyncReason::WorkerLost => {
+                match &mut allocation.status {
+                    AllocationState::Running {
+                        disconnected_workers,
+                        started_at,
+                        ..
+                    } => {
+                        // All expected workers have disconnected, the allocation ends in a normal way
+                        if disconnected_workers.count() == allocation.target_worker_count {
+                            let is_failed = disconnected_workers.all_crashed();
+
+                            allocation.status = AllocationState::Finished {
+                                started_at: *started_at,
+                                finished_at: SystemTime::now(),
+                                disconnected_workers: std::mem::take(disconnected_workers),
+                            };
+
+                            Some(if is_failed {
+                                Action::Failure
+                            } else {
+                                Action::Success
+                            })
+                        } else {
+                            None
+                        }
+                    }
+                    AllocationState::Invalid { .. }
+                    | AllocationState::Finished { .. }
+                    | AllocationState::Queued => None,
                 }
-            };
-            let failed = matches!(status, AllocationExternalStatus::Failed { .. });
-            match status {
-                AllocationExternalStatus::Finished {
-                    started_at,
-                    finished_at,
-                }
-                | AllocationExternalStatus::Failed {
-                    started_at,
-                    finished_at,
-                } => {
-                    log::debug!("Setting allocation {allocation_id} status to invalid because of external status {status:?}.");
-                    allocation.status = AllocationState::Invalid {
-                        connected_workers: connected,
+            }
+            AllocationSyncReason::AllocationExternalChange(status) => {
+                let (connected, disconnected) = match &mut allocation.status {
+                    AllocationState::Queued => (Default::default(), Default::default()),
+                    AllocationState::Running {
+                        connected_workers,
+                        disconnected_workers,
+                        ..
+                    } => (
+                        std::mem::take(connected_workers),
+                        std::mem::take(disconnected_workers),
+                    ),
+                    AllocationState::Finished { .. } | AllocationState::Invalid { .. } => {
+                        // The allocation was already finished before
+                        return;
+                    }
+                };
+                let failed = matches!(status, AllocationExternalStatus::Failed { .. });
+                match status {
+                    AllocationExternalStatus::Finished {
                         started_at,
                         finished_at,
-                        disconnected_workers: disconnected,
-                        failed,
-                    };
-                    Some(if failed {
-                        Action::Failure
-                    } else {
-                        Action::Success
-                    })
-                }
-                _ => None,
-            }
-        } else {
-            match &mut allocation.status {
-                AllocationState::Running {
-                    disconnected_workers,
-                    started_at,
-                    ..
-                } => {
-                    // All expected workers have disconnected, the allocation ends in a normal way
-                    if disconnected_workers.len() as u64 == allocation.target_worker_count {
-                        let is_failed = disconnected_workers
-                            .values()
-                            .any(|reason| reason.is_failure());
-
-                        allocation.status = AllocationState::Finished {
-                            started_at: *started_at,
-                            finished_at: SystemTime::now(),
-                            disconnected_workers: std::mem::take(disconnected_workers),
+                    }
+                    | AllocationExternalStatus::Failed {
+                        started_at,
+                        finished_at,
+                    } => {
+                        log::debug!("Setting allocation {allocation_id} status to invalid because of external status {status:?}.");
+                        allocation.status = AllocationState::Invalid {
+                            connected_workers: connected,
+                            started_at,
+                            finished_at,
+                            disconnected_workers: disconnected,
+                            failed,
                         };
-
-                        Some(if is_failed {
+                        Some(if failed {
                             Action::Failure
                         } else {
                             Action::Success
                         })
-                    } else {
-                        None
                     }
+                    _ => None,
                 }
-                AllocationState::Invalid { .. }
-                | AllocationState::Finished { .. }
-                | AllocationState::Queued => None,
             }
         }
     };
@@ -839,7 +850,9 @@ mod tests {
     use crate::server::autoalloc::state::{
         AllocationState, AutoAllocState, QueueState, RateLimiter,
     };
-    use crate::server::autoalloc::{Allocation, AllocationId, AutoAllocResult, QueueId, QueueInfo};
+    use crate::server::autoalloc::{
+        Allocation, AllocationId, AutoAllocResult, LostWorkerDetails, QueueId, QueueInfo,
+    };
     use crate::server::job::Job;
     use crate::server::state::StateRef;
     use crate::tests::utils::create_hq_state;
@@ -980,7 +993,7 @@ mod tests {
             &mut state,
             worker_id,
             &create_worker(&allocs[0].id),
-            LostWorkerReason::ConnectionLost,
+            lost_worker_normal(LostWorkerReason::ConnectionLost),
         );
         check_finished_workers(
             get_allocations(&state, queue_id).get(0).unwrap(),
@@ -1016,7 +1029,7 @@ mod tests {
             &mut state,
             0.into(),
             &create_worker(&allocs[0].id),
-            LostWorkerReason::ConnectionLost,
+            lost_worker_normal(LostWorkerReason::ConnectionLost),
         );
         let allocation = get_allocations(&state, queue_id)[0].clone();
         check_running_workers(&allocation, vec![1]);
@@ -1029,7 +1042,7 @@ mod tests {
             &mut state,
             1.into(),
             &create_worker(&allocs[0].id),
-            LostWorkerReason::HeartbeatLost,
+            lost_worker_normal(LostWorkerReason::HeartbeatLost),
         );
         let allocation = get_allocations(&state, queue_id)[0].clone();
         check_finished_workers(
@@ -1156,7 +1169,7 @@ mod tests {
             &mut state,
             1.into(),
             &create_worker(&allocations[1].id),
-            LostWorkerReason::ConnectionLost,
+            lost_worker_normal(LostWorkerReason::ConnectionLost),
         );
 
         // One worker was freed, create an additional allocation
@@ -1336,6 +1349,84 @@ mod tests {
             refresh_state(&hq_state, &mut state, RefreshReason::UpdateAllQueues).await;
             check_alloc_count(4);
         }
+    }
+
+    #[tokio::test]
+    async fn bump_fail_counter_if_worker_fails_quick() {
+        let hq_state = new_hq_state(1000);
+        let mut state = AutoAllocState::new();
+
+        let handler = always_queued_handler();
+        let queue_id = add_queue(
+            &mut state,
+            handler,
+            QueueBuilder::default().backlog(1).workers_per_alloc(1),
+        );
+
+        queue_try_submit(queue_id, &mut state, &hq_state, None).await;
+        let allocs = get_allocations(&state, queue_id);
+
+        let worker_id: WorkerId = 0.into();
+        on_worker_connected(
+            &hq_state,
+            &mut state,
+            worker_id,
+            &create_worker(&allocs[0].id),
+        );
+        on_worker_lost(
+            &hq_state,
+            &mut state,
+            worker_id,
+            &create_worker(&allocs[0].id),
+            lost_worker_quick(LostWorkerReason::ConnectionLost),
+        );
+        assert_eq!(
+            state
+                .get_queue(queue_id)
+                .unwrap()
+                .limiter()
+                .allocation_fail_count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn do_not_bump_fail_counter_if_worker_fails_normally() {
+        let hq_state = new_hq_state(1000);
+        let mut state = AutoAllocState::new();
+
+        let handler = always_queued_handler();
+        let queue_id = add_queue(
+            &mut state,
+            handler,
+            QueueBuilder::default().backlog(1).workers_per_alloc(1),
+        );
+
+        queue_try_submit(queue_id, &mut state, &hq_state, None).await;
+        let allocs = get_allocations(&state, queue_id);
+
+        let worker_id: WorkerId = 0.into();
+        on_worker_connected(
+            &hq_state,
+            &mut state,
+            worker_id,
+            &create_worker(&allocs[0].id),
+        );
+        on_worker_lost(
+            &hq_state,
+            &mut state,
+            worker_id,
+            &create_worker(&allocs[0].id),
+            lost_worker_normal(LostWorkerReason::ConnectionLost),
+        );
+        assert_eq!(
+            state
+                .get_queue(queue_id)
+                .unwrap()
+                .limiter()
+                .allocation_fail_count(),
+            0
+        );
     }
 
     // Utilities
@@ -1671,7 +1762,11 @@ mod tests {
                 disconnected_workers,
                 ..
             } => {
-                let mut disconnected: Vec<_> = disconnected_workers.clone().into_iter().collect();
+                let mut disconnected: Vec<_> = disconnected_workers
+                    .clone()
+                    .into_iter()
+                    .map(|(id, details)| (id, details.reason))
+                    .collect();
                 disconnected.sort_unstable_by_key(|(id, _)| *id);
                 assert_eq!(disconnected, workers);
             }
@@ -1689,7 +1784,11 @@ mod tests {
                 disconnected_workers,
                 ..
             } => {
-                let mut disconnected: Vec<_> = disconnected_workers.clone().into_iter().collect();
+                let mut disconnected: Vec<_> = disconnected_workers
+                    .clone()
+                    .into_iter()
+                    .map(|(id, details)| (id, details.reason))
+                    .collect();
                 disconnected.sort_unstable_by_key(|(id, _)| *id);
                 assert_eq!(disconnected, workers);
             }
@@ -1714,7 +1813,20 @@ mod tests {
             autoalloc,
             worker_id,
             &minfo,
-            LostWorkerReason::ConnectionLost,
+            lost_worker_quick(LostWorkerReason::ConnectionLost),
         );
+    }
+
+    fn lost_worker_normal(reason: LostWorkerReason) -> LostWorkerDetails {
+        LostWorkerDetails {
+            reason,
+            lifetime: Duration::from_secs(3600),
+        }
+    }
+    fn lost_worker_quick(reason: LostWorkerReason) -> LostWorkerDetails {
+        LostWorkerDetails {
+            reason,
+            lifetime: Duration::from_millis(1),
+        }
     }
 }

--- a/crates/hyperqueue/src/server/autoalloc/service.rs
+++ b/crates/hyperqueue/src/server/autoalloc/service.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::path::PathBuf;
+use std::time::Duration;
 use tako::Map;
 
 use tako::gateway::LostWorkerReason;
@@ -20,7 +21,7 @@ use crate::JobId;
 pub enum AutoAllocMessage {
     // Events
     WorkerConnected(WorkerId, ManagerInfo),
-    WorkerLost(WorkerId, ManagerInfo, LostWorkerReason),
+    WorkerLost(WorkerId, ManagerInfo, LostWorkerDetails),
     JobCreated(JobId),
     // Requests
     GetQueues(ResponseToken<Map<QueueId, QueueData>>),
@@ -38,6 +39,12 @@ pub enum AutoAllocMessage {
     GetAllocations(QueueId, ResponseToken<anyhow::Result<Vec<Allocation>>>),
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LostWorkerDetails {
+    pub reason: LostWorkerReason,
+    pub lifetime: Duration,
+}
+
 pub struct AutoAllocService {
     sender: RpcSender<AutoAllocMessage>,
 }
@@ -52,10 +59,10 @@ impl AutoAllocService {
         &self,
         id: WorkerId,
         configuration: &WorkerConfiguration,
-        reason: LostWorkerReason,
+        details: LostWorkerDetails,
     ) {
         if let Some(manager_info) = configuration.get_manager_info() {
-            self.send(AutoAllocMessage::WorkerLost(id, manager_info, reason));
+            self.send(AutoAllocMessage::WorkerLost(id, manager_info, details));
         }
     }
 

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -13,7 +13,7 @@ use crate::common::manager::info::ManagerType;
 use crate::common::utils::time::now_monotonic;
 use crate::server::autoalloc::config::MAX_KEPT_DIRECTORIES;
 use crate::server::autoalloc::queue::QueueHandler;
-use crate::server::autoalloc::QueueInfo;
+use crate::server::autoalloc::{LostWorkerDetails, QueueInfo};
 use crate::Map;
 
 // Main state holder
@@ -228,24 +228,59 @@ impl Allocation {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DisconnectedWorkers {
+    workers: Map<WorkerId, LostWorkerDetails>,
+}
+
+impl DisconnectedWorkers {
+    pub fn on_worker_lost(&mut self, worker_id: WorkerId, details: LostWorkerDetails) {
+        self.workers.insert(worker_id, details);
+    }
+    pub fn count(&self) -> u64 {
+        self.workers.len() as u64
+    }
+
+    /// Returns true if all workers that have disconnected have crashed.
+    /// A worker is considered to be failed if it has lost connection to the server very soon
+    /// after it has connected.
+    pub fn all_crashed(&self) -> bool {
+        self.workers.values().all(|details| {
+            matches!(
+                details.reason,
+                LostWorkerReason::ConnectionLost | LostWorkerReason::HeartbeatLost
+            ) && details.lifetime <= Duration::from_secs(60)
+        })
+    }
+}
+
+impl IntoIterator for DisconnectedWorkers {
+    type Item = (WorkerId, LostWorkerDetails);
+    type IntoIter = <Map<WorkerId, LostWorkerDetails> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.workers.into_iter()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AllocationState {
     Queued,
     Running {
         started_at: SystemTime,
         connected_workers: Set<WorkerId>,
-        disconnected_workers: Map<WorkerId, LostWorkerReason>,
+        disconnected_workers: DisconnectedWorkers,
     },
     // The allocation has finished by connecting and disconnecting the expected amount of workers.
     Finished {
         started_at: SystemTime,
         finished_at: SystemTime,
-        disconnected_workers: Map<WorkerId, LostWorkerReason>,
+        disconnected_workers: DisconnectedWorkers,
     },
     // Zero (or not enough) workers have connected, but the allocation has been finished.
     Invalid {
         connected_workers: Set<WorkerId>,
-        disconnected_workers: Map<WorkerId, LostWorkerReason>,
+        disconnected_workers: DisconnectedWorkers,
         started_at: Option<SystemTime>,
         finished_at: SystemTime,
         failed: bool,
@@ -378,6 +413,11 @@ impl RateLimiter {
         if self.current_delay < self.submission_delays.len() - 1 {
             self.current_delay += 1;
         }
+    }
+
+    #[cfg(test)]
+    pub fn allocation_fail_count(&self) -> u64 {
+        self.allocation_fails as u64
     }
 }
 

--- a/crates/hyperqueue/src/server/worker.rs
+++ b/crates/hyperqueue/src/server/worker.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use tako::gateway::LostWorkerReason;
 use tako::worker::WorkerConfiguration;
 
@@ -6,9 +6,17 @@ use crate::server::worker::WorkerState::Offline;
 use crate::transfer::messages::{WorkerExitInfo, WorkerInfo};
 use crate::WorkerId;
 
+#[derive(Default)]
+pub struct ConnectedWorkerData {
+    pub started_at: DateTime<Utc>,
+}
+
 pub enum WorkerState {
-    Online,
-    Offline(WorkerExitInfo),
+    Online(ConnectedWorkerData),
+    Offline {
+        connected: ConnectedWorkerData,
+        exit_info: WorkerExitInfo,
+    },
 }
 
 pub struct Worker {
@@ -22,7 +30,9 @@ impl Worker {
         Worker {
             worker_id,
             configuration,
-            state: WorkerState::Online,
+            state: WorkerState::Online(ConnectedWorkerData {
+                started_at: Utc::now(),
+            }),
         }
     }
 
@@ -35,23 +45,39 @@ impl Worker {
     }
 
     pub fn set_offline_state(&mut self, reason: LostWorkerReason) {
-        self.state = Offline(WorkerExitInfo {
-            ended_at: Utc::now(),
-            reason,
-        });
+        match self.state {
+            WorkerState::Online(ref mut connected) => {
+                self.state = Offline {
+                    connected: std::mem::take(connected),
+                    exit_info: WorkerExitInfo {
+                        ended_at: Utc::now(),
+                        reason,
+                    },
+                };
+            }
+            Offline { .. } => {
+                panic!(
+                    "Setting offline state of a worker {} that is already offline",
+                    self.worker_id
+                );
+            }
+        }
     }
 
     pub fn is_running(&self) -> bool {
-        matches!(self.state, WorkerState::Online)
+        matches!(self.state, WorkerState::Online(_))
     }
 
     pub fn make_info(&self) -> WorkerInfo {
         WorkerInfo {
             id: self.worker_id,
             configuration: self.configuration.clone(),
+            started: match &self.state {
+                WorkerState::Online(connected) | Offline { connected, .. } => connected.started_at,
+            },
             ended: match &self.state {
-                WorkerState::Online => None,
-                Offline(d) => Some(d.clone()),
+                WorkerState::Online(_) => None,
+                Offline { exit_info, .. } => Some(exit_info.clone()),
             },
         }
     }

--- a/crates/hyperqueue/src/server/worker.rs
+++ b/crates/hyperqueue/src/server/worker.rs
@@ -44,6 +44,12 @@ impl Worker {
         &self.configuration
     }
 
+    pub fn started_at(&self) -> DateTime<Utc> {
+        match &self.state {
+            WorkerState::Online(connected) | Offline { connected, .. } => connected.started_at,
+        }
+    }
+
     pub fn set_offline_state(&mut self, reason: LostWorkerReason) {
         match self.state {
             WorkerState::Online(ref mut connected) => {
@@ -72,9 +78,7 @@ impl Worker {
         WorkerInfo {
             id: self.worker_id,
             configuration: self.configuration.clone(),
-            started: match &self.state {
-                WorkerState::Online(connected) | Offline { connected, .. } => connected.started_at,
-            },
+            started: self.started_at(),
             ended: match &self.state {
                 WorkerState::Online(_) => None,
                 Offline { exit_info, .. } => Some(exit_info.clone()),

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -266,6 +266,7 @@ pub struct WorkerExitInfo {
 pub struct WorkerInfo {
     pub id: WorkerId,
     pub configuration: WorkerConfiguration,
+    pub started: DateTime<Utc>,
     pub ended: Option<WorkerExitInfo>,
 }
 

--- a/tests/output/test_json.py
+++ b/tests/output/test_json.py
@@ -50,11 +50,11 @@ def test_print_worker_info(hq_env: HqEnv):
                 "work_dir": str,
                 "on_server_lost": "stop",
             },
+            "started": str,
             "ended": None,
             "id": 1,
         }
     )
-    print(output)
     schema.validate(output)
 
 


### PR DESCRIPTION
Now an allocation will not be considered a failure (w.r.t the rate limiter) if a worker loses connection to the server after more than a minute.

Also an allocation is now considered to be a failure only when all its workers crash, not just any one them.

Fixes: https://github.com/It4innovations/hyperqueue/issues/501