### PR TITLE
Correctly submit allocations where time limit equals time request

### DIFF
--- a/crates/hyperqueue/src/server/autoalloc/estimator.rs
+++ b/crates/hyperqueue/src/server/autoalloc/estimator.rs
@@ -60,7 +60,7 @@ fn can_queue_execute_job(job: &Job, queue_info: &QueueInfo) -> bool {
         JobDescription::Array {
             task_desc: TaskDescription { resources, .. },
             ..
-        } => resources.min_time() < queue_info.timelimit(),
+        } => resources.min_time() <= queue_info.timelimit(),
         JobDescription::Graph { tasks } => {
             // TODO: optimize
             tasks
@@ -68,7 +68,7 @@ fn can_queue_execute_job(job: &Job, queue_info: &QueueInfo) -> bool {
                 .map(|t| t.task_desc.resources.min_time())
                 .min()
                 .unwrap_or(Duration::ZERO)
-                < queue_info.timelimit()
+                <= queue_info.timelimit()
         }
     }
 }

--- a/tests/autoalloc/test_autoalloc.py
+++ b/tests/autoalloc/test_autoalloc.py
@@ -255,6 +255,16 @@ def test_queue_submit_success(hq_env: HqEnv, spec: ManagerSpec):
         wait_for_alloc(hq_env, "QUEUED", "1.job")
 
 
+@all_managers
+def test_submit_time_request_equal_to_time_limit(hq_env: HqEnv, spec: ManagerSpec):
+    with MockJobManager(hq_env, spec.handler()):
+        hq_env.start_server()
+        hq_env.command(["submit", "--time-request", "10m", "sleep", "1"])
+
+        add_queue(hq_env, manager=spec.manager_type(), time_limit="10m")
+        wait_for_alloc(hq_env, "QUEUED", "1.job")
+
+
 def test_pbs_multinode_allocation(hq_env: HqEnv):
     queue = ManagerQueue()
 


### PR DESCRIPTION
Before, we used lt comparison instead of lte comparison. Since `--time-request` should serve as an upper bound, it makes sense to support it being equal to the `--time-limit` of an autoalloc queue.

Fixes: https://github.com/It4innovations/hyperqueue/issues/600#issuecomment-1607342986