### PR TITLE
Restrict resource names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,12 @@ to ask for any GPU resource (e.g. `--resource=gpus=2`), regardless of its type.
 
 * AMD GPUs are now automatically detected in workers from the environment variable `ROCR_VISIBLE_DEVICES`.
 
-* You can now use the `-`, `:` or `/` symbols in resource names.
+* Allowed characters for resource names has been changed. The name now has to begin with an ASCII letter,
+and it can only contain ASCII letters, ASCII digits and the slash (`/`) symbol. This restriction is
+introduced for better alignment with shells, which typically do not support complicated variable names.
+HQ passes the resource names to executed tasks through environment variables, so it has to take this
+into account. Note that the `/` symbol in resource name will be normalized to `_` when being passed
+to a task.
 
 ## Changes
 

--- a/docs/jobs/resources.md
+++ b/docs/jobs/resources.md
@@ -84,6 +84,22 @@ where `NAMEi` is a name (string ) of the `i`-th resource pool and `DEFi` is a de
     $ hq worker start --resources "foo=sum(5)"
     ```
 
+### Resource names
+Resource names are restricted by the following rules:
+
+- They can only contain ASCII letters and digits (`a-z`, `A-Z`, `0-9`) and the slash (`/`) symbol.
+- They need to begin with an ASCII letter.
+
+These restrictions exist because the resource names are passed as environment variable names to tasks,
+which often execute shell scripts. However, shells typically do not support environment variables
+containing anything else than ASCII letters, digits and the underscore symbol. Therefore, HQ limits
+resource naming to align with the behaviour of the shell.
+
+!!! important
+
+    HQ will normalize the resource name when passing environment variables
+    to a task (see [below](#resource-environment-variables)).
+
 ### Automatically detected resources
 
 The following resources are detected automatically if a resource of a given name is not explicitly defined.
@@ -196,13 +212,16 @@ each resource request named `<NAME>`:
 * `HQ_RESOURCE_VALUES_<NAME>` contains the specific resource values allocated for the task as a
 comma-separated list. This variable is only filled for indexed resource pool.
 
+The slash symbol (`/`) in resource name is normalized to underscore (`_`) when being used in the
+environment variable name.
+
 HQ also sets additional environment variables for various resources with special names:
 
 - For the resource `gpus/nvidia`, HQ will set:
-    - `CUDA_VISIBLE_DEVICES` to the same value as `HQ_RESOURCE_VALUES_gpus/nvidia`
+    - `CUDA_VISIBLE_DEVICES` to the same value as `HQ_RESOURCE_VALUES_gpus_nvidia`
     - `CUDA_DEVICE_ORDER` to `PCI_BUS_ID`
 - For the resource `gpus/amd`, HQ will set:
-    - `ROCR_VISIBLE_DEVICES` to the same value as `HQ_RESOURCE_VALUES_gpus/amd`
+    - `ROCR_VISIBLE_DEVICES` to the same value as `HQ_RESOURCE_VALUES_gpus_amd`
 
 ## Resource requests and job arrays
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -262,10 +262,10 @@ def test_string_resource_list(hq_env: HqEnv):
     table.check_row_value("Resources", "cpus: 1 compact\nfairy: 2 compact")
 
 
-def test_resource_name_special_symbol(hq_env: HqEnv):
+def test_resource_name_slash(hq_env: HqEnv):
     hq_env.start_server()
 
-    res_name = "gpus/amd-2:1"
+    res_name = "gpus/amd"
     hq_env.command(["submit", "--resource", f"{res_name}=1", "ls"])
     hq_env.start_worker(args=["--resource", f"{res_name}=[0]"])
     wait_for_job_state(hq_env, 1, "FINISHED")


### PR DESCRIPTION
To improve alignment with shells.