### PR TITLE
Create a new `dist` profile to make release builds faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           HQ_BUILD_VERSION: ${{ needs.set-env.outputs.version }}
         with:
           command: build
-          args: --release
+          args: --profile dist
 
       - name: Prepare archive
         id: archive
@@ -98,7 +98,7 @@ jobs:
           HQ_BUILD_VERSION: ${{ needs.set-env.outputs.version }}
         with:
           command: build
-          args: --target powerpc64le-unknown-linux-gnu --no-default-features --release
+          args: --target powerpc64le-unknown-linux-gnu --no-default-features --profile dist
           use-cross: true
 
       - name: Prepare archive
@@ -126,7 +126,7 @@ jobs:
           maturin-version: latest
           manylinux: 2014
           command: build
-          args: --manifest-path crates/pyhq/Cargo.toml --release --out wheels
+          args: --manifest-path crates/pyhq/Cargo.toml --profile dist --out wheels
       - name: Upload test artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,6 @@ default-members = [
     "crates/tako"
 ]
 
-[profile.release]
-lto = true
-codegen-units = 1
-opt-level = 3
-panic = "abort"
-strip = "debuginfo"
-
 [workspace.package]
 rust-version = "1.64.0"
 edition = "2021"
@@ -47,3 +40,14 @@ tempdir = "0.3"
 tracing = "0.1"
 anyhow = "1"
 nix = "0.25"
+
+[profile.release]
+panic = "abort"
+
+# Profile designed for the most optimized release build that is distributed
+# to users.
+[profile.dist]
+inherits = "release"
+lto = true
+codegen-units = 1
+strip = "debuginfo"


### PR DESCRIPTION
The `release` profile was excruciatingly slow to build because of fat LTO and 1 CGU. It was discouraging me from running benchmarks locally. I created a `dist` profile that has the previous properties of `release`, for the most optimized build, and use it in CI to create artifacts. But for local usage `release` should now be much faster to build.