### PR TITLE
Add `hq job summary` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Dev
+## New features
+
+### CLI
+* [#545](https://github.com/It4innovations/hyperqueue/issues/545) Add a new command `hq job summary`,
+which displays the amount of jobs per each job state.
+
 ## Fixes
 
 ### Worker

--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -7,8 +7,8 @@ use cli_table::ColorChoice;
 use hyperqueue::client::commands::autoalloc::command_autoalloc;
 use hyperqueue::client::commands::event::command_event_log;
 use hyperqueue::client::commands::job::{
-    cancel_job, output_job_cat, output_job_detail, output_job_list, JobCancelOpts, JobCatOpts,
-    JobInfoOpts, JobListOpts,
+    cancel_job, output_job_cat, output_job_detail, output_job_list, output_job_summary,
+    JobCancelOpts, JobCatOpts, JobInfoOpts, JobListOpts,
 };
 use hyperqueue::client::commands::log::command_log;
 use hyperqueue::client::commands::server::command_server;
@@ -76,6 +76,12 @@ async fn command_job_list(gsettings: &GlobalSettings, opts: JobListOpts) -> anyh
     };
 
     output_job_list(gsettings, &mut connection, filter).await
+}
+
+async fn command_job_summary(gsettings: &GlobalSettings) -> anyhow::Result<()> {
+    let mut connection = get_client_session(gsettings.server_directory()).await?;
+
+    output_job_summary(gsettings, &mut connection).await
 }
 
 async fn command_job_detail(gsettings: &GlobalSettings, opts: JobInfoOpts) -> anyhow::Result<()> {
@@ -345,6 +351,9 @@ async fn main() -> hyperqueue::Result<()> {
         SubCommand::Job(JobOpts {
             subcmd: JobCommand::List(opts),
         }) => command_job_list(&gsettings, opts).await,
+        SubCommand::Job(JobOpts {
+            subcmd: JobCommand::Summary,
+        }) => command_job_summary(&gsettings).await,
         SubCommand::Job(JobOpts {
             subcmd: JobCommand::Info(opts),
         }) => command_job_detail(&gsettings, opts).await,

--- a/crates/hyperqueue/src/client/commands/job.rs
+++ b/crates/hyperqueue/src/client/commands/job.rs
@@ -104,6 +104,20 @@ pub async fn output_job_list(
     Ok(())
 }
 
+pub async fn output_job_summary(
+    gsettings: &GlobalSettings,
+    session: &mut ClientSession,
+) -> anyhow::Result<()> {
+    let message = FromClientMessage::JobInfo(JobInfoRequest {
+        selector: IdSelector::All,
+    });
+    let response =
+        rpc_call!(session.connection(), message, ToClientMessage::JobInfoResponse(r) => r).await?;
+
+    gsettings.printer().print_job_summary(response.jobs);
+    Ok(())
+}
+
 pub async fn output_job_detail(
     gsettings: &GlobalSettings,
     session: &mut ClientSession,

--- a/crates/hyperqueue/src/client/output/common.rs
+++ b/crates/hyperqueue/src/client/output/common.rs
@@ -1,8 +1,9 @@
+use crate::client::status::{job_status, Status};
 use crate::common::placeholders::{
     fill_placeholders_in_paths, CompletePlaceholderCtx, ResolvablePaths,
 };
 use crate::server::job::JobTaskState;
-use crate::transfer::messages::{JobDescription, JobDetail, TaskDescription};
+use crate::transfer::messages::{JobDescription, JobDetail, JobInfo, TaskDescription};
 use crate::JobTaskId;
 use std::path::PathBuf;
 use tako::program::StdioDef;
@@ -90,4 +91,23 @@ impl From<VerbosityFlag> for Verbosity {
             Verbosity::Normal
         }
     }
+}
+
+pub const JOB_SUMMARY_STATUS_ORDER: [Status; 5] = [
+    Status::Running,
+    Status::Waiting,
+    Status::Finished,
+    Status::Failed,
+    Status::Canceled,
+];
+
+pub fn group_jobs_by_status(jobs: &[JobInfo]) -> Map<Status, u64> {
+    let mut map = Map::new();
+    for status in &JOB_SUMMARY_STATUS_ORDER {
+        map.insert(*status, 0);
+    }
+    for job in jobs {
+        *map.entry(job_status(job)).or_default() += 1;
+    }
+    map
 }

--- a/crates/hyperqueue/src/client/output/outputs.rs
+++ b/crates/hyperqueue/src/client/output/outputs.rs
@@ -44,6 +44,7 @@ pub trait Output {
     // Jobs
     fn print_job_submitted(&self, job: JobDetail);
     fn print_job_list(&self, jobs: Vec<JobInfo>, total_jobs: usize);
+    fn print_job_summary(&self, jobs: Vec<JobInfo>);
     fn print_job_detail(&self, job: JobDetail, worker_map: WorkerMap, server_uid: &str);
     fn print_job_wait(
         &self,

--- a/crates/hyperqueue/src/client/status.rs
+++ b/crates/hyperqueue/src/client/status.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use crate::server::job::JobTaskState;
 use crate::transfer::messages::JobInfo;
 
-#[derive(clap::ValueEnum, Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(clap::ValueEnum, Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
 pub enum Status {
     Waiting,
     Running,

--- a/crates/hyperqueue/src/common/cli.rs
+++ b/crates/hyperqueue/src/common/cli.rs
@@ -289,6 +289,8 @@ pub enum JobCommand {
     /// Display information about jobs.
     /// By default, only queued or running jobs will be displayed.
     List(JobListOpts),
+    /// Display a summary with the amount of jobs per each job state.
+    Summary,
     /// Display detailed information of the selected job
     Info(JobInfoOpts),
     /// Cancel a specific job

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -348,6 +348,11 @@ Here is a list of useful job commands:
     - `failed`
     - `canceled`
 
+### Display a summary table of all jobs
+```commandline
+$ hq job summary
+```
+
 ### Display information about a specific job
 
 ```commandline

--- a/tests/output/test_json.py
+++ b/tests/output/test_json.py
@@ -196,6 +196,20 @@ def test_print_hw(hq_env: HqEnv):
     hq_env.start_server()
     output = parse_json_output(hq_env, ["--output-mode=json", "worker", "hwdetect"])
 
-    print(output)
     schema = Schema({"resources": RESOURCE_DESCRIPTOR_SCHEMA})
+    schema.validate(output)
+
+
+def test_print_job_summary(hq_env: HqEnv):
+    hq_env.start_server()
+    output = parse_json_output(hq_env, ["--output-mode=json", "job", "summary"])
+    schema = Schema(
+        {
+            "Canceled": 0,
+            "Failed": 0,
+            "Finished": 0,
+            "Running": 0,
+            "Waiting": 0,
+        }
+    )
     schema.validate(output)

--- a/tests/pyapi/__init__.py
+++ b/tests/pyapi/__init__.py
@@ -1,10 +1,9 @@
 import os.path
 from typing import List, Tuple
 
+from hyperqueue import LocalCluster
 from hyperqueue.client import Client
 from hyperqueue.job import Job
-
-from hyperqueue import LocalCluster
 
 from ..conftest import HqEnv
 from ..utils.mock import ProgramMock

--- a/tests/pyapi/test_cluster.py
+++ b/tests/pyapi/test_cluster.py
@@ -1,4 +1,5 @@
 import pytest
+
 from hyperqueue.cluster import LocalCluster, WorkerConfig
 from hyperqueue.job import Job
 

--- a/tests/pyapi/test_function.py
+++ b/tests/pyapi/test_function.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from hyperqueue.client import Client, FailedJobsException, PythonEnv
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import iso8601
 import pytest
+
 from hyperqueue.client import FailedJobsException
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job


### PR DESCRIPTION
Adds a new HQ job summary command that shows the amount of jobs per each job state.

![image](https://user-images.githubusercontent.com/4539057/213132330-a89a333f-1319-41ec-ac7c-822cf1164d84.png)

Closes: https://github.com/It4innovations/hyperqueue/issues/545