### PR TITLE
Allow overriding autoalloc max allocation failure limit with an environment variable

### DIFF
--- a/crates/hyperqueue/src/server/autoalloc/config.rs
+++ b/crates/hyperqueue/src/server/autoalloc/config.rs
@@ -24,11 +24,16 @@ fn get_duration_from_env(key: &str) -> Option<Duration> {
 }
 
 /// Maximum number of successive allocation submission failures permitted
-/// before the allocation queue will be removed.
-pub const MAX_SUBMISSION_FAILS: usize = 10;
+/// before the allocation queue will be paused.
+pub const MAX_SUBMISSION_FAILS: u64 = 10;
 /// Maximum number of successive allocation execution failures permitted
-/// before the allocation queue will be removed.
-pub const MAX_ALLOCATION_FAILS: usize = 3;
+/// before the allocation queue will be paused.
+pub fn max_allocation_fails() -> u64 {
+    std::env::var("HQ_AUTOALLOC_MAX_ALLOCATION_FAILS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(3)
+}
 /// Delay levels between submisisons. See [`super::state::RateLimiter`].
 pub const SUBMISSION_DELAYS: [Duration; 5] = [
     Duration::ZERO,

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -308,18 +308,18 @@ pub struct RateLimiter {
     /// How often can status be checked.
     status_delay: Duration,
     /// How many times has an allocation failed in a row.
-    allocation_fails: usize,
-    max_allocation_fails: usize,
+    allocation_fails: u64,
+    max_allocation_fails: u64,
     /// How many times has the submission failed in a row.
-    submission_fails: usize,
-    max_submission_fails: usize,
+    submission_fails: u64,
+    max_submission_fails: u64,
 }
 
 impl RateLimiter {
     pub fn new(
         delays: Vec<Duration>,
-        max_submission_fails: usize,
-        max_allocation_fails: usize,
+        max_submission_fails: u64,
+        max_allocation_fails: u64,
         status_delay: Duration,
     ) -> Self {
         assert!(!delays.is_empty());

--- a/tests/pyapi/__init__.py
+++ b/tests/pyapi/__init__.py
@@ -1,10 +1,9 @@
 import os.path
 from typing import List, Tuple
 
+from hyperqueue import LocalCluster
 from hyperqueue.client import Client
 from hyperqueue.job import Job
-
-from hyperqueue import LocalCluster
 
 from ..conftest import HqEnv
 from ..utils.mock import ProgramMock

--- a/tests/pyapi/test_cluster.py
+++ b/tests/pyapi/test_cluster.py
@@ -1,4 +1,5 @@
 import pytest
+
 from hyperqueue.cluster import LocalCluster, WorkerConfig
 from hyperqueue.job import Job
 

--- a/tests/pyapi/test_function.py
+++ b/tests/pyapi/test_function.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from hyperqueue.client import Client, FailedJobsException, PythonEnv
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import iso8601
 import pytest
+
 from hyperqueue.client import FailedJobsException
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job


### PR DESCRIPTION
Suggested by @svatosFZU [here](https://github.com/It4innovations/hyperqueue/issues/501#issuecomment-1277205325).

I consider this to be an unstable feature so I wouldn't document it. It's currently quite difficult to write a test for this because of how the rate limiter works, so I didn't include any tests.