### PR TITLE
Record NVIDIA GPU usage in overview monitoring

### DIFF
--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -226,6 +226,7 @@ wasted allocation duration."
         no_detect_resources,
         no_hyper_threading,
         idle_timeout,
+        overview_interval,
     } = worker_args;
 
     let mut worker_args = vec![];
@@ -246,6 +247,12 @@ wasted allocation duration."
     }
     if no_detect_resources {
         worker_args.push("--no-detect-resources".to_string());
+    }
+    if let Some(overview_interval) = overview_interval {
+        worker_args.extend([
+            "--overview-interval".to_string(),
+            overview_interval.into_original_input(),
+        ]);
     }
     worker_args.extend([
         "--on-server-lost".to_string(),

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -418,7 +418,7 @@ fn format_worker_info(worker_info: WorkerInfo) -> serde_json::Value {
                 work_dir,
                 log_dir,
                 heartbeat_interval,
-                send_overview_interval: _,
+                overview_configuration: _,
                 idle_timeout,
                 time_limit,
                 on_server_lost,

--- a/crates/hyperqueue/src/common/cli.rs
+++ b/crates/hyperqueue/src/common/cli.rs
@@ -212,6 +212,7 @@ pub struct WorkerOpts {
     pub subcmd: WorkerCommand,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Parser)]
 pub enum WorkerCommand {
     /// Start worker

--- a/crates/hyperqueue/src/dashboard/ui/fragments/overview/worker_utilization_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/overview/worker_utilization_table.rs
@@ -92,7 +92,7 @@ fn create_rows(overview: Vec<&WorkerOverview>) -> Vec<WorkerUtilRow> {
             let hw_state = worker.hw_state.as_ref();
             let average_cpu_usage = hw_state.map(get_average_cpu_usage_for_worker);
             let memory_usage =
-                hw_state.map(|s| calculate_memory_usage_percent(&s.state.worker_memory_usage));
+                hw_state.map(|s| calculate_memory_usage_percent(&s.state.memory_usage));
 
             WorkerUtilRow {
                 id: worker.id,

--- a/crates/hyperqueue/src/dashboard/ui/fragments/worker/fragment.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/worker/fragment.rs
@@ -89,7 +89,7 @@ impl WorkerOverviewFragment {
             if let Some(cpu_util) = data
                 .query_worker_overview_at(worker_id, SystemTime::now())
                 .and_then(|overview| overview.hw_state.as_ref())
-                .map(|hw_state| &hw_state.state.worker_cpu_usage.cpu_per_core_percent_usage)
+                .map(|hw_state| &hw_state.state.cpu_usage.cpu_per_core_percent_usage)
             {
                 self.worker_per_core_cpu_util = cpu_util.clone()
             }

--- a/crates/hyperqueue/src/dashboard/ui/fragments/worker/worker_config_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/fragments/worker/worker_config_table.rs
@@ -72,8 +72,11 @@ fn create_rows(worker_info: &WorkerConfiguration) -> Vec<WorkerConfigDataRow> {
         WorkerConfigDataRow {
             label: "Send Overview Interval: ",
             data: worker_info
-                .send_overview_interval
-                .map(|interval| humantime::format_duration(interval).to_string())
+                .overview_configuration
+                .as_ref()
+                .map(|configuration| {
+                    humantime::format_duration(configuration.send_interval).to_string()
+                })
                 .unwrap_or_else(|| missing_data_str.clone()),
         },
         WorkerConfigDataRow {

--- a/crates/hyperqueue/src/dashboard/utils.rs
+++ b/crates/hyperqueue/src/dashboard/utils.rs
@@ -9,14 +9,10 @@ pub fn calculate_memory_usage_percent(memory_stats: &MemoryStats) -> u64 {
 }
 
 pub fn get_average_cpu_usage_for_worker(hw_state: &WorkerHwStateMessage) -> f32 {
-    let num_cpus = hw_state
-        .state
-        .worker_cpu_usage
-        .cpu_per_core_percent_usage
-        .len();
+    let num_cpus = hw_state.state.cpu_usage.cpu_per_core_percent_usage.len();
     let cpu_usage_sum_per_core = hw_state
         .state
-        .worker_cpu_usage
+        .cpu_usage
         .cpu_per_core_percent_usage
         .iter()
         .copied()

--- a/crates/hyperqueue/src/worker/hwdetect.rs
+++ b/crates/hyperqueue/src/worker/hwdetect.rs
@@ -102,8 +102,8 @@ pub fn detect_additional_resources(
 /// GPU resource that can be detected from an environment variable.
 pub struct GpuEnvironmentRecord {
     env_var: &'static str,
-    resource_name: &'static str,
-    family: GpuFamily,
+    pub resource_name: &'static str,
+    pub family: GpuFamily,
 }
 
 impl GpuEnvironmentRecord {
@@ -116,7 +116,7 @@ impl GpuEnvironmentRecord {
     }
 }
 
-pub const GPU_ENV_KEYS: &[GpuEnvironmentRecord; 2] = &[
+pub const GPU_ENVIRONMENTS: &[GpuEnvironmentRecord; 2] = &[
     GpuEnvironmentRecord::new(
         "CUDA_VISIBLE_DEVICES",
         NVIDIA_GPU_RESOURCE_NAME,
@@ -138,7 +138,7 @@ struct DetectedGpu {
 /// Tries to detect available GPUs from one of the `GPU_ENV_KEYS` environment variables.
 fn detect_gpus_from_env() -> Vec<DetectedGpu> {
     let mut gpus = Vec::new();
-    for gpu_env in GPU_ENV_KEYS {
+    for gpu_env in GPU_ENVIRONMENTS {
         if let Ok(devices_str) = std::env::var(gpu_env.env_var) {
             if let Ok(devices) = parse_comma_separated_values(&devices_str) {
                 log::info!(

--- a/crates/pyhq/src/cluster/worker.rs
+++ b/crates/pyhq/src/cluster/worker.rs
@@ -46,7 +46,7 @@ impl RunningWorker {
                 work_dir,
                 log_dir,
                 heartbeat_interval: Duration::from_secs(10),
-                send_overview_interval: None,
+                overview_configuration: None,
                 idle_timeout: None,
                 time_limit: None,
                 on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/benches/utils/mod.rs
+++ b/crates/tako/benches/utils/mod.rs
@@ -41,7 +41,7 @@ pub fn create_worker(id: u64) -> Worker {
             work_dir: Default::default(),
             log_dir: Default::default(),
             heartbeat_interval: Default::default(),
-            send_overview_interval: None,
+            overview_configuration: None,
             idle_timeout: None,
             time_limit: None,
             on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/hwstats.rs
+++ b/crates/tako/src/hwstats.rs
@@ -21,15 +21,34 @@ pub struct NetworkStats {
     pub tx_errors: u64,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct GpuStats {
+    pub id: String,
+    pub cpu_usage: f32,
+    pub mem_usage: f32,
+}
+
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+pub struct GpuCollectionStats {
+    pub gpus: Vec<GpuStats>,
+}
+
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
 pub struct WorkerHwState {
     pub cpu_usage: CpuStats,
     pub memory_usage: MemoryStats,
     pub network_usage: NetworkStats,
+    pub nvidia_gpus: Option<GpuCollectionStats>,
     pub timestamp: u64,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct WorkerHwStateMessage {
     pub state: WorkerHwState,
+}
+
+#[derive(Deserialize, Serialize, Hash, Debug, PartialEq, Eq, Copy, Clone)]
+pub enum GpuFamily {
+    Nvidia,
+    Amd,
 }

--- a/crates/tako/src/hwstats.rs
+++ b/crates/tako/src/hwstats.rs
@@ -23,9 +23,9 @@ pub struct NetworkStats {
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
 pub struct WorkerHwState {
-    pub worker_cpu_usage: CpuStats,
-    pub worker_memory_usage: MemoryStats,
-    pub worker_network_usage: NetworkStats,
+    pub cpu_usage: CpuStats,
+    pub memory_usage: MemoryStats,
+    pub network_usage: NetworkStats,
     pub timestamp: u64,
 }
 

--- a/crates/tako/src/hwstats.rs
+++ b/crates/tako/src/hwstats.rs
@@ -24,7 +24,7 @@ pub struct NetworkStats {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct GpuStats {
     pub id: String,
-    pub cpu_usage: f32,
+    pub processor_usage: f32,
     pub mem_usage: f32,
 }
 

--- a/crates/tako/src/internal/tests/integration/test_worker.rs
+++ b/crates/tako/src/internal/tests/integration/test_worker.rs
@@ -26,7 +26,7 @@ async fn test_hw_monitoring() {
             .as_ref()
             .unwrap()
             .state
-            .worker_cpu_usage
+            .cpu_usage
             .cpu_per_core_percent_usage
             .clone();
 

--- a/crates/tako/src/internal/tests/integration/utils/worker.rs
+++ b/crates/tako/src/internal/tests/integration/utils/worker.rs
@@ -8,6 +8,7 @@ use tempdir::TempDir;
 use crate::internal::common::error::DsError;
 use crate::internal::common::resources::ResourceDescriptor;
 use crate::internal::server::core::CoreRef;
+use crate::internal::worker::configuration::OverviewConfiguration;
 use crate::launcher::{LaunchContext, StopReason, TaskResult};
 use crate::program::ProgramDefinition;
 use crate::worker::WorkerConfiguration;
@@ -71,7 +72,12 @@ pub(super) fn create_worker_configuration(
             work_dir: Default::default(),
             log_dir: Default::default(),
             heartbeat_interval,
-            send_overview_interval,
+            overview_configuration: send_overview_interval.map(|send_interval| {
+                OverviewConfiguration {
+                    send_interval,
+                    gpu_families: Default::default(),
+                }
+            }),
             idle_timeout,
             on_server_lost: ServerLostPolicy::Stop,
             time_limit: None,

--- a/crates/tako/src/internal/tests/test_reactor.rs
+++ b/crates/tako/src/internal/tests/test_reactor.rs
@@ -29,6 +29,7 @@ use crate::internal::tests::utils::sorted_vec;
 use crate::internal::tests::utils::task::{task, task_running_msg, task_with_deps, TaskBuilder};
 use crate::internal::tests::utils::workflows::{submit_example_1, submit_example_3};
 use crate::internal::tests::utils::{env, schedule};
+use crate::internal::worker::configuration::OverviewConfiguration;
 use crate::resources::{ResourceDescriptorItem, ResourceMap};
 use crate::worker::{ServerLostPolicy, WorkerConfiguration};
 use crate::{TaskId, WorkerId};
@@ -48,7 +49,10 @@ fn test_worker_add() {
         work_dir: Default::default(),
         log_dir: Default::default(),
         heartbeat_interval: Duration::from_millis(1000),
-        send_overview_interval: Some(Duration::from_millis(1000)),
+        overview_configuration: Some(OverviewConfiguration {
+            send_interval: Duration::from_millis(1000),
+            gpu_families: Default::default(),
+        }),
         idle_timeout: None,
         time_limit: None,
         on_server_lost: ServerLostPolicy::Stop,
@@ -96,7 +100,10 @@ fn test_worker_add() {
         work_dir: Default::default(),
         log_dir: Default::default(),
         heartbeat_interval: Duration::from_millis(1000),
-        send_overview_interval: Some(Duration::from_millis(1000)),
+        overview_configuration: Some(OverviewConfiguration {
+            send_interval: Duration::from_millis(1000),
+            gpu_families: Default::default(),
+        }),
         idle_timeout: None,
         time_limit: None,
         on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/internal/tests/test_worker.rs
+++ b/crates/tako/src/internal/tests/test_worker.rs
@@ -4,6 +4,7 @@ use crate::internal::messages::worker::{
 };
 use crate::internal::server::workerload::WorkerResources;
 use crate::internal::worker::comm::WorkerComm;
+use crate::internal::worker::configuration::OverviewConfiguration;
 use crate::internal::worker::rpc::process_worker_message;
 use crate::internal::worker::state::WorkerStateRef;
 use crate::launcher::{LaunchContext, StopReason, TaskLaunchData, TaskLauncher};
@@ -38,7 +39,10 @@ fn create_test_worker_config() -> WorkerConfiguration {
         work_dir: Default::default(),
         log_dir: Default::default(),
         heartbeat_interval: Duration::from_millis(1000),
-        send_overview_interval: Some(Duration::from_millis(1000)),
+        overview_configuration: Some(OverviewConfiguration {
+            send_interval: Duration::from_millis(1000),
+            gpu_families: Default::default(),
+        }),
         idle_timeout: None,
         time_limit: None,
         on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/internal/tests/utils/env.rs
+++ b/crates/tako/src/internal/tests/utils/env.rs
@@ -17,6 +17,7 @@ use crate::internal::tests::utils::resources::cpus_compact;
 use crate::internal::tests::utils::schedule;
 use crate::internal::tests::utils::task::TaskBuilder;
 use crate::internal::transfer::auth::{deserialize, serialize};
+use crate::internal::worker::configuration::OverviewConfiguration;
 use crate::resources::{ResourceAmount, ResourceDescriptorItem, ResourceDescriptorKind};
 use crate::task::SerializedTaskContext;
 use crate::worker::{ServerLostPolicy, WorkerConfiguration};
@@ -105,7 +106,10 @@ impl TestEnv {
                 work_dir: Default::default(),
                 log_dir: Default::default(),
                 heartbeat_interval: Duration::from_millis(1000),
-                send_overview_interval: Some(Duration::from_millis(1000)),
+                overview_configuration: Some(OverviewConfiguration {
+                    send_interval: Duration::from_millis(1000),
+                    gpu_families: Default::default(),
+                }),
                 idle_timeout: None,
                 time_limit: time_limit.clone(),
                 on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/internal/tests/utils/schedule.rs
+++ b/crates/tako/src/internal/tests/utils/schedule.rs
@@ -9,6 +9,7 @@ use crate::internal::server::task::Task;
 use crate::internal::server::worker::Worker;
 use crate::internal::tests::utils::env::TestComm;
 use crate::internal::tests::utils::task::task_running_msg;
+use crate::internal::worker::configuration::OverviewConfiguration;
 use crate::resources::ResourceMap;
 use crate::worker::{ServerLostPolicy, WorkerConfiguration};
 use crate::{TaskId, WorkerId};
@@ -26,7 +27,10 @@ pub fn create_test_worker_config(
         work_dir: Default::default(),
         log_dir: Default::default(),
         heartbeat_interval: Duration::from_millis(1000),
-        send_overview_interval: Some(Duration::from_millis(1000)),
+        overview_configuration: Some(OverviewConfiguration {
+            send_interval: Duration::from_millis(1000),
+            gpu_families: Default::default(),
+        }),
         idle_timeout: None,
         time_limit: None,
         on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/internal/worker/configuration.rs
+++ b/crates/tako/src/internal/worker/configuration.rs
@@ -1,5 +1,7 @@
+use crate::hwstats::GpuFamily;
 use crate::internal::common::resources::ResourceDescriptor;
 use crate::internal::common::Map;
+use crate::Set;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -8,6 +10,14 @@ use std::time::Duration;
 pub enum ServerLostPolicy {
     Stop,
     FinishRunning,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct OverviewConfiguration {
+    /// How often should overview be gathered
+    pub send_interval: Duration,
+    /// GPU families to monitor
+    pub gpu_families: Set<GpuFamily>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -20,7 +30,7 @@ pub struct WorkerConfiguration {
     pub work_dir: PathBuf,
     pub log_dir: PathBuf,
     pub heartbeat_interval: Duration,
-    pub send_overview_interval: Option<Duration>,
+    pub overview_configuration: Option<OverviewConfiguration>,
     pub idle_timeout: Option<Duration>,
     pub time_limit: Option<Duration>,
     pub on_server_lost: ServerLostPolicy,

--- a/crates/tako/src/internal/worker/hwmonitor.rs
+++ b/crates/tako/src/internal/worker/hwmonitor.rs
@@ -43,6 +43,7 @@ impl HwSampler {
                 rx_errors: net_io_counters.err_in(),
                 tx_errors: net_io_counters.err_out(),
             },
+            nvidia_gpus: None,
             timestamp,
         })
     }

--- a/crates/tako/src/internal/worker/hwmonitor.rs
+++ b/crates/tako/src/internal/worker/hwmonitor.rs
@@ -28,14 +28,14 @@ impl HwSampler {
             }
         }
         Ok(WorkerHwState {
-            worker_cpu_usage: CpuStats {
+            cpu_usage: CpuStats {
                 cpu_per_core_percent_usage: cpu_usage,
             },
-            worker_memory_usage: MemoryStats {
+            memory_usage: MemoryStats {
                 total: memory_usage.total(),
                 free: memory_usage.available(),
             },
-            worker_network_usage: NetworkStats {
+            network_usage: NetworkStats {
                 rx_bytes: net_io_counters.bytes_recv(),
                 tx_bytes: net_io_counters.bytes_sent(),
                 rx_packets: net_io_counters.packets_recv(),

--- a/crates/tako/src/internal/worker/hwmonitor/nvidia.rs
+++ b/crates/tako/src/internal/worker/hwmonitor/nvidia.rs
@@ -1,0 +1,111 @@
+use crate::hwstats::{GpuCollectionStats, GpuStats};
+use crate::internal::common::error::DsError;
+use std::process::Command;
+
+/// Parses compute and memory utilization of Nvidia GPUs using `nvidia-smi`.
+/// Example expected output:
+/// ```console
+/// $ nvidia-smi --format=csv,noheader --query-gpu=pci.bus_id,utilization.gpu,memory.used,memory.total
+/// 00000000:C8:00.0, 0 %, 0 MiB, 6144 MiB
+/// 00000000:CB:00.0, 0 %, 0 MiB, 6144 MiB
+/// ```
+pub fn get_nvidia_gpu_state() -> crate::Result<GpuCollectionStats> {
+    let mut command = Command::new("nvidia-smi");
+    command.args([
+        "--format=csv,noheader",
+        "--query-gpu=pci.bus_id,utilization.gpu,memory.used,memory.total",
+    ]);
+    let output = command
+        .output()
+        .map_err::<DsError, _>(|error| format!("Cannot execute nvidia-smi: {error:?}").into())?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        return Err(format!(
+            "nvidia-smi exited with error code {}\nStdout: {stdout}\nStderr: {stderr}",
+            output.status
+        )
+        .into());
+    }
+
+    parse_nvidia_gpu_stats(&stdout)
+}
+
+fn parse_nvidia_gpu_stats(output: &str) -> crate::Result<GpuCollectionStats> {
+    let mut gpus = Vec::new();
+    for line in output.lines() {
+        let mut iter = line.split(',').map(|v| v.trim());
+        let bus_id = iter.next().unwrap_or("");
+        let gpu_util = iter
+            .next()
+            .unwrap_or("")
+            .trim_end_matches('%')
+            .trim()
+            .parse::<f32>()
+            .unwrap_or(0.0);
+        let memory_used = iter.next().and_then(parse_nvidia_gpu_memory).unwrap_or(0.0);
+        let memory_total = iter.next().and_then(parse_nvidia_gpu_memory).unwrap_or(0.0);
+
+        let memory_usage = if memory_total > 0.0 {
+            (memory_used / memory_total) * 100.0
+        } else {
+            0.0
+        };
+        gpus.push(GpuStats {
+            id: bus_id.to_string(),
+            processor_usage: gpu_util,
+            mem_usage: memory_usage,
+        });
+    }
+
+    Ok(GpuCollectionStats { gpus })
+}
+
+fn parse_nvidia_gpu_memory(input: &str) -> Option<f32> {
+    let mut iter = input.split(' ');
+    let value = iter.next().and_then(|v| v.parse::<f32>().ok())?;
+    let suffix = iter.next().unwrap_or("").trim();
+    let multiplier = match suffix {
+        "KiB" => 1024,
+        "MiB" => 1024 * 1024,
+        "GiB" => 1024 * 1024 * 1024,
+        _ => 1,
+    } as f32;
+    Some(value * multiplier)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::hwstats::GpuStats;
+    use crate::internal::worker::hwmonitor::nvidia::{
+        parse_nvidia_gpu_memory, parse_nvidia_gpu_stats,
+    };
+
+    #[test]
+    fn test_parse_nvidia_gpu_memory() {
+        assert_eq!(parse_nvidia_gpu_memory("123.5").unwrap(), 123.5);
+        assert_eq!(parse_nvidia_gpu_memory("123.2 KiB").unwrap(), 126156.8);
+        assert_eq!(parse_nvidia_gpu_memory("123.2 MiB").unwrap(), 129184560.0);
+        assert_eq!(
+            parse_nvidia_gpu_memory("123.4 GiB").unwrap(),
+            132499740000.0
+        );
+    }
+
+    #[test]
+    fn test_parse_nvidia_gpu_stats() {
+        let mut stats = parse_nvidia_gpu_stats("BUS1, 5.2 %, 100 MiB, 200 MiB").unwrap();
+        assert_eq!(stats.gpus.len(), 1);
+
+        let gpu = stats.gpus.pop().unwrap();
+        let GpuStats {
+            id,
+            processor_usage: cpu_usage,
+            mem_usage,
+        } = gpu;
+        assert_eq!(id, "BUS1");
+        assert_eq!(cpu_usage, 5.2);
+        assert_eq!(mem_usage, 50.0);
+    }
+}

--- a/crates/tako/src/internal/worker/rpc.rs
+++ b/crates/tako/src/internal/worker/rpc.rs
@@ -404,14 +404,14 @@ async fn send_overview_loop(
 
     let OverviewConfiguration {
         send_interval,
-        gpu_families: _,
+        gpu_families,
     } = configuration;
 
     // Fetching the HW state performs blocking I/O, therefore we should do it in a separate thread.
     // tokio::task::spawn_blocking is not used because it would need mutable access to a sampler,
     // which shouldn't be created again and again.
     std::thread::spawn(move || -> crate::Result<()> {
-        let mut sampler = HwSampler::init()?;
+        let mut sampler = HwSampler::init(gpu_families)?;
         loop {
             std::thread::sleep(send_interval);
             let hw_state = sampler.fetch_hw_state()?;

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -40,9 +40,9 @@ def test_worker_send_overview(hq_env: HqEnv):
     schema = Schema(
         {
             "timestamp": int,
-            "worker_cpu_usage": {"cpu_per_core_percent_usage": [float]},
-            "worker_memory_usage": {"free": int, "total": int},
-            "worker_network_usage": {
+            "cpu_usage": {"cpu_per_core_percent_usage": [float]},
+            "memory_usage": {"free": int, "total": int},
+            "network_usage": {
                 "rx_bytes": int,
                 "rx_errors": int,
                 "rx_packets": int,


### PR DESCRIPTION
It takes ~10-20ms to call `nvidia-smi`, which is not trivial, but now it's performed on a separate thread at least, so it won't block the async loop. We could try to use some NVIDIA library instead (as a dynamic library dependency?) if that has lower latency, but I would keep it as it is for now.

I will add support for AMD GPUs in a follow-up PR, this one is already quite big.

BRCBC (best reviewed commit by commit :) ).