### PR TITLE
Do not allow connections between production and development builds by default

### DIFF
--- a/crates/hyperqueue/src/common/cli.rs
+++ b/crates/hyperqueue/src/common/cli.rs
@@ -161,7 +161,7 @@ pub struct CommonOpts {
 #[command(
     author,
     about,
-    version(option_env!("HQ_BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))),
+    version(crate::HQ_VERSION),
     disable_help_subcommand(true),
     help_expected(true)
 )]

--- a/crates/hyperqueue/src/common/serverdir.rs
+++ b/crates/hyperqueue/src/common/serverdir.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::common::error::error;
 use crate::common::utils::fs::{absolute_path, create_symlink};
 use crate::transfer::auth::{deserialize_key, serialize_key};
+use crate::HQ_VERSION;
 
 #[derive(Clone)]
 pub struct ServerDir {
@@ -63,12 +64,11 @@ impl ServerDir {
 
     pub fn read_access_record(&self) -> crate::Result<AccessRecord> {
         let record = load_access_file(self.access_filename())?;
-        let version = env!("CARGO_PKG_VERSION");
-        if record.version != version {
+        if record.version != HQ_VERSION {
             return error(format!(
                 "Hyperqueue version mismatch detected.\nServer was started with version {}, \
                 but the current version is {}.",
-                record.version, version
+                record.version, HQ_VERSION
             ));
         }
 
@@ -181,7 +181,7 @@ impl AccessRecord {
         tako_secret_key: Arc<SecretKey>,
     ) -> Self {
         Self {
-            version: env!("CARGO_PKG_VERSION").to_string(),
+            version: HQ_VERSION.to_string(),
             host,
             server_uid,
             server_port,

--- a/crates/hyperqueue/src/lib.rs
+++ b/crates/hyperqueue/src/lib.rs
@@ -35,3 +35,10 @@ pub const DEFAULT_WORKER_GROUP_NAME: &str = "default";
 // Reexports
 pub use tako;
 pub use tako::WrappedRcRefCell;
+
+pub const HQ_VERSION: &str = {
+    match option_env!("HQ_BUILD_VERSION") {
+        Some(version) => version,
+        None => const_format::concatcp!(env!("CARGO_PKG_VERSION"), "-dev"),
+    }
+};

--- a/crates/hyperqueue/src/worker/bootstrap.rs
+++ b/crates/hyperqueue/src/worker/bootstrap.rs
@@ -89,7 +89,7 @@ pub async fn initialize_worker(
     server_directory: &Path,
     configuration: WorkerConfiguration,
 ) -> anyhow::Result<InitializedWorker> {
-    log::info!("Starting hyperqueue worker {}", env!("CARGO_PKG_VERSION"));
+    log::info!("Starting hyperqueue worker {}", crate::HQ_VERSION);
     let server_dir = ServerDir::open(server_directory).context("Cannot load server directory")?;
     let record = server_dir.read_access_record().with_context(|| {
         format!(


### PR DESCRIPTION
A simple solution for https://github.com/It4innovations/hyperqueue/issues/578, which doesn't require adding a build script.

CI uses `HQ_BUILD_VERSION`, so all nightly and production builds should have the correct version set.

Fixes https://github.com/It4innovations/hyperqueue/issues/578