### PR TITLE
Allow passing arbitrary arguments when creating a client from a local cluster

### DIFF
--- a/crates/pyhq/python/hyperqueue/cluster/__init__.py
+++ b/crates/pyhq/python/hyperqueue/cluster/__init__.py
@@ -54,11 +54,11 @@ class LocalCluster:
         cores = config.cores or multiprocessing.cpu_count()
         self.cluster.add_worker(cores)
 
-    def client(self) -> Client:
+    def client(self, **client_args) -> Client:
         """
         Creates a client connected to this cluster.
         """
-        return Client(self.cluster.server_dir)
+        return Client(self.cluster.server_dir, **client_args)
 
     def stop(self):
         """


### PR DESCRIPTION
Small QoL improvement found when working on the LIGATE Ligen workflow.