### PR TITLE
Only do size check assertion on x86_x64

### DIFF
--- a/crates/tako/src/internal/common/utils.rs
+++ b/crates/tako/src/internal/common/utils.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 #[macro_export]
 macro_rules! static_assert_size {
     ($ty:ty, $size:expr) => {
+        #[cfg(target_arch = "x86_x64")]
         const _: [(); $size] = [(); ::std::mem::size_of::<$ty>()];
     };
 }


### PR DESCRIPTION
This allows cross-compilation to Raspberry Pi.