### PR TITLE
Change default stdout/stderr path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
   $ hq worker start --resource="res1=[foo, bar]"
   ```
 
+## Changes
+
+### Job submission
+* The default path for `stdout` and `stderr` files has been changed from `%{SUBMIT_DIR}/job-%{JOB_ID}/%{TASK_ID}.[stdout/stderr]`
+  to `%{CWD}/job-%{JOB_ID}/%{TASK_ID}.[stdout/stderr]`. Note that the default value for the working
+  directory (`%{CWD}`) is set to the submission directory, so if you have used the defaults before,
+  nothing will change for you. Stdout and stderr paths are now also resolved relative to the working
+  directory of the given task, not to the submit directory.
+
 # v0.14.0
 
 ## New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "cli-table",
  "colored",
  "const_format",
+ "criterion",
  "derive_builder",
  "dirs",
  "env_logger",

--- a/crates/hyperqueue/Cargo.toml
+++ b/crates/hyperqueue/Cargo.toml
@@ -64,6 +64,7 @@ jemallocator = { version = "0.5", optional = true }
 [dev-dependencies]
 derive_builder = "0.11"
 insta = "1.15.0"
+criterion = { version = "0.3", features = ["html_reports"] }
 
 [features]
 default = ["jemalloc"]
@@ -71,3 +72,11 @@ default = ["jemalloc"]
 zero-worker = []
 # Use the jemalloc allocator
 jemalloc = ["jemallocator"]
+
+[[bench]]
+name = "benchmark"
+harness = false
+
+# Workaround for Criterion (https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options)
+[lib]
+bench = false

--- a/crates/hyperqueue/benches/benchmark.rs
+++ b/crates/hyperqueue/benches/benchmark.rs
@@ -1,0 +1,39 @@
+use criterion::measurement::WallTime;
+use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
+use hyperqueue::common::placeholders::{has_placeholders, parse_resolvable_string};
+
+fn bench_parse_placeholder(c: &mut BenchmarkGroup<WallTime>) {
+    c.bench_function("no placeholders", |bencher| {
+        bencher.iter(|| {
+            parse_resolvable_string("/tmp/my-very-long-path/that-is-even-longer-than-we-thought")
+        });
+    });
+    c.bench_function("single placeholder", |bencher| {
+        bencher.iter(|| {
+            parse_resolvable_string(
+                "/tmp/my-very-long-path/%{TASK_ID}/that-is-even-longer-than-we-thought",
+            )
+        });
+    });
+    c.bench_function("has_placeholders without placeholder", |bencher| {
+        bencher.iter(|| {
+            has_placeholders("/tmp/my-very-long-path/that-is-even-longer-than-we-thought")
+        });
+    });
+    c.bench_function("has_placeholders with placeholder", |bencher| {
+        bencher.iter(|| {
+            has_placeholders(
+                "/tmp/my-very-long-path/that-is-even-longer-than-we-thought/%{TASK_ID}",
+            )
+        });
+    });
+}
+
+pub fn benchmark_placeholders(c: &mut Criterion) {
+    let mut group = c.benchmark_group("placeholder");
+    bench_parse_placeholder(&mut group);
+}
+
+criterion_group!(placeholders, benchmark_placeholders);
+
+criterion_main!(placeholders);

--- a/crates/hyperqueue/src/client/commands/submit/command.rs
+++ b/crates/hyperqueue/src/client/commands/submit/command.rs
@@ -22,7 +22,7 @@ use crate::common::arraydef::IntArray;
 use crate::common::cli::OptsWithMatches;
 use crate::common::placeholders::{
     get_unknown_placeholders, parse_resolvable_string, StringPart, CWD_PLACEHOLDER,
-    JOB_ID_PLACEHOLDER, SUBMIT_DIR_PLACEHOLDER, TASK_ID_PLACEHOLDER,
+    JOB_ID_PLACEHOLDER, TASK_ID_PLACEHOLDER,
 };
 use crate::common::utils::fs::get_current_dir;
 use crate::common::utils::str::pluralize;
@@ -40,7 +40,7 @@ pub const DEFAULT_CRASH_LIMIT: u32 = 5;
 // Keep in sync with `tests/util/job.py::default_task_output` and `pyhq/python/hyperqueue/output.py`
 const DEFAULT_STDOUT_PATH: &str = const_format::concatcp!(
     "%{",
-    SUBMIT_DIR_PLACEHOLDER,
+    CWD_PLACEHOLDER,
     "}",
     "/",
     "job-",
@@ -55,7 +55,7 @@ const DEFAULT_STDOUT_PATH: &str = const_format::concatcp!(
 );
 const DEFAULT_STDERR_PATH: &str = const_format::concatcp!(
     "%{",
-    SUBMIT_DIR_PLACEHOLDER,
+    CWD_PLACEHOLDER,
     "}",
     "/",
     "job-",

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -76,8 +76,8 @@ $ hq submit --cwd=<path> ...
 By default, each job will produce two files containing the standard output and standard error output, respectively. The
 default paths of these files are
 
-- `%{SUBMIT_DIR}/job-%{JOB_ID}/%{TASK_ID}.stdout` for `stdout`
-- `%{SUBMIT_DIR}/job-%{JOB_ID}/%{TASK_ID}.stderr` for `stderr`
+- `%{CWD}/job-%{JOB_ID}/%{TASK_ID}.stdout` for `stdout`
+- `%{CWD}/job-%{JOB_ID}/%{TASK_ID}.stderr` for `stderr`
 
 `%{JOB_ID}` and `%{TASK_ID}` are so-called placeholders, you can read about them [below](#placeholders).
 
@@ -298,7 +298,6 @@ $ hq submit --stdin bash
 
 If you want to parse #HQ directives from standard input, you can use ``--directives=stdin``.
 
-
 ## Task directory
 
 When a job is submitted with ``--task-dir`` then a temporary directory is created for each task and
@@ -318,7 +317,6 @@ placed inside the task directory.
 If the message is longer than 2KiB, then it is truncated to 2KiB.
 
 If task terminates with zero return code, then the error file is ignored.
-
 
 ## Useful job commands
 Here is a list of useful job commands:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -128,7 +128,6 @@ def test_job_custom_working_dir(hq_env: HqEnv, tmpdir):
     test_file.write(test_string)
 
     submit_dir = tmpdir.mkdir("submit_dir")
-
     hq_env.command(
         ["submit", f"--cwd={work_dir}", "--", "bash", "-c", "cat testfile"],
         cwd=submit_dir,
@@ -139,7 +138,7 @@ def test_job_custom_working_dir(hq_env: HqEnv, tmpdir):
     hq_env.start_worker(cpus=1)
     wait_for_job_state(hq_env, 1, ["FINISHED"])
 
-    check_file_contents(default_task_output(submit_dir=submit_dir), test_string)
+    check_file_contents(default_task_output(working_dir=work_dir), test_string)
 
 
 def test_job_output_default(hq_env: HqEnv, tmp_path):

--- a/tests/utils/job.py
+++ b/tests/utils/job.py
@@ -6,10 +6,10 @@ from .table import Table
 
 
 def default_task_output(
-    job_id=1, task_id=0, type="stdout", submit_dir: Optional[str] = None
+    job_id=1, task_id=0, type="stdout", working_dir: Optional[str] = None
 ) -> str:
-    submit_dir = submit_dir if submit_dir else os.getcwd()
-    return f"{submit_dir}/job-{job_id}/{task_id}.{type}"
+    working_dir = working_dir if working_dir else os.getcwd()
+    return f"{working_dir}/job-{job_id}/{task_id}.{type}"
 
 
 def list_jobs(hq_env: HqEnv, all=True, filters: List[str] = None) -> Table:


### PR DESCRIPTION
The default is changed from the submit directory to the working directory, I think that it makes more sense. It was especially surprising that if you changed just he working directory and not the stdout/stderr paths, then the files would be created relative to the submit directory.