### PR TITLE
Add autoalloc worker start/stop commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 reduce the memory usage of the HQ server. It is useful especially if you submit a large amount of jobs and keep the
 server running for a long time.
 
+## Automatic allocation
+* Autoalloc can now execute a custom shell command/script on each worker node before the worker starts and after the 
+worker stops. You can use this feature e.g. to initialize some data or load software modules for each worker node.
+
+  ```console
+  $ hq alloc add pbs --time-limit 30m \
+    --worker-start-cmd "/project/xxx/init-node.sh" \
+    --worker-stop-cmd "/project/xxx/cleanup-node.sh"
+  ```
+
 # v0.15.0
 
 ## Breaking changes

--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -244,7 +244,10 @@ wasted allocation duration."
 
     let mut worker_args = vec![];
     if let Some(cpus) = cpus {
-        worker_args.extend(["--cpus".to_string(), cpus.into_original_input()]);
+        worker_args.extend([
+            "--cpus".to_string(),
+            format!("\"{}\"", cpus.into_original_input()),
+        ]);
     }
     for arg in resource {
         worker_args.extend([
@@ -264,12 +267,12 @@ wasted allocation duration."
     if let Some(overview_interval) = overview_interval {
         worker_args.extend([
             "--overview-interval".to_string(),
-            overview_interval.into_original_input(),
+            format!("\"{}\"", overview_interval.into_original_input()),
         ]);
     }
     worker_args.extend([
         "--on-server-lost".to_string(),
-        server_lost_policy_to_str(&on_server_lost.into()).to_string(),
+        format!("\"{}\"", server_lost_policy_to_str(&on_server_lost.into())),
     ]);
 
     AllocationQueueParams {

--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -110,6 +110,17 @@ struct SharedQueueOpts {
     #[arg(long, global = true)]
     no_dry_run: bool,
 
+    /// Shell command that will be executed on each allocated node, before a worker is created on
+    /// that node.
+    #[arg(long)]
+    worker_start_cmd: Option<String>,
+
+    /// Shell command that will be executed on each allocated node, just before the allocation ends.
+    /// Note that this execution is best-effort. It is not guaranteed that the script will always
+    /// be executed.
+    #[arg(long)]
+    worker_stop_cmd: Option<String>,
+
     /// Additional arguments passed to the submit command
     #[arg(trailing_var_arg(true))]
     additional_args: Vec<String>,
@@ -205,6 +216,8 @@ fn args_to_params(args: SharedQueueOpts) -> AllocationQueueParams {
         max_worker_count,
         name,
         worker_args,
+        worker_start_cmd,
+        worker_stop_cmd,
         additional_args,
         on_server_lost,
         no_dry_run: _,
@@ -265,6 +278,8 @@ wasted allocation duration."
         timelimit: time_limit,
         name,
         additional_args,
+        worker_start_cmd,
+        worker_stop_cmd,
         max_worker_count,
         worker_args,
         idle_timeout,

--- a/crates/hyperqueue/src/common/manager/pbs.rs
+++ b/crates/hyperqueue/src/common/manager/pbs.rs
@@ -15,11 +15,10 @@ fn parse_pbs_job_remaining_time(job_id: &str, data: &str) -> anyhow::Result<Dura
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Could not find walltime key for job {}", job_id))?,
     )?;
-    let used = parse_hms_time(
-        data_json["Jobs"][job_id]["resources_used"]["walltime"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Could not find used time key for job {}", job_id))?,
-    )?;
+    let used = data_json["Jobs"][job_id]["resources_used"]["walltime"]
+        .as_str()
+        .and_then(|v| parse_hms_time(v).ok())
+        .unwrap_or_default();
 
     if walltime < used {
         anyhow::bail!("Pbs: Used time is bigger then walltime");

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -228,6 +228,8 @@ pub fn create_queue_info(params: AllocationQueueParams) -> QueueInfo {
         timelimit,
         additional_args,
         max_worker_count,
+        worker_start_cmd,
+        worker_stop_cmd,
         worker_args,
         idle_timeout,
     } = params;
@@ -239,6 +241,8 @@ pub fn create_queue_info(params: AllocationQueueParams) -> QueueInfo {
         max_worker_count,
         worker_args,
         idle_timeout,
+        worker_start_cmd,
+        worker_stop_cmd,
     )
 }
 
@@ -1680,6 +1684,8 @@ mod tests {
                     vec![],
                     max_worker_count,
                     vec![],
+                    None,
+                    None,
                     None,
                 ),
                 RateLimiter::new(

--- a/crates/hyperqueue/src/server/autoalloc/queue/common.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/common.rs
@@ -142,12 +142,15 @@ pub fn build_worker_args(
     let idle_timeout = queue_info
         .idle_timeout
         .unwrap_or_else(get_default_worker_idle_time);
-    let duration = humantime::format_duration(idle_timeout).to_string();
+    let idle_timeout = humantime::format_duration(idle_timeout);
+
+    // Allow some time for cleanup
+    let time_limit = queue_info.timelimit.saturating_sub(Duration::from_secs(10));
+    let time_limit = humantime::format_duration(time_limit);
+
     let mut args = format!(
-        "{} worker start --idle-timeout {} --manager {} --server-dir {}",
+        "{} worker start --idle-timeout \"{idle_timeout}\" --time-limit \"{time_limit}\" --manager \"{manager}\" --server-dir \"{}\"",
         hq_path.display(),
-        duration,
-        manager,
         server_dir.display()
     );
 

--- a/crates/hyperqueue/src/server/autoalloc/queue/mod.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/mod.rs
@@ -20,6 +20,8 @@ pub struct QueueInfo {
     max_worker_count: Option<u32>,
     worker_args: Vec<String>,
     idle_timeout: Option<Duration>,
+    worker_start_cmd: Option<String>,
+    worker_stop_cmd: Option<String>,
 }
 
 impl QueueInfo {
@@ -32,6 +34,8 @@ impl QueueInfo {
         max_worker_count: Option<u32>,
         worker_args: Vec<String>,
         idle_timeout: Option<Duration>,
+        worker_start_cmd: Option<String>,
+        worker_stop_cmd: Option<String>,
     ) -> Self {
         Self {
             backlog,
@@ -41,6 +45,8 @@ impl QueueInfo {
             max_worker_count,
             worker_args,
             idle_timeout,
+            worker_start_cmd,
+            worker_stop_cmd,
         }
     }
 

--- a/crates/hyperqueue/src/server/autoalloc/queue/pbs.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/pbs.rs
@@ -12,7 +12,7 @@ use crate::common::manager::pbs::{format_pbs_duration, parse_pbs_datetime};
 use crate::common::utils::time::local_to_system_time;
 use crate::server::autoalloc::queue::common::{
     build_worker_args, check_command_output, create_allocation_dir, create_command, submit_script,
-    ExternalHandler,
+    wrap_worker_cmd, ExternalHandler,
 };
 use crate::server::autoalloc::queue::{
     AllocationExternalStatus, AllocationStatusMap, AllocationSubmissionResult, QueueHandler,
@@ -55,6 +55,11 @@ impl QueueHandler for PbsHandler {
             )?;
             let worker_args =
                 build_worker_args(&hq_path, ManagerType::Pbs, &server_directory, &queue_info);
+            let worker_args = wrap_worker_cmd(
+                worker_args,
+                queue_info.worker_start_cmd.as_deref(),
+                queue_info.worker_stop_cmd.as_deref(),
+            );
 
             let script = build_pbs_submit_script(
                 worker_count,

--- a/crates/hyperqueue/src/server/autoalloc/queue/slurm.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/slurm.rs
@@ -14,7 +14,8 @@ use crate::common::manager::slurm::{
 };
 use crate::common::utils::time::local_to_system_time;
 use crate::server::autoalloc::queue::common::{
-    build_worker_args, create_allocation_dir, create_command, submit_script, ExternalHandler,
+    build_worker_args, create_allocation_dir, create_command, submit_script, wrap_worker_cmd,
+    ExternalHandler,
 };
 use crate::server::autoalloc::queue::{
     common, AllocationExternalStatus, AllocationStatusMap, AllocationSubmissionResult,
@@ -58,6 +59,11 @@ impl QueueHandler for SlurmHandler {
 
             let worker_args =
                 build_worker_args(&hq_path, ManagerType::Slurm, &server_directory, &queue_info);
+            let worker_args = wrap_worker_cmd(
+                worker_args,
+                queue_info.worker_start_cmd.as_deref(),
+                queue_info.worker_stop_cmd.as_deref(),
+            );
             let script = build_slurm_submit_script(
                 worker_count,
                 timelimit,

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -491,7 +491,17 @@ mod tests {
         let _id = state.create_id();
         let id = state.add_queue(AllocationQueue::new(
             ManagerType::Pbs,
-            QueueInfo::new(1, 1, Duration::from_secs(1), vec![], None, vec![], None),
+            QueueInfo::new(
+                1,
+                1,
+                Duration::from_secs(1),
+                vec![],
+                None,
+                vec![],
+                None,
+                None,
+                None,
+            ),
             None,
             Box::new(NullHandler),
             RateLimiter::new(vec![Duration::from_secs(1)], 1, 1, Duration::from_secs(1)),

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -221,6 +221,9 @@ pub struct AllocationQueueParams {
     pub max_worker_count: Option<u32>,
     pub additional_args: Vec<String>,
 
+    pub worker_start_cmd: Option<String>,
+    pub worker_stop_cmd: Option<String>,
+
     // Black-box worker args that will be passed to `worker start`
     pub worker_args: Vec<String>,
     pub idle_timeout: Option<Duration>,

--- a/docs/deployment/allocation.md
+++ b/docs/deployment/allocation.md
@@ -90,6 +90,14 @@ creating a new allocation queue:
 automatic allocator. We suggest that you do not use a long duration for this parameter, as it can
 result in wasting precious allocation time.
 
+- `--worker-start-cmd <cmd>` This shell command will be executed on each allocated node just before a worker is started
+on the given node. You can use it e.g. to initialize some shared environment for the node, or to load software modules.
+
+- `--worker-stop-cmd <cmd>` This shell command will be executed on each allocated node just after the worker stops on
+that node. You can use it e.g. to clean up a previously initialized environment for the node. **Note that the execution of
+this command is best-effort! It is not guaranteed that the command will always be executed.** For example, PBS/Slurm can
+kill the allocation without giving HQ a chance to run the command.
+
 - `--name <name>` Name of the allocation queue. Will be used to name allocations. Serves for debug purposes only.
 
 [^1]: You can use various [shortcuts](../cli/shortcuts.md#duration) for the duration value.

--- a/tests/autoalloc/test_autoalloc.py
+++ b/tests/autoalloc/test_autoalloc.py
@@ -271,8 +271,9 @@ def test_pbs_multinode_allocation(hq_env: HqEnv):
             commands = extract_script_commands(f.read())
             assert (
                 commands
-                == f"pbsdsh -- bash -l -c '{get_hq_binary()} worker start --idle-timeout 5m \
---manager pbs --server-dir {hq_env.server_dir}/001 --on-server-lost finish-running'"
+                == f"""pbsdsh -- bash -l -c '{get_hq_binary()} worker start --idle-timeout "5m" \
+--time-limit "59m 50s" --manager "pbs" --server-dir "{hq_env.server_dir}/001" --on-server-lost \
+"finish-running"'"""
             )
 
 
@@ -290,8 +291,9 @@ def test_slurm_multinode_allocation(hq_env: HqEnv):
             commands = extract_script_commands(f.read())
             assert (
                 commands
-                == f"srun --overlap {get_hq_binary()} worker start --idle-timeout 5m \
---manager slurm --server-dir {hq_env.server_dir}/001 --on-server-lost finish-running"
+                == f"""srun --overlap {get_hq_binary()} worker start --idle-timeout "5m" \
+--time-limit "59m 50s" --manager "slurm" --server-dir "{hq_env.server_dir}/001" --on-server-lost "finish-running"
+""".rstrip()
             )
 
 
@@ -617,13 +619,16 @@ def test_pass_cpu_and_resources_to_worker(hq_env: HqEnv, spec: ManagerSpec):
             "worker",
             "start",
             "--idle-timeout",
-            "5m",
+            '"5m"',
+            "--time-limit",
+            '"59m',
+            '50s"',
             "--manager",
-            spec.manager_type(),
+            f'"{spec.manager_type()}"',
             "--server-dir",
-            f"{hq_env.server_dir}/001",
+            f'"{hq_env.server_dir}/001"',
             "--cpus",
-            "2x8",
+            '"2x8"',
             "--resource",
             '"x=sum(100)"',
             "--resource",
@@ -633,7 +638,7 @@ def test_pass_cpu_and_resources_to_worker(hq_env: HqEnv, spec: ManagerSpec):
             "--no-hyper-threading",
             "--no-detect-resources",
             "--on-server-lost",
-            "finish-running",
+            '"finish-running"',
         ]
 
 
@@ -660,13 +665,16 @@ def test_pass_idle_timeout_to_worker(hq_env: HqEnv, spec: ManagerSpec):
             "worker",
             "start",
             "--idle-timeout",
-            "30m",
+            '"30m"',
+            "--time-limit",
+            '"59m',
+            '50s"',
             "--manager",
-            spec.manager_type(),
+            f'"{spec.manager_type()}"',
             "--server-dir",
-            f"{hq_env.server_dir}/001",
+            f'"{hq_env.server_dir}/001"',
             "--on-server-lost",
-            "finish-running",
+            '"finish-running"',
         ]
 
 
@@ -689,13 +697,16 @@ def test_pass_on_server_lost(hq_env: HqEnv, spec: ManagerSpec):
             "worker",
             "start",
             "--idle-timeout",
-            "5m",
+            '"5m"',
+            "--time-limit",
+            '"59m',
+            '50s"',
             "--manager",
-            spec.manager_type(),
+            f'"{spec.manager_type()}"',
             "--server-dir",
-            f"{hq_env.server_dir}/001",
+            f'"{hq_env.server_dir}/001"',
             "--on-server-lost",
-            "stop",
+            '"stop"',
         ]
 
 
@@ -718,8 +729,9 @@ def test_start_stop_cmd(hq_env: HqEnv, spec: ManagerSpec):
         script = queue.get()
         assert (
             get_exec_script(script)
-            == f"init.sh && {get_hq_binary()} worker start --idle-timeout 5m \
---manager {spec.manager_type()} --server-dir {hq_env.server_dir}/001 --on-server-lost finish-running; unload.sh"
+            == f"""init.sh && {get_hq_binary()} worker start --idle-timeout "5m" \
+--time-limit "59m 50s" --manager "{spec.manager_type()}" --server-dir "{hq_env.server_dir}/001" \
+--on-server-lost "finish-running"; unload.sh"""
         )
 
 

--- a/tests/autoalloc/utils.py
+++ b/tests/autoalloc/utils.py
@@ -38,6 +38,8 @@ def add_queue(
     additional_args=None,
     time_limit="1h",
     dry_run=False,
+    start_cmd: Optional[str] = None,
+    stop_cmd: Optional[str] = None,
     **kwargs,
 ) -> str:
     args = ["alloc", "add", manager]
@@ -55,6 +57,10 @@ def add_queue(
     )
     if time_limit is not None:
         args.extend(["--time-limit", time_limit])
+    if start_cmd is not None:
+        args.extend(["--worker-start-cmd", start_cmd])
+    if stop_cmd is not None:
+        args.extend(["--worker-stop-cmd", stop_cmd])
     if additional_worker_args is not None:
         args.extend(additional_worker_args)
     if additional_args is not None:

--- a/tests/pyapi/__init__.py
+++ b/tests/pyapi/__init__.py
@@ -1,10 +1,9 @@
 import os.path
 from typing import List, Tuple
 
+from hyperqueue import LocalCluster
 from hyperqueue.client import Client
 from hyperqueue.job import Job
-
-from hyperqueue import LocalCluster
 
 from ..conftest import HqEnv
 from ..utils.mock import ProgramMock

--- a/tests/pyapi/test_cluster.py
+++ b/tests/pyapi/test_cluster.py
@@ -1,4 +1,5 @@
 import pytest
+
 from hyperqueue.cluster import LocalCluster, WorkerConfig
 from hyperqueue.job import Job
 

--- a/tests/pyapi/test_function.py
+++ b/tests/pyapi/test_function.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from hyperqueue.client import Client, FailedJobsException, PythonEnv
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import iso8601
 import pytest
+
 from hyperqueue.client import FailedJobsException
 from hyperqueue.ffi.protocol import ResourceRequest
 from hyperqueue.job import Job


### PR DESCRIPTION
Add the option to execute a shell command before/after a worker runs in an autoalloc allocation.

Fixes: https://github.com/It4innovations/hyperqueue/issues/600