### PR TITLE
Pin maturin version and test Python binding in CI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: pyhq
+      - name: Build HQ
+        run: cargo build
       - uses: messense/maturin-action@v1
         env:
           CARGO_PROFILE_DIST_PANIC: unwind
@@ -134,6 +139,15 @@ jobs:
           manylinux: 2014
           command: build
           args: --manifest-path crates/pyhq/Cargo.toml --profile dist --out wheels
+      - name: Test Python wheel
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          python3 -m pip install -U setuptools wheel pip
+          python3 -m pip install -r tests/requirements.txt
+          WHEEL=`realpath wheels/*.whl`
+          python3 -m pip install $WHEEL[all]
+          python3 -m pytest tests/pyapi
       - name: Upload test artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
           CARGO_PROFILE_DIST_PANIC: unwind
           CARGO_PROFILE_DIST_STRIP: none
         with:
-          maturin-version: latest
+          maturin-version: 0.13.5
           manylinux: 2014
           command: build
           args: --manifest-path crates/pyhq/Cargo.toml --profile dist --out wheels

--- a/crates/pyhq/src/cluster/mod.rs
+++ b/crates/pyhq/src/cluster/mod.rs
@@ -38,10 +38,14 @@ impl Cluster {
         Ok(())
     }
 
-    pub fn stop(&mut self) {
-        self.server
-            .take()
-            .expect("Attempting to stop an already stopped server")
-            .stop();
+    pub fn stop(&mut self) -> anyhow::Result<()> {
+        if let Some(server) = self.server.take() {
+            server.stop();
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Attempting to stop an already stopped server"
+            ))
+        }
     }
 }

--- a/crates/pyhq/src/lib.rs
+++ b/crates/pyhq/src/lib.rs
@@ -89,8 +89,9 @@ impl HqClusterContext {
         self.cluster.server_dir().to_string_lossy().into_owned()
     }
 
-    pub fn stop(&mut self) {
-        self.cluster.stop();
+    pub fn stop(&mut self) -> PyResult<()> {
+        self.cluster.stop()?;
+        Ok(())
     }
 
     pub fn add_worker(&mut self, cores: usize) -> PyResult<()> {


### PR DESCRIPTION
We were using latest maturin version, it was updated recently and that broke the Python binding silently.