### PR TITLE
Optimize `Task` size in `tako`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempdir",
+ "thin-vec",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2026,6 +2027,12 @@ dependencies = [
  "unicode-linebreak",
  "unicode-width",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104c2cb3180b6fb6d5b2278768e9b88b578d32ba751ea6e8d026688a40d7ed87"
 
 [[package]]
 name = "thiserror"

--- a/crates/tako/Cargo.toml
+++ b/crates/tako/Cargo.toml
@@ -35,6 +35,7 @@ bitflags = "1.2"
 bstr = { version = "0.2", features = ["serde1"] }
 psutil = "3.2.1"
 fxhash = "0.2.1"
+thin-vec = "0.2.8"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/tako/benches/benchmarks/worker.rs
+++ b/crates/tako/benches/benchmarks/worker.rs
@@ -66,7 +66,7 @@ fn create_worker_task(id: u64) -> Task {
         time_limit: None,
         n_outputs: 0,
         node_list: vec![],
-        body: vec![],
+        body: Default::default(),
     })
 }
 

--- a/crates/tako/benches/utils/mod.rs
+++ b/crates/tako/benches/utils/mod.rs
@@ -18,7 +18,14 @@ pub fn create_task(id: TaskId) -> Task {
         n_outputs: 0,
         crash_limit: 5,
     };
-    Task::new(id, vec![], Rc::new(conf), Default::default(), false, false)
+    Task::new(
+        id,
+        Default::default(),
+        Rc::new(conf),
+        Default::default(),
+        false,
+        false,
+    )
 }
 pub fn create_worker(id: u64) -> Worker {
     Worker::new(

--- a/crates/tako/src/gateway.rs
+++ b/crates/tako/src/gateway.rs
@@ -78,7 +78,7 @@ pub struct TaskConfiguration {
 
     /// Opaque data that is passed by the gateway user to task launchers.
     #[serde(with = "serde_bytes")]
-    pub body: Vec<u8>,
+    pub body: Box<[u8]>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/crates/tako/src/internal/messages/worker.rs
+++ b/crates/tako/src/internal/messages/worker.rs
@@ -32,7 +32,7 @@ pub struct ComputeTaskMsg {
     pub node_list: Vec<WorkerId>,
 
     #[serde(with = "serde_bytes")]
-    pub body: Vec<u8>,
+    pub body: Box<[u8]>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/tako/src/internal/scheduler/metrics.rs
+++ b/crates/tako/src/internal/scheduler/metrics.rs
@@ -29,7 +29,7 @@ fn crawl<F1: Fn(&Task) -> &Set<TaskId>>(tasks: &mut TaskMap, predecessor_fn: F1)
         let task = tasks.get_task_mut(task_id);
         task.set_scheduler_priority(level + 1);
 
-        for ti in &task.inputs {
+        for ti in task.inputs.iter() {
             let input_id = ti.task();
             let v: &mut u32 = neighbours
                 .get_mut(&input_id)

--- a/crates/tako/src/internal/scheduler/state.rs
+++ b/crates/tako/src/internal/scheduler/state.rs
@@ -273,7 +273,7 @@ impl SchedulerState {
             (task.inputs.clone(), assigned_worker)
         };
 
-        for ti in inputs {
+        for ti in inputs.into_iter() {
             let input = core.get_task_mut(ti.task());
             if let Some(wr) = assigned_worker {
                 input.remove_future_placement(wr);

--- a/crates/tako/src/internal/server/client.rs
+++ b/crates/tako/src/internal/server/client.rs
@@ -14,6 +14,7 @@ use crate::internal::server::task::{Task, TaskConfiguration, TaskInput, TaskRunt
 use crate::internal::common::resources::request::ResourceRequestEntry;
 use crate::internal::scheduler::query::compute_new_worker_query;
 use std::rc::Rc;
+use thin_vec::ThinVec;
 
 /*pub(crate) async fn client_connection_handler(
     core_ref: CoreRef,
@@ -264,7 +265,7 @@ fn handle_new_tasks(
             return Some(format!("Invalid configuration index {}", idx));
         }
         let (conf, keep, observe) = &configurations[idx];
-        let inputs: Vec<_> = task
+        let inputs: ThinVec<_> = task
             .task_deps
             .iter()
             .map(|&task_id| TaskInput::new_task_dependency(task_id))

--- a/crates/tako/src/internal/server/reactor.rs
+++ b/crates/tako/src/internal/server/reactor.rs
@@ -173,7 +173,7 @@ pub(crate) fn on_new_tasks(core: &mut Core, comm: &mut impl Comm, new_tasks: Vec
         let mut task = task_map.remove(&task_id).unwrap();
 
         let mut count = 0;
-        for ti in &task.inputs {
+        for ti in task.inputs.iter() {
             let input_id = ti.task();
             let task_dep = task_map
                 .get_mut(&input_id)

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -6,8 +6,8 @@ use crate::internal::common::stablemap::ExtractKey;
 use crate::internal::common::{Map, Set};
 use crate::internal::messages::worker::{ComputeTaskMsg, ToWorkerMessage};
 use crate::internal::server::taskmap::TaskMap;
-use crate::TaskId;
 use crate::WorkerId;
+use crate::{static_assert_size, TaskId};
 use crate::{InstanceId, Priority};
 
 #[derive(Debug)]
@@ -118,8 +118,11 @@ pub struct Task {
     pub scheduler_priority: Priority,
     pub instance_id: InstanceId,
     pub crash_counter: u32,
-    pub body: Vec<u8>,
+    pub body: Box<[u8]>,
 }
+
+// Task is a critical data structure, so we should keep its size in check
+static_assert_size!(Task, 184);
 
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -133,7 +136,7 @@ impl Task {
         id: TaskId,
         inputs: Vec<TaskInput>,
         configuration: Rc<TaskConfiguration>,
-        body: Vec<u8>,
+        body: Box<[u8]>,
         keep: bool,
         observe: bool,
     ) -> Self {

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::rc::Rc;
 use std::time::Duration;
+use thin_vec::ThinVec;
 
 use crate::internal::common::stablemap::ExtractKey;
 use crate::internal::common::{Map, Set};
@@ -112,7 +113,7 @@ pub struct Task {
     pub id: TaskId,
     pub state: TaskRuntimeState,
     consumers: Set<TaskId>,
-    pub inputs: Vec<TaskInput>,
+    pub inputs: ThinVec<TaskInput>,
     pub flags: TaskFlags,
     pub configuration: Rc<TaskConfiguration>,
     pub scheduler_priority: Priority,
@@ -122,7 +123,7 @@ pub struct Task {
 }
 
 // Task is a critical data structure, so we should keep its size in check
-static_assert_size!(Task, 184);
+static_assert_size!(Task, 168);
 
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -134,7 +135,7 @@ impl fmt::Debug for Task {
 impl Task {
     pub fn new(
         id: TaskId,
-        inputs: Vec<TaskInput>,
+        inputs: ThinVec<TaskInput>,
         configuration: Rc<TaskConfiguration>,
         body: Box<[u8]>,
         keep: bool,

--- a/crates/tako/src/internal/tests/integration/utils/task.rs
+++ b/crates/tako/src/internal/tests/integration/utils/task.rs
@@ -117,7 +117,7 @@ pub fn build_task_def_from_config(
             id: TaskId::new(id.unwrap_or(1) as <TaskId as ItemId>::IdType),
             shared_data_index: 0,
             task_deps: Vec::new(),
-            body,
+            body: body.into_boxed_slice(),
         },
         conf,
     )

--- a/crates/tako/src/internal/tests/test_worker.rs
+++ b/crates/tako/src/internal/tests/test_worker.rs
@@ -74,7 +74,7 @@ fn create_dummy_compute_msg(task_id: TaskId) -> ComputeTaskMsg {
         time_limit: None,
         n_outputs: 0,
         node_list: vec![],
-        body: vec![],
+        body: Default::default(),
     }
 }
 

--- a/crates/tako/src/internal/tests/utils/task.rs
+++ b/crates/tako/src/internal/tests/utils/task.rs
@@ -83,7 +83,7 @@ impl TaskBuilder {
         resources.validate().unwrap();
         Task::new(
             self.id,
-            self.inputs,
+            self.inputs.into_iter().collect(),
             Rc::new(TaskConfiguration {
                 resources,
                 n_outputs: self.n_outputs,

--- a/crates/tako/src/internal/worker/task.rs
+++ b/crates/tako/src/internal/worker/task.rs
@@ -19,7 +19,7 @@ pub struct Task {
     pub resources: crate::internal::common::resources::ResourceRequest,
     pub time_limit: Option<Duration>,
     pub n_outputs: u32,
-    pub body: Vec<u8>,
+    pub body: Box<[u8]>,
     pub node_list: Vec<WorkerId>, // Filled in multi-node tasks; otherwise empty
 }
 

--- a/crates/tako/src/internal/worker/test_util.rs
+++ b/crates/tako/src/internal/worker/test_util.rs
@@ -53,7 +53,7 @@ impl WorkerTaskBuilder {
             time_limit: None,
             n_outputs: 0,
             node_list: vec![],
-            body: vec![],
+            body: Default::default(),
         })
     }
 }

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1304,13 +1304,14 @@ def test_submit_task_dir(hq_env: HqEnv, mode):
     )
     wait_for_job_state(hq_env, 1, "RUNNING")
 
-    def read_task_dir():
-        path = read_file(default_task_output()).rstrip()
-        if path is not None:
-            return path
+    def file_created():
+        task_dir = read_file(default_task_output()).rstrip()
+        if task_dir is None:
+            return
+        return os.path.isfile(os.path.join(task_dir, "xyz"))
 
-    task_dir = wait_until(read_task_dir)
-    assert os.path.isfile(os.path.join(task_dir, "xyz"))
+    wait_until(file_created)
+    task_dir = read_file(default_task_output()).rstrip()
 
     if mode == "CANCELED":
         hq_env.command(["job", "cancel", "all"])


### PR DESCRIPTION
I didn't use `ThinVec` for body, because it does not support `serde_bytes` serialization, so it would have to be copied an additional time after network roundtrip.