### PR TITLE
Revert "Remove Python binding CI caching"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,9 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: pyhq
       - uses: messense/maturin-action@v1
         env:
           CARGO_PROFILE_DIST_PANIC: unwind

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
           CARGO_PROFILE_DIST_PANIC: unwind
           CARGO_PROFILE_DIST_STRIP: none
         with:
-          docker-options: -e HQ_BUILD_VERSION=${{ needs.set-env.outputs.version }}
+          docker-options: -e HQ_BUILD_VERSION=${{ needs.set-env.outputs.version }} --user ${UID}
           maturin-version: 0.13.5
           manylinux: 2014
           command: build


### PR DESCRIPTION
Reverts It4innovations/hyperqueue#596. CI failed after it was merged, so apparently the cache is not the issue.