### PR TITLE
Add ARM 64-bit to CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,8 @@ jobs:
             name: powerpc64
           - arch: armv7-unknown-linux-gnueabihf
             name: raspberry-pi
+          - arch: aarch64-unknown-linux-gnu
+            name: arm64-linux
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
Closes: https://github.com/It4innovations/hyperqueue/issues/609