### PR TITLE
Add the ability to pause autoallocation queues

### DIFF
--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -223,8 +223,8 @@ impl Output for JsonOutput {
 
         self.print(
             queues
-                .iter()
-                .map(|(key, queue)| format_autoalloc_queue(*key, queue))
+                .into_iter()
+                .map(|(key, queue)| format_autoalloc_queue(key, queue))
                 .collect(),
         );
     }
@@ -334,16 +334,23 @@ fn format_tasks(tasks: Vec<JobTaskInfo>, map: TaskToPathsMap) -> serde_json::Val
         .collect()
 }
 
-fn format_autoalloc_queue(id: QueueId, descriptor: &QueueData) -> serde_json::Value {
-    let manager = match descriptor.manager_type {
+fn format_autoalloc_queue(id: QueueId, descriptor: QueueData) -> serde_json::Value {
+    let QueueData {
+        info,
+        name,
+        manager_type,
+        state,
+    } = descriptor;
+
+    let manager = match manager_type {
         ManagerType::Pbs => "PBS",
         ManagerType::Slurm => "Slurm",
     };
-    let info = &descriptor.info;
 
     json!({
         "id": id,
-        "name": descriptor.name,
+        "name": name,
+        "state": state,
         "manager": manager,
         "additional_args": info.additional_args(),
         "backlog": info.backlog(),

--- a/crates/hyperqueue/src/server/autoalloc/estimator.rs
+++ b/crates/hyperqueue/src/server/autoalloc/estimator.rs
@@ -1,4 +1,4 @@
-use crate::server::autoalloc::state::QueueState;
+use crate::server::autoalloc::state::AllocationQueue;
 use crate::server::autoalloc::QueueInfo;
 use crate::server::job::Job;
 use crate::server::state::State;
@@ -78,7 +78,7 @@ pub fn can_worker_execute_job(_job: &Job, worker: &Worker) -> bool {
     worker.is_running()
 }
 
-pub fn count_active_workers(queue: &QueueState) -> u64 {
+pub fn count_active_workers(queue: &AllocationQueue) -> u64 {
     queue
         .active_allocations()
         .map(|allocation| allocation.target_worker_count)

--- a/crates/hyperqueue/src/server/autoalloc/service.rs
+++ b/crates/hyperqueue/src/server/autoalloc/service.rs
@@ -35,6 +35,14 @@ pub enum AutoAllocMessage {
         force: bool,
         response: ResponseToken<anyhow::Result<()>>,
     },
+    PauseQueue {
+        id: QueueId,
+        response: ResponseToken<anyhow::Result<()>>,
+    },
+    ResumeQueue {
+        id: QueueId,
+        response: ResponseToken<anyhow::Result<()>>,
+    },
     GetAllocations(QueueId, ResponseToken<anyhow::Result<Vec<Allocation>>>),
 }
 
@@ -93,6 +101,24 @@ impl AutoAllocService {
             self.sender.send(AutoAllocMessage::RemoveQueue {
                 id,
                 force,
+                response: token,
+            })
+        });
+        async move { fut.await.unwrap() }
+    }
+    pub fn pause_queue(&self, id: QueueId) -> impl Future<Output = anyhow::Result<()>> {
+        let fut = initiate_request(|token| {
+            self.sender.send(AutoAllocMessage::PauseQueue {
+                id,
+                response: token,
+            })
+        });
+        async move { fut.await.unwrap() }
+    }
+    pub fn resume_queue(&self, id: QueueId) -> impl Future<Output = anyhow::Result<()>> {
+        let fut = initiate_request(|token| {
+            self.sender.send(AutoAllocMessage::ResumeQueue {
+                id,
                 response: token,
             })
         });

--- a/crates/hyperqueue/src/server/client/autoalloc.rs
+++ b/crates/hyperqueue/src/server/client/autoalloc.rs
@@ -67,5 +67,23 @@ pub async fn handle_autoalloc_message(
                 Err(error) => ToClientMessage::Error(error.to_string()),
             }
         }
+        AutoAllocRequest::PauseQueue { queue_id } => {
+            let result = state_ref.get().autoalloc().pause_queue(queue_id);
+            match result.await {
+                Ok(_) => {
+                    ToClientMessage::AutoAllocResponse(AutoAllocResponse::QueuePaused(queue_id))
+                }
+                Err(error) => ToClientMessage::Error(error.to_string()),
+            }
+        }
+        AutoAllocRequest::ResumeQueue { queue_id } => {
+            let result = state_ref.get().autoalloc().resume_queue(queue_id);
+            match result.await {
+                Ok(_) => {
+                    ToClientMessage::AutoAllocResponse(AutoAllocResponse::QueueResumed(queue_id))
+                }
+                Err(error) => ToClientMessage::Error(error.to_string()),
+            }
+        }
     }
 }

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -183,6 +183,12 @@ pub enum AutoAllocRequest {
         queue_id: QueueId,
         force: bool,
     },
+    PauseQueue {
+        queue_id: QueueId,
+    },
+    ResumeQueue {
+        queue_id: QueueId,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -311,6 +317,8 @@ pub struct WorkerInfoResponse {
 pub enum AutoAllocResponse {
     QueueCreated(QueueId),
     QueueRemoved(QueueId),
+    QueuePaused(QueueId),
+    QueueResumed(QueueId),
     DryRunSuccessful,
     Info(Vec<Allocation>),
     List(AutoAllocListResponse),
@@ -322,10 +330,17 @@ pub struct AutoAllocListResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub enum QueueState {
+    Running,
+    Paused,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct QueueData {
     pub info: QueueInfo,
     pub name: Option<String>,
     pub manager_type: ManagerType,
+    pub state: QueueState,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/tests/autoalloc/utils.py
+++ b/tests/autoalloc/utils.py
@@ -6,19 +6,6 @@ from .mock.handler import MockInput
 from .mock.manager import Manager, WrappedManager
 
 
-def program_code_store_args_json(path: str) -> str:
-    """
-    Creates program code that stores its cmd arguments as JSON into the specified `path`.
-    """
-    return f"""
-import sys
-import json
-
-with open("{path}", "w") as f:
-    f.write(json.dumps(sys.argv))
-"""
-
-
 def extract_script_args(script: str, prefix: str) -> List[str]:
     return [
         line[len(prefix) :].strip()
@@ -108,3 +95,13 @@ class ExtractSubmitScriptPath(WrappedManager):
         script_path = input.arguments[0]
         self.queue.put(script_path)
         return await super().handle_submit(input)
+
+
+def pause_queue(hq_env: HqEnv, queue_id: int, **kwargs):
+    args = ["alloc", "pause", str(queue_id)]
+    return hq_env.command(args, **kwargs)
+
+
+def resume_queue(hq_env: HqEnv, queue_id: int, **kwargs):
+    args = ["alloc", "resume", str(queue_id)]
+    return hq_env.command(args, **kwargs)


### PR DESCRIPTION
Paused queues do not submit new allocations. This can be used for interactive experiments to avoid removing the queue.

Fixes: https://github.com/It4innovations/hyperqueue/issues/467