### PR TITLE
Option --crash-limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   better behavior on non-heterogeneous clusters;
   better interaction between resources and priorities.
 
+### Tasks
+
+* HQ allows to limit how many times a task may be in a running state while worker is lost
+  (such a task may be a potential source of worker's crash).
+  If the limit is reached, the task is marked as failed.
+  The limit can be configured by `--crash-limit` in submit.
+
 ## Changes
 
 ### Resource management

--- a/crates/hyperqueue/src/client/commands/submit/command.rs
+++ b/crates/hyperqueue/src/client/commands/submit/command.rs
@@ -33,7 +33,7 @@ use crate::transfer::messages::{
 use crate::{arg_wrapper, rpc_call, JobTaskCount, Map};
 
 const SUBMIT_ARRAY_LIMIT: JobTaskCount = 999;
-const DEFAULT_CRASH_LIMIT: u32 = 5;
+pub const DEFAULT_CRASH_LIMIT: u32 = 5;
 
 // Keep in sync with `tests/util/job.py::default_task_output` and `pyhq/python/hyperqueue/output.py`
 const DEFAULT_STDOUT_PATH: &str = const_format::concatcp!(

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -103,6 +103,7 @@ impl CliOutput {
             time_limit,
             priority,
             task_dir: _,
+            crash_limit,
         } = task_desc;
 
         let resources = format_resource_request(resources);
@@ -160,6 +161,8 @@ impl CliOutput {
                 .unwrap_or_else(|| "None".to_string())
                 .cell(),
         ]);
+
+        rows.push(vec!["Crash limit".cell().bold(true), crash_limit.cell()]);
     }
 
     fn print_task_summary(&self, tasks: &[JobTaskInfo], info: &JobInfo, worker_map: &WorkerMap) {

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -124,6 +124,7 @@ impl Output for JsonOutput {
                     time_limit,
                     priority,
                     task_dir,
+                    crash_limit,
                 },
             ..
         } = job_desc
@@ -144,6 +145,7 @@ impl Output for JsonOutput {
             json["priority"] = json!(priority);
             json["time_limit"] = json!(time_limit.map(format_duration));
             json["task_dir"] = json!(task_dir);
+            json["crash_limit"] = json!(crash_limit);
         }
 
         json["tasks"] = format_tasks(tasks, task_paths);

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -1625,6 +1625,7 @@ mod tests {
                     task_dir: false,
                     time_limit: None,
                     priority: 0,
+                    crash_limit: 5,
                 },
             },
             job_id.into(),

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -298,6 +298,7 @@ fn build_tasks_array(
             keep: false,
             observe: true,
             priority: task_desc.priority,
+            crash_limit: task_desc.crash_limit,
         }],
     }
 }
@@ -332,6 +333,7 @@ fn build_tasks_graph(
                 priority: task.priority,
                 keep: false,
                 observe: true,
+                crash_limit: task.crash_limit,
             });
             index
         });
@@ -502,6 +504,7 @@ mod tests {
             task_dir: false,
             time_limit,
             priority,
+            crash_limit: 5,
         }
     }
 

--- a/crates/hyperqueue/src/server/job.rs
+++ b/crates/hyperqueue/src/server/job.rs
@@ -18,10 +18,6 @@ use tako::Set;
 use tako::TaskId;
 use tokio::sync::oneshot;
 
-/// Threshold that is used to determine if task
-/// is causing crash of the worker(s).
-const CRASHING_TASK_THRESHOLD: u32 = 5;
-
 /// State of a task that has been started at least once.
 /// It contains the last known state of the task.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -120,7 +116,6 @@ pub struct Job {
     pub counters: JobTaskCounters,
 
     pub tasks: Map<TakoTaskId, JobTaskInfo>,
-    pub tasks_crash_counter: Map<TakoTaskId, u32>,
 
     pub log: Option<PathBuf>,
 
@@ -193,7 +188,6 @@ impl Job {
             completion_date: None,
             submit_dir,
             completion_callbacks: Default::default(),
-            tasks_crash_counter: Default::default(),
         }
     }
 
@@ -312,20 +306,6 @@ impl Job {
             for handler in self.completion_callbacks.drain(..) {
                 handler.send(self.job_id).ok();
             }
-        }
-    }
-
-    pub fn increment_task_crash_count(&mut self, tako_task_id: TakoTaskId) {
-        self.tasks_crash_counter
-            .entry(tako_task_id)
-            .and_modify(|count| *count += 1)
-            .or_insert(1);
-    }
-
-    pub fn is_often_crashing_task(&self, tako_task_id: TakoTaskId) -> bool {
-        match self.tasks_crash_counter.get(&tako_task_id) {
-            Some(&crashes) => crashes >= CRASHING_TASK_THRESHOLD,
-            None => false,
         }
     }
 

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -60,6 +60,7 @@ pub struct TaskDescription {
     pub task_dir: bool,
     pub time_limit: Option<Duration>,
     pub priority: tako::Priority,
+    pub crash_limit: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/pyhq/src/client/job.rs
+++ b/crates/pyhq/src/client/job.rs
@@ -1,3 +1,4 @@
+use hyperqueue::client::commands::submit::command::DEFAULT_CRASH_LIMIT;
 use hyperqueue::client::output::resolve_task_paths;
 use hyperqueue::client::resources::parse_allocation_request;
 use hyperqueue::client::status::{is_terminated, Status};
@@ -147,6 +148,7 @@ fn build_task_desc(desc: TaskDescription, submit_dir: &Path) -> anyhow::Result<H
         task_dir: desc.task_dir,
         priority: desc.priority,
         time_limit: None,
+        crash_limit: DEFAULT_CRASH_LIMIT,
     })
 }
 

--- a/crates/tako/benches/utils/mod.rs
+++ b/crates/tako/benches/utils/mod.rs
@@ -16,6 +16,7 @@ pub fn create_task(id: TaskId) -> Task {
         user_priority: 0,
         time_limit: None,
         n_outputs: 0,
+        crash_limit: 5,
     };
     Task::new(id, vec![], Rc::new(conf), Default::default(), false, false)
 }

--- a/crates/tako/src/gateway.rs
+++ b/crates/tako/src/gateway.rs
@@ -63,6 +63,8 @@ pub struct SharedTaskConfiguration {
 
     #[serde(default)]
     pub observe: bool,
+
+    pub crash_limit: u32,
 }
 
 /// Task data that is unique for each task.

--- a/crates/tako/src/internal/server/client.rs
+++ b/crates/tako/src/internal/server/client.rs
@@ -90,6 +90,7 @@ fn create_task_configuration(
         n_outputs: msg.n_outputs,
         time_limit: msg.time_limit,
         user_priority: msg.priority,
+        crash_limit: msg.crash_limit,
     }
 }
 

--- a/crates/tako/src/internal/server/core.rs
+++ b/crates/tako/src/internal/server/core.rs
@@ -14,7 +14,7 @@ use crate::internal::server::taskmap::TaskMap;
 use crate::internal::server::worker::Worker;
 use crate::internal::server::workerload::WorkerResources;
 use crate::internal::server::workermap::WorkerMap;
-use crate::{Map, TaskId, WorkerId};
+use crate::{TaskId, WorkerId};
 
 pub(crate) type CustomConnectionHandler = Box<dyn Fn(ConnectionDescriptor)>;
 
@@ -33,8 +33,6 @@ pub struct Core {
 
     sleeping_sn_tasks: Vec<TaskId>, // Tasks that cannot be scheduled to any available worker
     sleeping_mn_tasks: Vec<TaskId>,
-
-    crash_counter: Map<TaskId, u32>,
 
     maximal_task_id: TaskId,
     worker_id_counter: u32,
@@ -282,7 +280,6 @@ impl Core {
     /// it up.
     #[must_use]
     pub fn remove_task(&mut self, task_id: TaskId) -> TaskRuntimeState {
-        self.crash_counter.remove(&task_id);
         let task = self
             .tasks
             .remove(task_id)
@@ -450,20 +447,6 @@ impl Core {
     pub fn secret_key(&self) -> &Option<Arc<SecretKey>> {
         &self.secret_key
     }
-
-    pub fn increment_crash_counter(&mut self, task_id: TaskId) -> Option<u32> {
-        let limit = self.get_task(task_id).configuration.crash_limit;
-        if limit == 0 {
-            return None;
-        }
-        let entry = self.crash_counter.entry(task_id).or_default();
-        *entry += 1;
-        if *entry >= limit {
-            Some(*entry)
-        } else {
-            None
-        }
-    }
 }
 
 #[cfg(test)]
@@ -476,10 +459,6 @@ mod tests {
     use crate::{TaskId, WorkerId};
 
     impl Core {
-        pub fn crash_counter(&self, task_id: TaskId) -> Option<u32> {
-            self.crash_counter.get(&task_id).copied()
-        }
-
         pub fn get_read_to_assign(&self) -> &[TaskId] {
             &self.single_node_ready_to_assign
         }

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -104,6 +104,7 @@ pub struct TaskConfiguration {
     pub user_priority: Priority,
     pub time_limit: Option<Duration>,
     pub n_outputs: u32,
+    pub crash_limit: u32,
 }
 
 #[cfg_attr(test, derive(Eq, PartialEq))]

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -117,6 +117,7 @@ pub struct Task {
     pub configuration: Rc<TaskConfiguration>,
     pub scheduler_priority: Priority,
     pub instance_id: InstanceId,
+    pub crash_counter: u32,
     pub body: Vec<u8>,
 }
 
@@ -153,6 +154,7 @@ impl Task {
             state: TaskRuntimeState::Waiting(WaitingInfo { unfinished_deps: 0 }),
             consumers: Default::default(),
             instance_id: InstanceId::new(0),
+            crash_counter: 0,
         }
     }
 
@@ -276,6 +278,11 @@ impl Task {
 
     pub(crate) fn increment_instance_id(&mut self) {
         self.instance_id = InstanceId(self.instance_id.as_num() + 1);
+    }
+
+    pub(crate) fn increment_crash_counter(&mut self) -> bool {
+        self.crash_counter += 1;
+        self.crash_counter >= self.configuration.crash_limit && self.configuration.crash_limit > 0
     }
 
     pub(crate) fn make_compute_message(&self, node_list: Vec<WorkerId>) -> ToWorkerMessage {

--- a/crates/tako/src/internal/tests/integration/test_worker.rs
+++ b/crates/tako/src/internal/tests/integration/test_worker.rs
@@ -174,7 +174,8 @@ async fn test_lost_worker_with_tasks_restarts() {
         }
 
         let _worker_handle = handle.start_worker(Default::default()).await.unwrap();
-        handle.wait(&[1]).await.assert_all_finished();
+        let r = handle.wait(&[1]).await;
+        assert!(r.is_failed(1));
     })
     .await;
 }

--- a/crates/tako/src/internal/tests/integration/utils/task.rs
+++ b/crates/tako/src/internal/tests/integration/utils/task.rs
@@ -110,6 +110,7 @@ pub fn build_task_def_from_config(
         priority: 0,
         keep,
         observe: observe.unwrap_or(true),
+        crash_limit: 5,
     };
     (
         TaskConfiguration {

--- a/crates/tako/src/internal/tests/test_reactor.rs
+++ b/crates/tako/src/internal/tests/test_reactor.rs
@@ -656,7 +656,7 @@ fn test_worker_crashing_task() {
 
     let t1 = task(1);
     submit_test_tasks(&mut core, vec![t1]);
-    assert_eq!(core.crash_counter(TaskId::new(1)), None);
+    assert_eq!(core.get_task(TaskId::new(1)).crash_counter, 0);
 
     for x in 1..=5 {
         let mut comm = create_test_comm();
@@ -681,11 +681,10 @@ fn test_worker_crashing_task() {
             let errs = comm.take_client_task_errors(1);
             assert_eq!(errs[0].0, TaskId::new(1));
             assert_eq!(errs[0].2.message, "Task was running on a worker that was lost; the task has occurred 5 times in this situation and limit was reached.");
-            assert_eq!(core.crash_counter(TaskId::new(1)), None);
             assert_eq!(std::mem::take(&mut lw[0].1), vec![].to_ids());
         } else {
             assert_eq!(std::mem::take(&mut lw[0].1), vec![1].to_ids());
-            assert_eq!(core.crash_counter(TaskId::new(1)), Some(x));
+            assert_eq!(core.get_task(TaskId::new(1)).crash_counter, x);
         }
         comm.emptiness_check();
     }

--- a/crates/tako/src/internal/tests/utils/task.rs
+++ b/crates/tako/src/internal/tests/utils/task.rs
@@ -11,6 +11,7 @@ pub struct TaskBuilder {
     n_outputs: u32,
     resources: ResBuilder,
     user_priority: Priority,
+    crash_limit: u32,
 }
 
 impl TaskBuilder {
@@ -21,6 +22,7 @@ impl TaskBuilder {
             n_outputs: 0,
             resources: Default::default(),
             user_priority: 0,
+            crash_limit: 5,
         }
     }
 
@@ -87,6 +89,7 @@ impl TaskBuilder {
                 n_outputs: self.n_outputs,
                 time_limit: None,
                 user_priority: self.user_priority,
+                crash_limit: self.crash_limit,
             }),
             Default::default(),
             false,

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -350,18 +350,31 @@ Here is a list of useful job commands:
 
 ### Display information about a specific job
 
-```bash
+```commandline
 $ hq job info <job-selector>
 ```
 
 ### Display information about individual tasks (potentially across multiple jobs)
 
-```bash
+```commandline
 $ hq task list <job-selector> [--task-status <status>] [--tasks <task-selector>]
 ```
 
 ### Display job `stdout`/`stderr`
 
-```bash
+```commandline
 $ hq job cat <job-id> [--tasks <task-selector>] <stdout/stderr>
 ```
+
+## Crashing limit
+
+When a worker is lost then all running tasks on the worker are suspicious that they may cause the crash of the
+worker. HyperQueue server remembers how many times were a task running while a worker is lost. If the count 
+reaches the limit, then the task is set to the failed state.
+By default, this limit is `5` but it can be changed as follows:
+
+```commandline
+$ hq submit --crash-limit=<NEWLIMIT> ...
+```
+
+If the limit is set to 0, then the limit is disabled.

--- a/tests/output/test_json.py
+++ b/tests/output/test_json.py
@@ -142,6 +142,7 @@ def test_print_job_detail(hq_env: HqEnv):
             "submit_dir": str,
             "tasks": list,
             "task_dir": bool,
+            "crash_limit": int,
         }
     )
     schema.validate(output)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -62,5 +62,5 @@ def test_task_info(hq_env: HqEnv):
     assert "WARN Task 4 not found" in r
 
     hq_env.command(["submit", "--", "bash", "-c", "hostname"])
-    r = hq_env.command(["task", "info", "last", "0"])
-    assert "Task ID   | 0" in r
+    r = hq_env.command(["task", "info", "last", "0"], as_table=True)
+    assert r.get_row_value("Task ID") == "0"


### PR DESCRIPTION
Add `--crash-limit` flag to `hq submit`. It lets you control the maximum time a task might be present when its executing worker fails, before that task is cancelled.