### PR TITLE
Pass more parameters verbatim to worker start in autoalloc

### DIFF
--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -357,9 +357,7 @@ fn format_autoalloc_queue(id: QueueId, descriptor: QueueData) -> serde_json::Val
         "workers_per_alloc": info.workers_per_alloc(),
         "timelimit": format_duration(info.timelimit()),
         "max_worker_count": info.max_worker_count(),
-        "worker_cpu_args": info.worker_cpu_args(),
-        "worker_resource_args": info.worker_resource_args(),
-        "on_server_lost": crate::common::format::server_lost_policy_to_str(info.on_server_lost()),
+        "worker_args": info.worker_args(),
     })
 }
 fn format_allocation(allocation: Allocation) -> serde_json::Value {

--- a/crates/hyperqueue/src/client/utils.rs
+++ b/crates/hyperqueue/src/client/utils.rs
@@ -1,7 +1,6 @@
 use clap::builder::TypedValueParser;
 use clap::{Command, Error};
 use std::ffi::OsStr;
-use std::marker::PhantomData;
 
 #[macro_export]
 macro_rules! rpc_call {
@@ -21,13 +20,18 @@ macro_rules! rpc_call {
 }
 
 /// This argument checks that the input can be parsed as `Arg`.
-/// If it is, it will return the original input from the command line as a [`String`].
+/// If it is, it will return the original input from the command line as a [`String`] along with the
+/// parsed value.
 #[derive(Debug, Clone)]
-pub struct PassThroughArgument<Arg>(String, PhantomData<Arg>);
+pub struct PassThroughArgument<Arg>(String, Arg);
 
-impl<Arg> From<PassThroughArgument<Arg>> for String {
-    fn from(arg: PassThroughArgument<Arg>) -> Self {
-        arg.0
+impl<Arg> PassThroughArgument<Arg> {
+    pub fn into_original_input(self) -> String {
+        self.0
+    }
+
+    pub fn into_parsed_arg(self) -> Arg {
+        self.1
     }
 }
 
@@ -51,6 +55,6 @@ impl<Arg: Clone + Sync + Send + 'static> TypedValueParser for PassthroughParser<
     ) -> Result<Self::Value, Error> {
         self.0
             .parse_ref(cmd, arg, value)
-            .map(|_| PassThroughArgument(value.to_string_lossy().to_string(), Default::default()))
+            .map(|parsed| PassThroughArgument(value.to_string_lossy().to_string(), parsed))
     }
 }

--- a/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/queue_params_display.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/queue_params_display.rs
@@ -3,7 +3,6 @@ use crate::dashboard::ui::styles::table_style_deselected;
 use crate::dashboard::ui::terminal::DashboardFrame;
 use crate::dashboard::ui::widgets::table::{StatefulTable, TableColumnHeaders};
 use crate::transfer::messages::AllocationQueueParams;
-use tako::worker::ServerLostPolicy;
 use tui::layout::{Constraint, Rect};
 use tui::widgets::{Cell, Row};
 
@@ -55,11 +54,8 @@ fn create_rows(params: &AllocationQueueParams) -> Vec<QueueParamsDataRow> {
             data: human_duration(chrono::Duration::from_std(params.timelimit).unwrap()),
         },
         QueueParamsDataRow {
-            label: "Worker On Server Lost: ",
-            data: match params.on_server_lost {
-                ServerLostPolicy::Stop => "STOP".to_string(),
-                ServerLostPolicy::FinishRunning => "FINISH_RUNNING".to_string(),
-            },
+            label: "Worker Args: ",
+            data: params.worker_args.join(" "),
         },
         QueueParamsDataRow {
             label: "Queue Name: ",
@@ -68,14 +64,6 @@ fn create_rows(params: &AllocationQueueParams) -> Vec<QueueParamsDataRow> {
         QueueParamsDataRow {
             label: "Additional Args: ",
             data: params.additional_args.join(" "),
-        },
-        QueueParamsDataRow {
-            label: "Worker CPU Arg: ",
-            data: params.worker_cpu_arg.clone().unwrap_or_default(),
-        },
-        QueueParamsDataRow {
-            label: "Worker Resource Args: ",
-            data: params.worker_resources_args.join(" "),
         },
         QueueParamsDataRow {
             label: "Max Worker Count: ",

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -228,21 +228,17 @@ pub fn create_queue_info(params: AllocationQueueParams) -> QueueInfo {
         backlog,
         timelimit,
         additional_args,
-        worker_cpu_arg,
-        worker_resources_args,
         max_worker_count,
-        on_server_lost,
+        worker_args,
         idle_timeout,
     } = params;
     QueueInfo::new(
         backlog,
         workers_per_alloc,
         timelimit,
-        on_server_lost,
         additional_args,
-        worker_cpu_arg,
-        worker_resources_args,
         max_worker_count,
+        worker_args,
         idle_timeout,
     )
 }
@@ -863,7 +859,6 @@ mod tests {
     use tako::gateway::{LostWorkerReason, ResourceRequest, ResourceRequestEntry};
     use tako::program::ProgramDefinition;
     use tako::resources::{AllocationRequest, TimeRequest, CPU_RESOURCE_NAME};
-    use tako::worker::ServerLostPolicy;
     use tako::WorkerId;
     use tako::{Map, Set, WrappedRcRefCell};
 
@@ -1589,11 +1584,9 @@ mod tests {
                     backlog,
                     workers_per_alloc,
                     timelimit,
-                    ServerLostPolicy::Stop,
-                    vec![],
-                    None,
                     vec![],
                     max_worker_count,
+                    vec![],
                     None,
                 ),
                 RateLimiter::new(

--- a/crates/hyperqueue/src/server/autoalloc/queue/common.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/common.rs
@@ -1,7 +1,6 @@
 use crate::common::manager::info::ManagerType;
 use anyhow::Context;
 use bstr::ByteSlice;
-use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::process::Output;
 use std::time::Duration;
@@ -151,17 +150,9 @@ pub fn build_worker_args(
         server_dir.display()
     );
 
-    if let Some(cpu_arg) = queue_info.worker_cpu_args() {
-        args.write_fmt(format_args!(" --cpus {}", cpu_arg)).unwrap();
+    if !queue_info.worker_args.is_empty() {
+        args.push_str(&format!(" {}", queue_info.worker_args.join(" ")));
     }
-    for resource_arg in queue_info.worker_resource_args() {
-        args.write_fmt(format_args!(" --resource \"{}\"", resource_arg))
-            .unwrap();
-    }
-    args.write_fmt(format_args!(
-        " --on-server-lost={}",
-        crate::common::format::server_lost_policy_to_str(&queue_info.on_server_lost)
-    ))
-    .unwrap();
+
     args
 }

--- a/crates/hyperqueue/src/server/autoalloc/queue/mod.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/mod.rs
@@ -9,7 +9,6 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::time::{Duration, SystemTime};
-use tako::worker::ServerLostPolicy;
 use tako::Map;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,11 +16,9 @@ pub struct QueueInfo {
     backlog: u32,
     workers_per_alloc: u32,
     timelimit: Duration,
-    on_server_lost: ServerLostPolicy,
     additional_args: Vec<String>,
-    worker_cpu_arg: Option<String>,
-    worker_resource_args: Vec<String>,
     max_worker_count: Option<u32>,
+    worker_args: Vec<String>,
     idle_timeout: Option<Duration>,
 }
 
@@ -31,11 +28,9 @@ impl QueueInfo {
         backlog: u32,
         workers_per_alloc: u32,
         timelimit: Duration,
-        on_server_lost: ServerLostPolicy,
         additional_args: Vec<String>,
-        worker_cpu_arg: Option<String>,
-        worker_resource_args: Vec<String>,
         max_worker_count: Option<u32>,
+        worker_args: Vec<String>,
         idle_timeout: Option<Duration>,
     ) -> Self {
         Self {
@@ -43,10 +38,8 @@ impl QueueInfo {
             workers_per_alloc,
             timelimit,
             additional_args,
-            worker_cpu_arg,
-            worker_resource_args,
             max_worker_count,
-            on_server_lost,
+            worker_args,
             idle_timeout,
         }
     }
@@ -67,20 +60,12 @@ impl QueueInfo {
         &self.additional_args
     }
 
-    pub fn worker_cpu_args(&self) -> Option<&String> {
-        self.worker_cpu_arg.as_ref()
-    }
-
-    pub fn worker_resource_args(&self) -> &[String] {
-        &self.worker_resource_args
-    }
-
-    pub fn on_server_lost(&self) -> &ServerLostPolicy {
-        &self.on_server_lost
-    }
-
     pub fn max_worker_count(&self) -> Option<u32> {
         self.max_worker_count
+    }
+
+    pub fn worker_args(&self) -> &[String] {
+        &self.worker_args
     }
 }
 

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -417,7 +417,6 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
     use std::time::Duration;
-    use tako::worker::ServerLostPolicy;
 
     struct NullHandler;
     impl QueueHandler for NullHandler {
@@ -452,17 +451,7 @@ mod tests {
         let _id = state.create_id();
         let id = state.add_queue(AllocationQueue::new(
             ManagerType::Pbs,
-            QueueInfo::new(
-                1,
-                1,
-                Duration::from_secs(1),
-                ServerLostPolicy::FinishRunning,
-                vec![],
-                None,
-                vec![],
-                None,
-                None,
-            ),
+            QueueInfo::new(1, 1, Duration::from_secs(1), vec![], None, vec![], None),
             None,
             Box::new(NullHandler),
             RateLimiter::new(vec![Duration::from_secs(1)], 1, 1, Duration::from_secs(1)),

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use crate::server::event::MonitoringEvent;
 use tako::gateway::{LostWorkerReason, MonitoringEventRequest, ResourceRequest};
 use tako::program::ProgramDefinition;
-use tako::worker::{ServerLostPolicy, WorkerConfiguration};
+use tako::worker::WorkerConfiguration;
 
 // Messages client -> server
 #[allow(clippy::large_enum_variant)]
@@ -196,12 +196,12 @@ pub struct AllocationQueueParams {
     pub workers_per_alloc: u32,
     pub backlog: u32,
     pub timelimit: Duration,
-    pub on_server_lost: ServerLostPolicy,
     pub name: Option<String>,
-    pub additional_args: Vec<String>,
-    pub worker_cpu_arg: Option<String>,
-    pub worker_resources_args: Vec<String>,
     pub max_worker_count: Option<u32>,
+    pub additional_args: Vec<String>,
+
+    // Black-box worker args that will be passed to `worker start`
+    pub worker_args: Vec<String>,
     pub idle_timeout: Option<Duration>,
 }
 

--- a/tests/autoalloc/test_autoalloc.py
+++ b/tests/autoalloc/test_autoalloc.py
@@ -272,7 +272,7 @@ def test_pbs_multinode_allocation(hq_env: HqEnv):
             assert (
                 commands
                 == f"pbsdsh -- bash -l -c '{get_hq_binary()} worker start --idle-timeout 5m \
---manager pbs --server-dir {hq_env.server_dir}/001 --on-server-lost=finish-running'"
+--manager pbs --server-dir {hq_env.server_dir}/001 --on-server-lost finish-running'"
             )
 
 
@@ -291,7 +291,7 @@ def test_slurm_multinode_allocation(hq_env: HqEnv):
             assert (
                 commands
                 == f"srun --overlap {get_hq_binary()} worker start --idle-timeout 5m \
---manager slurm --server-dir {hq_env.server_dir}/001 --on-server-lost=finish-running"
+--manager slurm --server-dir {hq_env.server_dir}/001 --on-server-lost finish-running"
             )
 
 
@@ -600,6 +600,8 @@ def test_pass_cpu_and_resources_to_worker(hq_env: HqEnv, spec: ManagerSpec):
                 "y=range(1-4)",
                 "--resource",
                 "z=[1,2,4]",
+                "--no-hyper-threading",
+                "--no-detect-resources",
             ],
         )
 
@@ -621,7 +623,10 @@ def test_pass_cpu_and_resources_to_worker(hq_env: HqEnv, spec: ManagerSpec):
             '"y=range(1-4)"',
             "--resource",
             '"z=[1,2,4]"',
-            "--on-server-lost=finish-running",
+            "--no-hyper-threading",
+            "--no-detect-resources",
+            "--on-server-lost",
+            "finish-running",
         ]
 
 
@@ -653,7 +658,8 @@ def test_pass_idle_timeout_to_worker(hq_env: HqEnv, spec: ManagerSpec):
             spec.manager_type(),
             "--server-dir",
             f"{hq_env.server_dir}/001",
-            "--on-server-lost=finish-running",
+            "--on-server-lost",
+            "finish-running",
         ]
 
 
@@ -681,7 +687,8 @@ def test_pass_on_server_lost(hq_env: HqEnv, spec: ManagerSpec):
             spec.manager_type(),
             "--server-dir",
             f"{hq_env.server_dir}/001",
-            "--on-server-lost=stop",
+            "--on-server-lost",
+            "stop",
         ]
 
 


### PR DESCRIPTION
For parameters that are black-box to autoalloc (most of them), the client now build an opaque list of string arguments that are then passed by autoalloc to workers that are being started.

Fixes: https://github.com/It4innovations/hyperqueue/issues/531