### PR TITLE
Split NVIDIA and AMD GPUs into two resource groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * AMD GPUs are now automatically detected in workers from the environment variable `ROCR_VISIBLE_DEVICES`
   or `HIP_VISIBLE_DEVICES`.
 
+* You can now use the `-`, `:` or `/` symbols in resource names.
+
 ## Changes
 
 ### Job submission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ resources that are automatically detected on a worker has been changed from `gpu
 for NVIDIA GPUs. AMD GPUs are now autodetected as `gpus/amd`. In the future, we intend to create a way
 to ask for any GPU resource (e.g. `--resource=gpus=2`), regardless of its type.
 
-* AMD GPUs are now automatically detected in workers from the environment variable `ROCR_VISIBLE_DEVICES`
-  or `HIP_VISIBLE_DEVICES`.
+* AMD GPUs are now automatically detected in workers from the environment variable `ROCR_VISIBLE_DEVICES`.
 
 * You can now use the `-`, `:` or `/` symbols in resource names.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dev
 
+## Breaking changes
+
+- **NVIDIA GPUs are now automatically detected under the resource name `gpus/nvidia`, instead of
+just `gpus`!** If you have been using the `gpus` resource name, you should update your scripts.
+See more details below.
+
 ## New features
 
 ### Resource management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   $ hq worker start --resource="res1=[foo, bar]"
   ```
 
+* HyperQueue now provides built-in support for AMD GPUs. For this reason, the default name of GPU
+resources that are automatically detected on a worker has been changed from `gpus` to `gpus/nvidia`
+for NVIDIA GPUs. AMD GPUs are now autodetected as `gpus/amd`. In the future, we intend to create a way
+to ask for any GPU resource (e.g. `--resource=gpus=2`), regardless of its type.
+
 * AMD GPUs are now automatically detected in workers from the environment variable `ROCR_VISIBLE_DEVICES`
   or `HIP_VISIBLE_DEVICES`.
 

--- a/crates/hyperqueue/src/common/parser2.rs
+++ b/crates/hyperqueue/src/common/parser2.rs
@@ -264,16 +264,6 @@ pub fn parse_exact_string(keyword: &'static str) -> impl CharParser<()> {
         })
 }
 
-pub fn parse_named_string(name: &'static str) -> impl CharParser<String> {
-    ident().map_err_with_span(|error: ParseError, span| {
-        error.merge(ParseError::expected_input_found_string(
-            span,
-            Some(Some(name.to_string())),
-            None,
-        ))
-    })
-}
-
 /// Return a parser that will fail if there is any input following the text parsed by the
 /// provided parser.
 pub fn all_consuming<T>(parser: impl CharParser<T>) -> impl CharParser<T> {

--- a/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/fragment.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/auto_allocator/fragment.rs
@@ -27,7 +27,9 @@ pub struct AutoAllocatorFragment {
     component_in_focus: FocusedComponent,
 }
 
+#[derive(Default)]
 enum FocusedComponent {
+    #[default]
     QueueParamsTable,
     AllocationInfoTable,
 }
@@ -164,11 +166,5 @@ impl AutoAllocFragmentLayout {
             allocation_info_chunk: component_area[1],
             footer_chunk: auto_alloc_screen_chunks[3],
         }
-    }
-}
-
-impl Default for FocusedComponent {
-    fn default() -> Self {
-        FocusedComponent::QueueParamsTable
     }
 }

--- a/crates/hyperqueue/src/dashboard/ui/fragments/job/fragment.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/job/fragment.rs
@@ -31,7 +31,9 @@ pub struct JobFragment {
     component_in_focus: FocusedComponent,
 }
 
+#[derive(Default)]
 enum FocusedComponent {
+    #[default]
     JobsTable,
     JobTasksTable,
 }
@@ -154,11 +156,5 @@ impl JobFragmentLayout {
             job_tasks_chunk: table_area[1],
             footer_chunk: job_screen_chunks[3],
         }
-    }
-}
-
-impl Default for FocusedComponent {
-    fn default() -> Self {
-        FocusedComponent::JobsTable
     }
 }

--- a/crates/hyperqueue/src/worker/hwdetect.rs
+++ b/crates/hyperqueue/src/worker/hwdetect.rs
@@ -86,9 +86,8 @@ pub fn detect_additional_resources(items: &mut Vec<ResourceDescriptorItem>) -> a
     Ok(())
 }
 
-pub const GPU_ENV_KEYS: &[(&str, &str); 3] = &[
+pub const GPU_ENV_KEYS: &[(&str, &str); 2] = &[
     ("CUDA_VISIBLE_DEVICES", NVIDIA_GPU_RESOURCE_NAME),
-    ("HIP_VISIBLE_DEVICES", AMD_GPU_RESOURCE_NAME),
     ("ROCR_VISIBLE_DEVICES", AMD_GPU_RESOURCE_NAME),
 ];
 

--- a/crates/tako/benches/benchmarks/worker.rs
+++ b/crates/tako/benches/benchmarks/worker.rs
@@ -13,7 +13,7 @@ use tako::resources::{
     AllocationRequest, ResourceDescriptor, ResourceRequest, ResourceRequestEntry, TimeRequest,
 };
 use tako::resources::{
-    ResourceDescriptorItem, ResourceDescriptorKind, CPU_RESOURCE_NAME, GPU_RESOURCE_NAME,
+    ResourceDescriptorItem, ResourceDescriptorKind, CPU_RESOURCE_NAME, NVIDIA_GPU_RESOURCE_NAME,
 };
 use tako::ItemId;
 use tokio::sync::mpsc::unbounded_channel;
@@ -170,7 +170,7 @@ fn create_resource_queue(num_cpus: u32) -> ResourceWaitQueue {
             kind: ResourceDescriptorKind::simple_indices(num_cpus),
         },
         ResourceDescriptorItem {
-            name: GPU_RESOURCE_NAME.to_string(),
+            name: NVIDIA_GPU_RESOURCE_NAME.to_string(),
             kind: ResourceDescriptorKind::simple_indices(8),
         },
     ]);

--- a/crates/tako/src/internal/common/resources/map.rs
+++ b/crates/tako/src/internal/common/resources/map.rs
@@ -4,7 +4,8 @@ use crate::internal::common::Map;
 pub const CPU_RESOURCE_ID: ResourceId = ResourceId(0);
 
 pub const CPU_RESOURCE_NAME: &str = "cpus";
-pub const GPU_RESOURCE_NAME: &str = "gpus";
+pub const NVIDIA_GPU_RESOURCE_NAME: &str = "gpus/nvidia";
+pub const AMD_GPU_RESOURCE_NAME: &str = "gpus/amd";
 pub const MEM_RESOURCE_NAME: &str = "mem";
 
 #[derive(Debug)]

--- a/crates/tako/src/internal/common/resources/mod.rs
+++ b/crates/tako/src/internal/common/resources/mod.rs
@@ -9,7 +9,10 @@ pub use allocation::{Allocation, AllocationValue, ResourceAllocation, ResourceAl
 pub use descriptor::{
     DescriptorError, ResourceDescriptor, ResourceDescriptorItem, ResourceDescriptorKind,
 };
-pub use map::{CPU_RESOURCE_ID, CPU_RESOURCE_NAME, GPU_RESOURCE_NAME, MEM_RESOURCE_NAME};
+pub use map::{
+    AMD_GPU_RESOURCE_NAME, CPU_RESOURCE_ID, CPU_RESOURCE_NAME, MEM_RESOURCE_NAME,
+    NVIDIA_GPU_RESOURCE_NAME,
+};
 pub use request::{
     AllocationRequest, ResourceRequest, ResourceRequestEntries, ResourceRequestEntry, TimeRequest,
 };

--- a/crates/tako/src/lib.rs
+++ b/crates/tako/src/lib.rs
@@ -31,8 +31,8 @@ pub mod resources {
         Allocation, AllocationRequest, AllocationValue, NumOfNodes, ResourceAllocation,
         ResourceAmount, ResourceDescriptor, ResourceDescriptorItem, ResourceDescriptorKind,
         ResourceIndex, ResourceLabel, ResourceRequest, ResourceRequestEntries,
-        ResourceRequestEntry, TimeRequest, CPU_RESOURCE_ID, CPU_RESOURCE_NAME, GPU_RESOURCE_NAME,
-        MEM_RESOURCE_NAME,
+        ResourceRequestEntry, TimeRequest, AMD_GPU_RESOURCE_NAME, CPU_RESOURCE_ID,
+        CPU_RESOURCE_NAME, MEM_RESOURCE_NAME, NVIDIA_GPU_RESOURCE_NAME,
     };
 
     pub use crate::internal::common::resources::map::ResourceMap;

--- a/crates/tako/src/program.rs
+++ b/crates/tako/src/program.rs
@@ -3,8 +3,9 @@ use bstr::BString;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
 pub enum StdioDef {
+    #[default]
     Null,
     File(PathBuf),
     Pipe,
@@ -20,12 +21,6 @@ impl StdioDef {
             StdioDef::File(filename) => StdioDef::File(f(filename)),
             StdioDef::Pipe => StdioDef::Pipe,
         }
-    }
-}
-
-impl Default for StdioDef {
-    fn default() -> Self {
-        StdioDef::Null
     }
 }
 

--- a/docs/deployment/allocation.md
+++ b/docs/deployment/allocation.md
@@ -74,13 +74,13 @@ creating a new allocation queue:
     === "PBS"
     
         ```bash
-        $ hq alloc add pbs --time-limit 1h --cpus 4x4 --resource "gpus=range(1-2)" -- -qqprod -AAccount1
+        $ hq alloc add pbs --time-limit 1h --cpus 4x4 --resource "gpus/nvidia=range(1-2)" -- -qqprod -AAccount1
         ```
     
     === "Slurm"
     
         ``` bash
-        $ hq alloc add slurm --time-limit 1h --cpus 4x4 --resource "gpus=range(1-2)" -- --partition=p1
+        $ hq alloc add slurm --time-limit 1h --cpus 4x4 --resource "gpus/nvidia=range(1-2)" -- --partition=p1
         ```
     
     If you do not pass any resources, they will be detected automatically (same as it works with

--- a/docs/jobs/resources.md
+++ b/docs/jobs/resources.md
@@ -95,7 +95,7 @@ The following resources are detected automatically if a resource of a given name
     - NVIDIA GPUs are stored the under resource name `gpus/nvidia`. These GPUs are detected from the
       environment variable `CUDA_VISIBLE_DEVICES` or from the `procfs` filesystem.
     - AMD GPUs are stored under the resource name `gpus/amd`. These GPUs are detected from the environment
-      variables `ROCR_VISIBLE_DEVICES` or `HIP_VISIBLE_DEVICES`.
+      variable `ROCR_VISIBLE_DEVICES`.
 
     You can set these environment variables when starting a worker to override the list of available GPUs:
   
@@ -202,7 +202,7 @@ HQ also sets additional environment variables for various resources with special
     - `CUDA_VISIBLE_DEVICES` to the same value as `HQ_RESOURCE_VALUES_gpus/nvidia`
     - `CUDA_DEVICE_ORDER` to `PCI_BUS_ID`
 - For the resource `gpus/amd`, HQ will set:
-    - `ROCR_VISIBLE_DEVICES` and `HIP_VISIBLE_DEVICES` to the same value as `HQ_RESOURCE_VALUES_gpus/amd`
+    - `ROCR_VISIBLE_DEVICES` to the same value as `HQ_RESOURCE_VALUES_gpus/amd`
 
 ## Resource requests and job arrays
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -214,6 +214,19 @@ def test_worker_detect_uuid_gpus_from_env(hq_env: HqEnv):
     assert "gpus/nvidia: [foo,bar]" in resources
 
 
+def test_worker_detect_multiple_gpus_from_env(hq_env: HqEnv):
+    hq_env.start_server()
+    resources = hq_env.command(
+        ["worker", "hwdetect"],
+        env={
+            "CUDA_VISIBLE_DEVICES": "0,1",
+            "ROCR_VISIBLE_DEVICES": "1",
+        },
+    )
+    assert "gpus/nvidia: [0,1]" in resources
+    assert "gpus/amd: [1]" in resources
+
+
 def test_task_info_resources(hq_env: HqEnv):
     hq_env.start_server()
     hq_env.start_worker()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -244,3 +244,12 @@ def test_string_resource_list(hq_env: HqEnv):
 
     table = hq_env.command(["task", "info", "1", "1"], as_table=True)
     table.check_row_value("Resources", "cpus: 1 compact\nfairy: 2 compact")
+
+
+def test_resource_name_special_symbol(hq_env: HqEnv):
+    hq_env.start_server()
+
+    res_name = "gpus/amd-2:1"
+    hq_env.command(["submit", "--resource", f"{res_name}=1", "ls"])
+    hq_env.start_worker(args=["--resource", f"{res_name}=[0]"])
+    wait_for_job_state(hq_env, 1, "FINISHED")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -196,7 +196,6 @@ echo $CUDA_VISIBLE_DEVICES
     "env_and_res",
     (
         ("CUDA_VISIBLE_DEVICES", "gpus/nvidia"),
-        ("HIP_VISIBLE_DEVICES", "gpus/amd"),
         ("ROCR_VISIBLE_DEVICES", "gpus/amd"),
     ),
 )


### PR DESCRIPTION
This is required to properly pass `CUDA_VISIBLE_DEVICES`/`ROCR_VISIBLE_DEVICES` to tasks separately. Best reviewed commit by commit.