### PR TITLE
Add a command to forget a job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Dev
+
+## New features
+
+## Job submission
+* A new command `hq job forget <job-selector>` has been introduced. It can be used to completely forget a job, and thus
+reduce the memory usage of the HQ server. It is useful especially if you submit a large amount of jobs and keep the
+server running for a long time.
+
 # v0.15.0
 
 ## Breaking changes

--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -7,8 +7,8 @@ use cli_table::ColorChoice;
 use hyperqueue::client::commands::autoalloc::command_autoalloc;
 use hyperqueue::client::commands::event::command_event_log;
 use hyperqueue::client::commands::job::{
-    cancel_job, output_job_cat, output_job_detail, output_job_list, output_job_summary,
-    JobCancelOpts, JobCatOpts, JobInfoOpts, JobListOpts,
+    cancel_job, forget_job, output_job_cat, output_job_detail, output_job_list, output_job_summary,
+    JobCancelOpts, JobCatOpts, JobForgetOpts, JobInfoOpts, JobListOpts,
 };
 use hyperqueue::client::commands::log::command_log;
 use hyperqueue::client::commands::server::command_server;
@@ -118,6 +118,11 @@ async fn command_job_cat(gsettings: &GlobalSettings, opts: JobCatOpts) -> anyhow
 async fn command_job_cancel(gsettings: &GlobalSettings, opts: JobCancelOpts) -> anyhow::Result<()> {
     let mut connection = get_client_session(gsettings.server_directory()).await?;
     cancel_job(gsettings, &mut connection, opts.selector).await
+}
+
+async fn command_job_delete(gsettings: &GlobalSettings, opts: JobForgetOpts) -> anyhow::Result<()> {
+    let mut connection = get_client_session(gsettings.server_directory()).await?;
+    forget_job(gsettings, &mut connection, opts).await
 }
 
 async fn command_job_resubmit(
@@ -378,6 +383,9 @@ async fn main() -> hyperqueue::Result<()> {
         SubCommand::Job(JobOpts {
             subcmd: JobCommand::Cancel(opts),
         }) => command_job_cancel(&gsettings, opts).await,
+        SubCommand::Job(JobOpts {
+            subcmd: JobCommand::Forget(opts),
+        }) => command_job_delete(&gsettings, opts).await,
         SubCommand::Job(JobOpts {
             subcmd: JobCommand::Resubmit(opts),
         }) => command_job_resubmit(&gsettings, opts).await,

--- a/crates/hyperqueue/src/client/commands/job.rs
+++ b/crates/hyperqueue/src/client/commands/job.rs
@@ -50,7 +50,12 @@ pub struct JobForgetOpts {
     /// Forget only jobs with the given states.
     /// You can use multiple states separated by a comma.
     /// You can only filter by states that mark a completed job.
-    #[arg(long, value_delimiter(','), value_enum, default_value("finished"))]
+    #[arg(
+        long,
+        value_delimiter(','),
+        value_enum,
+        default_value("finished,failed,canceled")
+    )]
     pub filter: Vec<CompletedJobStatus>,
 }
 

--- a/crates/hyperqueue/src/common/cli.rs
+++ b/crates/hyperqueue/src/common/cli.rs
@@ -8,7 +8,9 @@ use tako::WorkerId;
 
 use crate::client::commands::autoalloc::AutoAllocOpts;
 use crate::client::commands::event::EventLogOpts;
-use crate::client::commands::job::{JobCancelOpts, JobCatOpts, JobInfoOpts, JobListOpts};
+use crate::client::commands::job::{
+    JobCancelOpts, JobCatOpts, JobForgetOpts, JobInfoOpts, JobListOpts,
+};
 use crate::client::commands::log::LogOpts;
 use crate::client::commands::server::ServerOpts;
 use crate::client::commands::submit::{JobResubmitOpts, JobSubmitFileOpts, JobSubmitOpts};
@@ -295,8 +297,17 @@ pub enum JobCommand {
     Summary,
     /// Display detailed information of the selected job
     Info(JobInfoOpts),
-    /// Cancel a specific job
+    /// Cancel a specific job.
+    /// This will cancel all tasks, stopping them from being computation.
+    /// The job will still remain in the server's memory, and you will be able to resubmit it later.
     Cancel(JobCancelOpts),
+    /// Forget a specific job.
+    /// This will remove the job from the server's memory, forgetting it completely and reducing
+    /// the server's memory usage.
+    ///
+    /// You can only forget jobs that have been completed, i.e. that are not running or waiting to
+    /// be executed. You have to cancel these jobs first.
+    Forget(JobForgetOpts),
     /// Shows task(s) streams(stdout, stderr) of a specific job
     Cat(JobCatOpts),
     /// Submit a job to HyperQueue

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -24,6 +24,7 @@ pub enum FromClientMessage {
     Submit(SubmitRequest),
     Resubmit(ResubmitRequest),
     Cancel(CancelRequest),
+    ForgetJob(ForgetJobRequest),
     JobDetail(JobDetailRequest),
     JobInfo(JobInfoRequest),
     WorkerList,
@@ -157,6 +158,12 @@ pub struct CancelRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct ForgetJobRequest {
+    pub selector: IdSelector,
+    pub filter: Vec<Status>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct JobInfoRequest {
     pub selector: IdSelector,
 }
@@ -235,6 +242,7 @@ pub enum ToClientMessage {
     StatsResponse(StatsResponse),
     StopWorkerResponse(Vec<(WorkerId, StopWorkerResponse)>),
     CancelJobResponse(Vec<(JobId, CancelJobResponse)>),
+    ForgetJobResponse(ForgetJobResponse),
     AutoAllocResponse(AutoAllocResponse),
     WaitForJobsResponse(WaitForJobsResponse),
     MonitoringEventsResponse(Vec<MonitoringEvent>),
@@ -246,6 +254,14 @@ pub enum CancelJobResponse {
     Canceled(Vec<JobTaskId>, JobTaskCount),
     InvalidJob,
     Failed(String),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ForgetJobResponse {
+    // How many jobs were forgotten
+    pub forgotten: usize,
+    // How many jobs were ignored due to not being completed or not existing
+    pub ignored: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/pyhq/python/hyperqueue/client.py
+++ b/crates/pyhq/python/hyperqueue/client.py
@@ -12,7 +12,7 @@ from .ffi.client import (
     TaskFailureMap,
     TaskId,
 )
-from .job import Job, SubmittedJob
+from .job import Job, SubmittedJob, HasJobId, get_job_id
 from .task.function import PythonEnv
 from .utils.string import pluralize
 
@@ -53,9 +53,9 @@ class FailedJobsException(Exception):
 
 class Client:
     def __init__(
-        self,
-        server_dir: Optional[GenericPath] = None,
-        python_env: Optional[PythonEnv] = None,
+            self,
+            server_dir: Optional[GenericPath] = None,
+            python_env: Optional[PythonEnv] = None,
     ):
         """
         A client serves as a gateway for submitting jobs and querying information about a running
@@ -111,6 +111,16 @@ class Client:
     def get_failed_tasks(self, job: SubmittedJob) -> Dict[TaskId, FailedTaskContext]:
         result = self.connection.get_failed_tasks([job.id])
         return result[job.id]
+
+    def forget(self, job: HasJobId):
+        """
+        Forget a completed job to free up its resources from the server.
+
+        :param job: Submitted job (or job ID) that will be forgotten.
+        """
+        job_id = get_job_id(job)
+        self.connection.forget_job(job_id)
+        logging.info(f"Forgotten job {job_id}")
 
 
 def create_progress_callback():

--- a/crates/pyhq/python/hyperqueue/client.py
+++ b/crates/pyhq/python/hyperqueue/client.py
@@ -12,7 +12,7 @@ from .ffi.client import (
     TaskFailureMap,
     TaskId,
 )
-from .job import Job, SubmittedJob, HasJobId, get_job_id
+from .job import HasJobId, Job, SubmittedJob, get_job_id
 from .task.function import PythonEnv
 from .utils.string import pluralize
 
@@ -53,9 +53,9 @@ class FailedJobsException(Exception):
 
 class Client:
     def __init__(
-            self,
-            server_dir: Optional[GenericPath] = None,
-            python_env: Optional[PythonEnv] = None,
+        self,
+        server_dir: Optional[GenericPath] = None,
+        python_env: Optional[PythonEnv] = None,
     ):
         """
         A client serves as a gateway for submitting jobs and querying information about a running

--- a/crates/pyhq/python/hyperqueue/ffi/client.py
+++ b/crates/pyhq/python/hyperqueue/ffi/client.py
@@ -52,3 +52,6 @@ class ClientConnection:
             }
             for (job_id, task_data) in jobs.items()
         }
+
+    def forget_job(self, job_id: JobId):
+        return ffi.forget_job(self.ctx, job_id)

--- a/crates/pyhq/python/hyperqueue/job.py
+++ b/crates/pyhq/python/hyperqueue/job.py
@@ -1,6 +1,7 @@
-import dataclasses
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Union
+
+import dataclasses
 
 from .common import GenericPath
 from .ffi import JobId, TaskId
@@ -17,10 +18,10 @@ class Job:
     """
 
     def __init__(
-        self,
-        default_workdir: Optional[GenericPath] = None,
-        max_fails: Optional[int] = 1,
-        default_env: Optional[EnvType] = None,
+            self,
+            default_workdir: Optional[GenericPath] = None,
+            max_fails: Optional[int] = 1,
+            default_env: Optional[EnvType] = None,
     ):
         """
         :param default_workdir: Default working directory for tasks.
@@ -45,19 +46,19 @@ class Job:
         return self.task_map.get(id)
 
     def program(
-        self,
-        args: ProgramArgs,
-        *,
-        env: Optional[EnvType] = None,
-        cwd: Optional[GenericPath] = None,
-        stdout: Optional[GenericPath] = default_stdout(),
-        stderr: Optional[GenericPath] = default_stderr(),
-        stdin: Optional[Union[str, bytes]] = None,
-        deps: Sequence[Task] = (),
-        name: Optional[str] = None,
-        task_dir: bool = False,
-        priority: int = 0,
-        resources: Optional[Union[ResourceRequest, Sequence[ResourceRequest]]] = None,
+            self,
+            args: ProgramArgs,
+            *,
+            env: Optional[EnvType] = None,
+            cwd: Optional[GenericPath] = None,
+            stdout: Optional[GenericPath] = default_stdout(),
+            stderr: Optional[GenericPath] = default_stderr(),
+            stdin: Optional[Union[str, bytes]] = None,
+            deps: Sequence[Task] = (),
+            name: Optional[str] = None,
+            task_dir: bool = False,
+            priority: int = 0,
+            resources: Optional[Union[ResourceRequest, Sequence[ResourceRequest]]] = None,
     ) -> ExternalProgram:
         """
         Creates a new task that will execute the provided command.
@@ -95,19 +96,19 @@ class Job:
         return task
 
     def function(
-        self,
-        fn,
-        *,
-        args=(),
-        kwargs=None,
-        env: Optional[EnvType] = None,
-        cwd: Optional[GenericPath] = None,
-        stdout: Optional[GenericPath] = default_stdout(),
-        stderr: Optional[GenericPath] = default_stderr(),
-        deps: Sequence[Task] = (),
-        name: Optional[str] = None,
-        priority: int = 0,
-        resources: Optional[Union[ResourceRequest, Sequence[ResourceRequest]]] = None,
+            self,
+            fn,
+            *,
+            args=(),
+            kwargs=None,
+            env: Optional[EnvType] = None,
+            cwd: Optional[GenericPath] = None,
+            stdout: Optional[GenericPath] = default_stdout(),
+            stderr: Optional[GenericPath] = default_stderr(),
+            deps: Sequence[Task] = (),
+            name: Optional[str] = None,
+            priority: int = 0,
+            resources: Optional[Union[ResourceRequest, Sequence[ResourceRequest]]] = None,
     ) -> PythonFunction:
         """
         Creates a new task that will execute the provided Python function.
@@ -161,6 +162,18 @@ class SubmittedJob:
 
     job: Job
     id: JobId
+
+
+HasJobId = Union[JobId, SubmittedJob]
+
+
+def get_job_id(job: HasJobId) -> JobId:
+    if isinstance(job, SubmittedJob):
+        return job.id
+    elif isinstance(job, (JobId, int)):
+        return job
+    else:
+        raise ValueError(f"Invalid value of type {type(job)} passed to `get_job_id`")
 
 
 def merge_envs(default: EnvType, env: Optional[EnvType]) -> EnvType:

--- a/crates/pyhq/python/hyperqueue/job.py
+++ b/crates/pyhq/python/hyperqueue/job.py
@@ -1,7 +1,6 @@
+import dataclasses
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Union
-
-import dataclasses
 
 from .common import GenericPath
 from .ffi import JobId, TaskId
@@ -18,10 +17,10 @@ class Job:
     """
 
     def __init__(
-            self,
-            default_workdir: Optional[GenericPath] = None,
-            max_fails: Optional[int] = 1,
-            default_env: Optional[EnvType] = None,
+        self,
+        default_workdir: Optional[GenericPath] = None,
+        max_fails: Optional[int] = 1,
+        default_env: Optional[EnvType] = None,
     ):
         """
         :param default_workdir: Default working directory for tasks.
@@ -46,19 +45,19 @@ class Job:
         return self.task_map.get(id)
 
     def program(
-            self,
-            args: ProgramArgs,
-            *,
-            env: Optional[EnvType] = None,
-            cwd: Optional[GenericPath] = None,
-            stdout: Optional[GenericPath] = default_stdout(),
-            stderr: Optional[GenericPath] = default_stderr(),
-            stdin: Optional[Union[str, bytes]] = None,
-            deps: Sequence[Task] = (),
-            name: Optional[str] = None,
-            task_dir: bool = False,
-            priority: int = 0,
-            resources: Optional[Union[ResourceRequest, Sequence[ResourceRequest]]] = None,
+        self,
+        args: ProgramArgs,
+        *,
+        env: Optional[EnvType] = None,
+        cwd: Optional[GenericPath] = None,
+        stdout: Optional[GenericPath] = default_stdout(),
+        stderr: Optional[GenericPath] = default_stderr(),
+        stdin: Optional[Union[str, bytes]] = None,
+        deps: Sequence[Task] = (),
+        name: Optional[str] = None,
+        task_dir: bool = False,
+        priority: int = 0,
+        resources: Optional[Union[ResourceRequest, Sequence[ResourceRequest]]] = None,
     ) -> ExternalProgram:
         """
         Creates a new task that will execute the provided command.
@@ -96,19 +95,19 @@ class Job:
         return task
 
     def function(
-            self,
-            fn,
-            *,
-            args=(),
-            kwargs=None,
-            env: Optional[EnvType] = None,
-            cwd: Optional[GenericPath] = None,
-            stdout: Optional[GenericPath] = default_stdout(),
-            stderr: Optional[GenericPath] = default_stderr(),
-            deps: Sequence[Task] = (),
-            name: Optional[str] = None,
-            priority: int = 0,
-            resources: Optional[Union[ResourceRequest, Sequence[ResourceRequest]]] = None,
+        self,
+        fn,
+        *,
+        args=(),
+        kwargs=None,
+        env: Optional[EnvType] = None,
+        cwd: Optional[GenericPath] = None,
+        stdout: Optional[GenericPath] = default_stdout(),
+        stderr: Optional[GenericPath] = default_stderr(),
+        deps: Sequence[Task] = (),
+        name: Optional[str] = None,
+        priority: int = 0,
+        resources: Optional[Union[ResourceRequest, Sequence[ResourceRequest]]] = None,
     ) -> PythonFunction:
         """
         Creates a new task that will execute the provided Python function.

--- a/crates/pyhq/src/lib.rs
+++ b/crates/pyhq/src/lib.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Builder;
 
 use hyperqueue::transfer::connection::ClientSession;
 
-use crate::client::job::FailedTaskMap;
+use crate::client::job::{forget_job_impl, FailedTaskMap};
 use crate::cluster::Cluster;
 use crate::utils::run_future;
 use client::job::{get_failed_tasks_impl, submit_job_impl, wait_for_jobs_impl, JobDescription};
@@ -47,6 +47,11 @@ fn stop_server(py: Python, ctx: ClientContextPtr) -> PyResult<()> {
 #[pyfunction]
 fn submit_job(py: Python, ctx: ClientContextPtr, job: JobDescription) -> PyResult<PyJobId> {
     submit_job_impl(py, ctx, job)
+}
+
+#[pyfunction]
+fn forget_job(py: Python, ctx: ClientContextPtr, job_id: PyJobId) -> PyResult<()> {
+    forget_job_impl(py, ctx, job_id)
 }
 
 /// Wait until the specified jobs finish.
@@ -115,6 +120,7 @@ fn hyperqueue(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(stop_server, m)?)?;
 
     m.add_function(wrap_pyfunction!(submit_job, m)?)?;
+    m.add_function(wrap_pyfunction!(forget_job, m)?)?;
     m.add_function(wrap_pyfunction!(wait_for_jobs, m)?)?;
     m.add_function(wrap_pyfunction!(get_failed_tasks, m)?)?;
 

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -253,6 +253,24 @@ $ hq job cancel <job-selector>
 
 Cancelling a job will cancel all of its tasks that are not yet completed.
 
+## Forgetting jobs
+If you want to completely forget a job, and thus free up its associated memory, you can do that using
+the `hq job forget` command[^1]:
+
+```console
+$ hq job forget <job-selector>
+```
+
+By default, only successfully finished jobs will be forgotten. You can use the `--status` parameter to forget jobs in
+other statuses:
+
+```console
+$ hq job forget all --status finished,canceled
+```
+
+However, only jobs that are completed, i.e. that have finished successfully, failed or have been canceled, can be forgotten.
+If you want to forget a waiting or a running job, [cancel](#cancelling-jobs) it first.
+
 ## Waiting for jobs
 There are three ways of waiting until a job completes:
 

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -261,15 +261,15 @@ the `hq job forget` command[^1]:
 $ hq job forget <job-selector>
 ```
 
-By default, only successfully finished jobs will be forgotten. You can use the `--status` parameter to forget jobs in
-other statuses:
+By default, all completed jobs (finished/failed/canceled) will be forgotten. You can use the `--status` parameter to
+only forget jobs in certain statuses:
 
 ```console
 $ hq job forget all --status finished,canceled
 ```
 
-However, only jobs that are completed, i.e. that have finished successfully, failed or have been canceled, can be forgotten.
-If you want to forget a waiting or a running job, [cancel](#cancelling-jobs) it first.
+However, only jobs that are completed, i.e. that have been finished successfully, failed or have been canceled, can be
+forgotten. If you want to forget a waiting or a running job, [cancel](#cancelling-jobs) it first.
 
 ## Waiting for jobs
 There are three ways of waiting until a job completes:

--- a/tests/job/test_job_forget.py
+++ b/tests/job/test_job_forget.py
@@ -1,0 +1,93 @@
+from typing import List, Optional
+
+from ..conftest import HqEnv
+from ..utils import wait_for_job_state
+from ..utils.wait import wait_until
+
+
+def test_forget_waiting_job(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.command(["submit", "hostname"])
+    forget_jobs(hq_env, "1", forgotten=0, ignored=1)
+    hq_env.start_worker()
+    wait_for_job_state(hq_env, 1, "FINISHED")
+
+
+def test_forget_running_job(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.start_worker()
+    hq_env.command(["submit", "sleep", "100"])
+    wait_for_job_state(hq_env, 1, "RUNNING")
+
+    forget_jobs(hq_env, "1", forgotten=0, ignored=1)
+
+
+def test_forget_finished_job(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.command(["submit", "hostname"])
+    hq_env.start_worker()
+    wait_for_job_state(hq_env, 1, "FINISHED")
+    forget_jobs(hq_env, "1", forgotten=1)
+    wait_for_job_list_count(hq_env, 0)
+
+
+def test_forget_failed_job(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.command(["submit", "/non-existent"])
+    hq_env.start_worker()
+    wait_for_job_state(hq_env, 1, "FAILED")
+    forget_jobs(hq_env, "1", forgotten=1, statutes=["failed"])
+    wait_for_job_list_count(hq_env, 0)
+
+
+def test_forget_canceled_job(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.command(["submit", "sleep", "100"])
+    hq_env.command(["job", "cancel", "1"])
+    forget_jobs(hq_env, "1", forgotten=1, statutes=["canceled"])
+    wait_for_job_list_count(hq_env, 0)
+
+
+def test_forget_multiple_jobs(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.command(["submit", "hostname"])
+    hq_env.command(["job", "cancel", "1"])
+
+    hq_env.start_worker()
+    for _ in range(5):
+        hq_env.command(["submit", "hostname"])
+    wait_for_job_state(hq_env, [2, 3, 4, 5, 6], "FINISHED")
+
+    hq_env.command(["submit", "/non-existing"])
+    wait_for_job_state(hq_env, 7, "FAILED")
+
+    forget_jobs(
+        hq_env, "all", forgotten=6, ignored=1, statutes=["finished", "canceled"]
+    )
+    wait_for_job_list_count(hq_env, 1)
+
+
+def wait_for_job_list_count(hq_env: HqEnv, count: int):
+    wait_until(
+        lambda: len(hq_env.command(["job", "list", "--all"], as_table=True)) == count
+    )
+
+
+def forget_jobs(
+    hq_env: HqEnv,
+    selector: str,
+    forgotten: int,
+    statutes: Optional[List[str]] = None,
+    ignored: int = 0,
+):
+    pluralized = "jobs" if forgotten != 1 else "job"
+
+    args = ["job", "forget", selector]
+    if statutes:
+        args.extend(["--filter", ",".join(statutes)])
+    output = hq_env.command(args, as_lines=True)
+
+    expected_msg = f"{forgotten} {pluralized} were forgotten"
+    if ignored > 0:
+        expected_msg += f", {ignored} were ignored due to wrong state or invalid ID"
+    assert expected_msg in output[0]

--- a/tests/job/test_job_forget.py
+++ b/tests/job/test_job_forget.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from ..conftest import HqEnv
 from ..utils import wait_for_job_state
-from ..utils.wait import wait_until
+from ..utils.wait import wait_for_job_list_count
 
 
 def test_forget_waiting_job(hq_env: HqEnv):
@@ -67,18 +67,12 @@ def test_forget_multiple_jobs(hq_env: HqEnv):
     wait_for_job_list_count(hq_env, 1)
 
 
-def wait_for_job_list_count(hq_env: HqEnv, count: int):
-    wait_until(
-        lambda: len(hq_env.command(["job", "list", "--all"], as_table=True)) == count
-    )
-
-
 def forget_jobs(
-    hq_env: HqEnv,
-    selector: str,
-    forgotten: int,
-    statutes: Optional[List[str]] = None,
-    ignored: int = 0,
+        hq_env: HqEnv,
+        selector: str,
+        forgotten: int,
+        statutes: Optional[List[str]] = None,
+        ignored: int = 0,
 ):
     pluralized = "jobs" if forgotten != 1 else "job"
 

--- a/tests/job/test_job_forget.py
+++ b/tests/job/test_job_forget.py
@@ -68,11 +68,11 @@ def test_forget_multiple_jobs(hq_env: HqEnv):
 
 
 def forget_jobs(
-        hq_env: HqEnv,
-        selector: str,
-        forgotten: int,
-        statutes: Optional[List[str]] = None,
-        ignored: int = 0,
+    hq_env: HqEnv,
+    selector: str,
+    forgotten: int,
+    statutes: Optional[List[str]] = None,
+    ignored: int = 0,
 ):
     pluralized = "jobs" if forgotten != 1 else "job"
 

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -8,18 +8,19 @@ import pytest
 from hyperqueue.client import FailedJobsException
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job
-from . import bash, prepare_job_client
+
 from ..conftest import HqEnv
 from ..utils import wait_for_job_state
 from ..utils.io import check_file_contents
 from ..utils.table import parse_multiline_cell
 from ..utils.wait import wait_for_job_list_count
+from . import bash, prepare_job_client
 
 
 def test_submit_empty_job(hq_env: HqEnv):
     (job, client) = prepare_job_client(hq_env)
     with pytest.raises(
-            Exception, match="Submitted job must have at least a single task"
+        Exception, match="Submitted job must have at least a single task"
     ):
         client.submit(job)
 

--- a/tests/utils/wait.py
+++ b/tests/utils/wait.py
@@ -76,3 +76,9 @@ def wait_for_pid_exit(pid: int):
     Waits until the given `pid` does not represent any process anymore.
     """
     wait_until(lambda: not psutil.pid_exists(pid))
+
+
+def wait_for_job_list_count(env, count: int):
+    wait_until(
+        lambda: len(env.command(["job", "list", "--all"], as_table=True)) == count
+    )


### PR DESCRIPTION
We could also clean up the streaming log and stdout/stderr files of all tasks (if there are any), but for now I think that this should be enough. I'll also add Python API for this in this PR.