### PR TITLE
Remove Python binding CI caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,9 +126,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: pyhq
       - uses: messense/maturin-action@v1
         env:
           CARGO_PROFILE_DIST_PANIC: unwind


### PR DESCRIPTION
Let's see if this fixes the intermittent CI failures (https://github.com/It4innovations/hyperqueue/actions/runs/5284469144/jobs/9561946603).