### PR TITLE
Add GHA workflow for publishing Docker image for each new version

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -1,0 +1,79 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to create release from"
+        required: true
+      tag:
+        description: "Tag of the release"
+        required: true
+  schedule:
+    - cron: "0 23 * * 1"
+jobs:
+  set-env:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ env.SHA }}
+      tag: ${{ env.TAG }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Set env on push
+        if: github.event_name == 'push'
+        run: |
+          echo "SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "TAG=$(git tag --points-at HEAD)" >> $GITHUB_ENV
+      - name: Set env on trigger
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "SHA=${{ github.event.inputs.sha }}" >> $GITHUB_ENV
+          echo "TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+      - name: Set env on cron
+        if: github.event_name == 'schedule'
+        run: |
+          echo "SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "TAG=nightly" >> $GITHUB_ENV
+      - name: Check values
+        run: |
+          echo "SHA: ${{ env.SHA }}"
+          echo "Tag: ${{ env.TAG }}"
+  build:
+    runs-on: ubuntu-latest
+    needs: [set-env]
+    env:
+      container: ghcr.io/it4innovations/hyperqueue
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.set-env.outputs.sha }}
+
+      - uses: docker/setup-buildx-action@v2
+      - name: Build container
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          # Export the image to Docker to make it available in the next step
+          load: true
+          tags: ${{ env.container }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Login to Docker registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and push image
+        run: |
+          tag=${{ needs.set-env.outputs.tag || 'nightly' }}
+          echo "Tagging and releasing ${{ env.container }}:${tag}"
+          docker tag ${{ env.container }}:latest ${{ env.container }}:${tag}
+          docker push ${{ env.container }}:${tag}


### PR DESCRIPTION
Currently it is fired on each new pushed version, or manually.