### PR TITLE
Try harder to kill local processes when worker stops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ dependencies = [
  "serde-tuple-vec-map",
  "serde_bytes",
  "serde_json",
+ "signal-hook",
  "smallvec",
  "tako",
  "tempdir",
@@ -2023,6 +2024,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]

--- a/crates/hyperqueue/Cargo.toml
+++ b/crates/hyperqueue/Cargo.toml
@@ -52,6 +52,7 @@ flate2 = { version = "1", features = ["default"] }
 psutil = "3.2"
 chumsky = "0.8.0"
 toml = "0.5"
+signal-hook = "0.3"
 
 # Dashboard
 tui = { version = "0.19.0", default-features = false, features = ["termion"], optional = true }

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -584,7 +584,7 @@ async fn task_process<F: Future<Output = tako::Result<TaskResult>>>(
         );
 
         // We have received a stop command for this task.
-        // We should attempt ti kill it and wait until the child process from `task_future` resolves.
+        // We should attempt to kill it and wait until the child process from `task_future` resolves.
         send_signal(signal::SIGINT)?;
 
         Ok(stop_reason.into())

--- a/crates/pyhq/src/cluster/worker.rs
+++ b/crates/pyhq/src/cluster/worker.rs
@@ -60,9 +60,9 @@ impl RunningWorker {
                 let set = LocalSet::new();
                 set.run_until(async move {
                     match initialize_worker(&server_dir, configuration).await {
-                        Ok((future, _)) => {
+                        Ok(worker) => {
                             tx.send(Ok(())).unwrap();
-                            if let Err(error) = future.await {
+                            if let Err(error) = worker.run().await {
                                 log::error!("HyperQueue worker ended with error: {error:?}");
                             }
                         }

--- a/crates/tako/src/internal/messages/worker.rs
+++ b/crates/tako/src/internal/messages/worker.rs
@@ -136,6 +136,7 @@ pub struct WorkerOverview {
 pub enum WorkerStopReason {
     IdleTimeout,
     TimeLimitReached,
+    Interrupted,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/tako/src/internal/server/rpc.rs
+++ b/crates/tako/src/internal/server/rpc.rs
@@ -214,7 +214,8 @@ async fn worker_rpc_loop(
             if let Ok(Some(reason)) = result {
                 match reason {
                     WorkerStopReason::IdleTimeout => LostWorkerReason::IdleTimeout,
-                    WorkerStopReason::TimeLimitReached => LostWorkerReason::TimeLimitReached
+                    WorkerStopReason::TimeLimitReached => LostWorkerReason::TimeLimitReached,
+                    WorkerStopReason::Interrupted => LostWorkerReason::ConnectionLost
                 }
             } else {
                 LostWorkerReason::ConnectionLost

--- a/crates/tako/src/internal/tests/integration/utils/worker.rs
+++ b/crates/tako/src/internal/tests/integration/utils/worker.rs
@@ -15,6 +15,7 @@ use crate::worker::WorkerConfiguration;
 use derive_builder::Builder;
 use orion::auth::SecretKey;
 use tokio::io::AsyncWriteExt;
+use tokio::sync::Notify;
 use tokio::task::LocalSet;
 
 use crate::internal::worker::rpc::run_worker;
@@ -177,6 +178,7 @@ pub(super) async fn start_worker(
                 configuration,
                 secret_key,
                 Box::new(TestTaskLauncher),
+                Arc::new(Notify::new()),
             )
             .await;
 

--- a/tests/pyapi/__init__.py
+++ b/tests/pyapi/__init__.py
@@ -1,10 +1,9 @@
 import os.path
 from typing import List, Tuple
 
+from hyperqueue import LocalCluster
 from hyperqueue.client import Client
 from hyperqueue.job import Job
-
-from hyperqueue import LocalCluster
 
 from ..conftest import HqEnv
 from ..utils.mock import ProgramMock

--- a/tests/pyapi/test_cluster.py
+++ b/tests/pyapi/test_cluster.py
@@ -1,4 +1,5 @@
 import pytest
+
 from hyperqueue.cluster import LocalCluster, WorkerConfig
 from hyperqueue.job import Job
 

--- a/tests/pyapi/test_function.py
+++ b/tests/pyapi/test_function.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from hyperqueue.client import Client, FailedJobsException, PythonEnv
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import iso8601
 import pytest
+
 from hyperqueue.client import FailedJobsException
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1442,17 +1442,18 @@ def test_crashing_job_status_default(count, hq_env: HqEnv):
 
 def test_crashing_job_by_files(hq_env: HqEnv):
     hq_env.start_server()
-    hq_env.command(["submit", "--", "bash", "-c", "sleep 1; echo done > output.txt"])
+    hq_env.command(["submit", "--", "bash", "-c", "sleep 3; echo done > output.txt"])
 
     # Crashing tasks threshold is 5
     for i in range(5):
         hq_env.start_worker()
         wait_for_job_state(hq_env, 1, "RUNNING")
         hq_env.kill_worker(i + 1)
+        if i < 4:
+            wait_for_job_state(hq_env, 1, "WAITING")
 
     hq_env.start_worker()
     wait_for_job_state(hq_env, 1, "FAILED")
-    time.sleep(2)
 
     table = list_jobs(hq_env)
     table.check_column_value("State", 0, "FAILED")

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1481,10 +1481,17 @@ def test_kill_task_subprocess_when_worker_is_interrupted(hq_env: HqEnv):
     check_child_process_exited(hq_env, interrupt_worker)
 
 
-@pytest.mark.xfail
 def test_kill_task_subprocess_when_worker_is_terminated(hq_env: HqEnv):
     def terminate_worker(worker_process):
         hq_env.kill_worker(1, signal=signal.SIGTERM)
+
+    check_child_process_exited(hq_env, terminate_worker)
+
+
+@pytest.mark.xfail
+def test_kill_task_subprocess_when_worker_is_killed(hq_env: HqEnv):
+    def terminate_worker(worker_process):
+        hq_env.kill_worker(1, signal=signal.SIGKILL)
 
     check_child_process_exited(hq_env, terminate_worker)
 

--- a/tests/test_jobfile.py
+++ b/tests/test_jobfile.py
@@ -105,7 +105,7 @@ def test_job_file_resource_variants1(hq_env: HqEnv, tmp_path):
         """
 [[task]]
 id = 0
-command = ["sleep", "0"]
+command = ["sleep", "1"]
 
 [[task.request]]
 resources = { "cpus" = "8" }
@@ -116,6 +116,7 @@ resources = { "cpus" = "1", "gpus" = "1" }
     )
     hq_env.command(["job", "submit-file", "job.toml"])
 
+    wait_for_job_state(hq_env, 1, "RUNNING")
     table = hq_env.command(["task", "info", "1", "0"], as_table=True)
     table.check_row_value(
         "Resources",

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -95,7 +95,7 @@ def test_stream_overlap(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FINISHED")
     result = hq_env.command(["log", "mylog", "show"], as_lines=True)
 
-    chunks = [set(result[i * 2: i * 2 + 2]) for i in range(3)]
+    chunks = [set(result[i * 2 : i * 2 + 2]) for i in range(3)]
     assert chunks[0] == {"1:0> A", "2:0> A"}
     assert chunks[1] == {"2:0> B", "1:0> B"}
     assert chunks[2] == {"1: > stream closed", "2: > stream closed"}
@@ -331,7 +331,9 @@ def test_stream_task_fail(hq_env: HqEnv):
 
     wait_for_job_state(hq_env, 1, "FAILED")
     wait_until(
-        lambda: hq_env.command(["log", "mylog", "show"]) == "0:0> Start\n0: > stream closed\n")
+        lambda: hq_env.command(["log", "mylog", "show"])
+        == "0:0> Start\n0: > stream closed\n"
+    )
 
     check_no_stream_connections(hq_env)
 
@@ -360,7 +362,9 @@ def test_stream_task_cancel(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "CANCELED")
 
     wait_until(
-        lambda: hq_env.command(["log", "mylog", "show"]) == "0:0> Start\n0: > stream closed\n")
+        lambda: hq_env.command(["log", "mylog", "show"])
+        == "0:0> Start\n0: > stream closed\n"
+    )
 
     check_no_stream_connections(hq_env)
 
@@ -388,7 +392,9 @@ def test_stream_worker_killed(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "WAITING")
 
     wait_until(
-        lambda: hq_env.command(["log", "mylog", "show"]) == "0:0> Start\n0: > stream closed\n")
+        lambda: hq_env.command(["log", "mylog", "show"])
+        == "0:0> Start\n0: > stream closed\n"
+    )
 
     table = hq_env.command(["server", "info", "--stats"], as_table=True)
     table.check_row_value("Stream connections", "")
@@ -416,6 +422,8 @@ def test_stream_timeout(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FAILED")
 
     wait_until(
-        lambda: hq_env.command(["log", "mylog", "show"]) == "0:0> Start\n0: > stream closed\n")
+        lambda: hq_env.command(["log", "mylog", "show"])
+        == "0:0> Start\n0: > stream closed\n"
+    )
 
     check_no_stream_connections(hq_env)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -206,11 +206,8 @@ def test_worker_time_limit(hq_env: HqEnv):
     hq_env.start_server()
     w = hq_env.start_worker(args=["--time-limit", "1s 200ms"])
     wait_for_worker_state(hq_env, 1, "RUNNING")
-    start = time.time()
     wait_for_worker_state(hq_env, 1, "TIME LIMIT REACHED")
     hq_env.check_process_exited(w, expected_code=None)
-    duration = time.time() - start
-    assert 0.9 < duration < 1.5
 
     table = hq_env.command(["worker", "info", "1"], as_table=True)
     table.check_row_value("Time Limit", "1s 200ms")
@@ -263,11 +260,10 @@ def test_server_lost_stop_with_task(hq_env: HqEnv):
     worker = hq_env.start_worker(on_server_lost="stop")
     path = os.path.join(hq_env.work_path, "finished")
     hq_env.command(
-        ["submit", "--array=1-10", "--", "bash", "-c", f"sleep 2; touch {path}"]
+        ["submit", "--array=1-10", "--", "bash", "-c", f"sleep 3; touch {path}"]
     )
     wait_for_job_state(hq_env, 1, "RUNNING")
     hq_env.kill_server()
-    time.sleep(0.5)
     hq_env.check_process_exited(worker, expected_code=1)
     assert not os.path.isfile(path)
 


### PR DESCRIPTION
With this PR, the worker will attempt to send SIGINT (or SIGTERM, if they refuse to cooperate) to task (grandchild) processes when the worker receives a stop command or a (preventible) signal. Before the (grandchild) processes would simply continue executing.

It's not bulletproof, if the worker is SIGKILLED, the processes might continue to live, but AFAIK this is an unresolvable problem on Linux without elevated privileges (https://lists.kernelnewbies.org/pipermail/kernelnewbies/2012-August/005988.html).

In theory, we could get rid of the `PR_SET_PDEATHSIG` with this PR. It would provide us slightly better task startup performance, at the cost of not killing even the main (not grandchild) processes when the worker is stopped with a SIGKILL.

Best reviewed commit by commit.