### PR TITLE
Add automatic file cleanup after task success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Dev
+
+## New features
+
+### Job submission
+* You can now specify `cleanup modes` when passing `stdout`/`stderr` paths to tasks. Cleanup mode decides what should
+happen with the file once the task has finished executing. Currently, a single cleanup mode is implemented, which removes
+the file if the task has finished successfully:
+```bash
+$ hq submit --stdout=out.txt:rm-if-finished /my-program
+```
+
 # v0.16.0
 
 ## New features

--- a/crates/hyperqueue/src/client/commands/submit/jobfile.rs
+++ b/crates/hyperqueue/src/client/commands/submit/jobfile.rs
@@ -15,7 +15,7 @@ use clap::Parser;
 use smallvec::smallvec;
 use std::path::PathBuf;
 use tako::gateway::{ResourceRequest, ResourceRequestVariants};
-use tako::program::{ProgramDefinition, StdioDef};
+use tako::program::{FileOnCloseBehavior, ProgramDefinition, StdioDef};
 
 #[derive(Parser)]
 pub struct JobSubmitFileOpts {
@@ -29,11 +29,17 @@ fn create_stdio(def: Option<&str>, default: &str, is_log: bool) -> StdioDef {
             if is_log {
                 StdioDef::Pipe
             } else {
-                StdioDef::File(PathBuf::from(default))
+                StdioDef::File {
+                    path: PathBuf::from(default),
+                    on_close: FileOnCloseBehavior::None,
+                }
             }
         }
         Some("none") => StdioDef::Null,
-        Some(x) => StdioDef::File(PathBuf::from(x)),
+        Some(x) => StdioDef::File {
+            path: PathBuf::from(x),
+            on_close: FileOnCloseBehavior::None,
+        },
     }
 }
 

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -978,7 +978,7 @@ fn multiline_cell<T: AsRef<str>>(rows: Vec<(&'static str, T)>) -> CellStruct {
 fn stdio_to_str(stdio: &StdioDef) -> &str {
     match stdio {
         StdioDef::Null => "<None>",
-        StdioDef::File(filename) => filename.to_str().unwrap(),
+        StdioDef::File { path, .. } => path.to_str().unwrap(),
         StdioDef::Pipe => "<Stream>",
     }
 }
@@ -1283,11 +1283,11 @@ fn get_task_paths<'a>(
         Some(ref paths) => (
             Some(paths.cwd.to_str().unwrap()),
             match &paths.stdout {
-                StdioDef::File(filename) => Some(filename.to_str().unwrap()),
+                StdioDef::File { path, .. } => Some(path.to_str().unwrap()),
                 _ => None,
             },
             match &paths.stderr {
-                StdioDef::File(filename) => Some(filename.to_str().unwrap()),
+                StdioDef::File { path, .. } => Some(path.to_str().unwrap()),
                 _ => None,
             },
         ),

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -282,7 +282,7 @@ fn fill_task_paths(dict: &mut Value, map: &TaskToPathsMap, task_id: JobTaskId) {
 fn format_stdio_def(stdio: &StdioDef) -> Value {
     match stdio {
         StdioDef::Null => Value::Null,
-        StdioDef::File(path) => json!(Some(path)),
+        StdioDef::File { path, .. } => json!(Some(path)),
         StdioDef::Pipe => json!("<pipe>"),
     }
 }

--- a/crates/hyperqueue/src/common/placeholders.rs
+++ b/crates/hyperqueue/src/common/placeholders.rs
@@ -247,7 +247,7 @@ pub fn parse_resolvable_string(data: &str) -> Vec<StringPart> {
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
-    use tako::program::{ProgramDefinition, StdioDef};
+    use tako::program::{FileOnCloseBehavior, ProgramDefinition, StdioDef};
 
     use crate::common::env::{HQ_INSTANCE_ID, HQ_JOB_ID, HQ_SUBMIT_DIR, HQ_TASK_ID};
     use crate::common::placeholders::{
@@ -341,11 +341,17 @@ mod tests {
         assert_eq!(program.cwd, PathBuf::from("/foo/testHQ/5-%{TASK_ID}"));
         assert_eq!(
             program.stdout,
-            StdioDef::File("/foo/testHQ/5-%{TASK_ID}/out".into())
+            StdioDef::File {
+                path: "/foo/testHQ/5-%{TASK_ID}/out".into(),
+                on_close: FileOnCloseBehavior::None
+            }
         );
         assert_eq!(
             program.stderr,
-            StdioDef::File("/foo/testHQ/5-%{TASK_ID}/err".into())
+            StdioDef::File {
+                path: "/foo/testHQ/5-%{TASK_ID}/err".into(),
+                on_close: FileOnCloseBehavior::None
+            }
         );
     }
 
@@ -363,11 +369,17 @@ mod tests {
         assert_eq!(paths.cwd, PathBuf::from("/foo/testHQ-10-6"));
         assert_eq!(
             paths.stdout,
-            StdioDef::File("/foo/testHQ-10-6/5/stdout".into())
+            StdioDef::File {
+                path: "/foo/testHQ-10-6/5/stdout".into(),
+                on_close: FileOnCloseBehavior::None
+            }
         );
         assert_eq!(
             paths.stderr,
-            StdioDef::File("/foo/testHQ-10-6/5/stderr".into())
+            StdioDef::File {
+                path: "/foo/testHQ-10-6/5/stderr".into(),
+                on_close: FileOnCloseBehavior::None
+            }
         );
     }
 
@@ -383,8 +395,20 @@ mod tests {
 
         fill_placeholders_in_paths(ResolvablePaths::from_paths(&mut paths), ctx);
         assert_eq!(paths.cwd, PathBuf::from("/foo/bar/1"));
-        assert_eq!(paths.stdout, StdioDef::File("/foo/bar/1/2.out".into()));
-        assert_eq!(paths.stderr, StdioDef::File("/foo/bar/1/2.err".into()));
+        assert_eq!(
+            paths.stdout,
+            StdioDef::File {
+                path: "/foo/bar/1/2.out".into(),
+                on_close: FileOnCloseBehavior::None
+            }
+        );
+        assert_eq!(
+            paths.stderr,
+            StdioDef::File {
+                path: "/foo/bar/1/2.err".into(),
+                on_close: FileOnCloseBehavior::None
+            }
+        );
     }
 
     struct ResolvedPaths {
@@ -406,8 +430,14 @@ mod tests {
     fn paths(cwd: &str, stdout: &str, stderr: &str) -> ResolvedPaths {
         ResolvedPaths {
             cwd: cwd.to_string().into(),
-            stdout: StdioDef::File(stdout.to_string().into()),
-            stderr: StdioDef::File(stderr.to_string().into()),
+            stdout: StdioDef::File {
+                path: stdout.to_string().into(),
+                on_close: FileOnCloseBehavior::None,
+            },
+            stderr: StdioDef::File {
+                path: stderr.to_string().into(),
+                on_close: FileOnCloseBehavior::None,
+            },
         }
     }
 
@@ -444,8 +474,18 @@ mod tests {
         ProgramDefinition {
             args: vec![],
             env,
-            stdout: stdout.map(|v| StdioDef::File(v.into())).unwrap_or_default(),
-            stderr: stderr.map(|v| StdioDef::File(v.into())).unwrap_or_default(),
+            stdout: stdout
+                .map(|v| StdioDef::File {
+                    path: v.into(),
+                    on_close: FileOnCloseBehavior::None,
+                })
+                .unwrap_or_default(),
+            stderr: stderr
+                .map(|v| StdioDef::File {
+                    path: v.into(),
+                    on_close: FileOnCloseBehavior::None,
+                })
+                .unwrap_or_default(),
             stdin: vec![],
             cwd: cwd.into(),
         }

--- a/crates/hyperqueue/src/worker/start.rs
+++ b/crates/hyperqueue/src/worker/start.rs
@@ -193,7 +193,7 @@ async fn resend_stdio(
 }
 
 fn create_directory_if_needed(file: &StdioDef) -> io::Result<()> {
-    if let StdioDef::File(path) = file {
+    if let StdioDef::File { path, .. } = file {
         if let Some(path) = path.parent() {
             std::fs::create_dir_all(path)?;
         }

--- a/crates/pyhq/python/hyperqueue/ffi/protocol.py
+++ b/crates/pyhq/python/hyperqueue/ffi/protocol.py
@@ -1,6 +1,8 @@
 import dataclasses
 from typing import Dict, List, Optional, Sequence, Union
 
+from ..output import StdioDef
+
 
 class ResourceRequest:
     n_nodes: int = 0
@@ -28,8 +30,8 @@ class TaskDescription:
     id: int
     args: List[str]
     cwd: Optional[str]
-    stdout: Optional[str]
-    stderr: Optional[str]
+    stdout: Optional[StdioDef]
+    stderr: Optional[StdioDef]
     stdin: Optional[bytes]
     env: Optional[Dict[str, str]]
     dependencies: Sequence[int]

--- a/crates/pyhq/python/hyperqueue/job.py
+++ b/crates/pyhq/python/hyperqueue/job.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Sequence, Union
 from .common import GenericPath
 from .ffi import JobId, TaskId
 from .ffi.protocol import JobDescription, ResourceRequest
-from .output import default_stderr, default_stdout
+from .output import Stdio, default_stderr, default_stdout
 from .task.function import PythonFunction
 from .task.program import ExternalProgram, ProgramArgs
 from .task.task import EnvType, Task
@@ -46,8 +46,8 @@ class Job:
         *,
         env: Optional[EnvType] = None,
         cwd: Optional[GenericPath] = None,
-        stdout: Optional[GenericPath] = default_stdout(),
-        stderr: Optional[GenericPath] = default_stderr(),
+        stdout: Optional[Stdio] = default_stdout(),
+        stderr: Optional[Stdio] = default_stderr(),
         stdin: Optional[Union[str, bytes]] = None,
         deps: Sequence[Task] = (),
         name: Optional[str] = None,
@@ -98,8 +98,8 @@ class Job:
         kwargs=None,
         env: Optional[EnvType] = None,
         cwd: Optional[GenericPath] = None,
-        stdout: Optional[GenericPath] = default_stdout(),
-        stderr: Optional[GenericPath] = default_stderr(),
+        stdout: Optional[Stdio] = default_stdout(),
+        stderr: Optional[Stdio] = default_stderr(),
         deps: Sequence[Task] = (),
         name: Optional[str] = None,
         priority: int = 0,

--- a/crates/pyhq/python/hyperqueue/output.py
+++ b/crates/pyhq/python/hyperqueue/output.py
@@ -1,7 +1,28 @@
+import dataclasses
 import uuid
-from typing import List, Optional
+from typing import List, Literal, Optional, Union
 
+from .common import GenericPath
 from .validation import ValidationException
+
+FileOnCloseBehavior = Literal["none", "rm-if-finished"]
+
+
+@dataclasses.dataclass
+class StdioDef:
+    path: Optional[GenericPath]
+    on_close: FileOnCloseBehavior
+
+    @staticmethod
+    def from_path(path: GenericPath) -> "StdioDef":
+        return StdioDef(path=path, on_close="none")
+
+    @staticmethod
+    def remove_if_finished(path: Optional[GenericPath] = None) -> "StdioDef":
+        return StdioDef(path=path, on_close="rm-if-finished")
+
+
+Stdio = Union[GenericPath, StdioDef]
 
 
 # Keep in sync with `DEFAULT_STDOUT_PATH`
@@ -19,13 +40,9 @@ def default_stderr() -> str:
 
 # TODO: how to resolve TASK_ID in the context of some other task?
 class Output:
-    def __init__(
-        self, name: str, filepath: Optional[str] = None, extension: Optional[str] = None
-    ):
+    def __init__(self, name: str, filepath: Optional[str] = None, extension: Optional[str] = None):
         if filepath and extension:
-            raise ValidationException(
-                "Parameters `filepath` and `extension` are mutually exclusive"
-            )
+            raise ValidationException("Parameters `filepath` and `extension` are mutually exclusive")
 
         self.name = name
         self.filepath = filepath

--- a/crates/pyhq/python/hyperqueue/output.py
+++ b/crates/pyhq/python/hyperqueue/output.py
@@ -19,9 +19,13 @@ def default_stderr() -> str:
 
 # TODO: how to resolve TASK_ID in the context of some other task?
 class Output:
-    def __init__(self, name: str, filepath: Optional[str] = None, extension: Optional[str] = None):
+    def __init__(
+        self, name: str, filepath: Optional[str] = None, extension: Optional[str] = None
+    ):
         if filepath and extension:
-            raise ValidationException("Parameters `filepath` and `extension` are mutually exclusive")
+            raise ValidationException(
+                "Parameters `filepath` and `extension` are mutually exclusive"
+            )
 
         self.name = name
         self.filepath = filepath

--- a/crates/pyhq/python/hyperqueue/task/program.py
+++ b/crates/pyhq/python/hyperqueue/task/program.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Sequence, Union
 from ..common import GenericPath
 from ..ffi import TaskId
 from ..ffi.protocol import ResourceRequest, TaskDescription
-from ..output import Output, gather_outputs
+from ..output import Output, Stdio, gather_outputs
 from ..validation import ValidationException, validate_args
 from .task import EnvType, Task, _make_ffi_requests
 
@@ -22,8 +22,8 @@ class ExternalProgram(Task):
         args: List[str],
         env: Optional[EnvType] = None,
         cwd: Optional[GenericPath] = None,
-        stdout: Optional[GenericPath] = None,
-        stderr: Optional[GenericPath] = None,
+        stdout: Optional[Stdio] = None,
+        stderr: Optional[Stdio] = None,
         stdin: Optional[Union[str, bytes]] = None,
         name: Optional[str] = None,
         dependencies: Sequence[Task] = (),

--- a/crates/tako/src/internal/tests/integration/test_basic.rs
+++ b/crates/tako/src/internal/tests/integration/test_basic.rs
@@ -36,8 +36,14 @@ async fn test_submit_simple_task_ok() {
                     .task(
                         TaskConfigBuilder::default()
                             .args(simple_args(&["bash", "-c", "echo 'hello'"]))
-                            .stdout(StdioDef::File(stdout.clone()))
-                            .stderr(StdioDef::File(stderr.clone())),
+                            .stdout(StdioDef::File {
+                                path: stdout.clone(),
+                                on_close: Default::default(),
+                            })
+                            .stderr(StdioDef::File {
+                                path: stderr.clone(),
+                                on_close: Default::default(),
+                            }),
                     )
                     .build(),
             )

--- a/crates/tako/src/launcher.rs
+++ b/crates/tako/src/launcher.rs
@@ -141,7 +141,7 @@ pub trait TaskLauncher {
 /// If the path is relative, the file will be created relative to `cwd`.
 fn create_output_stream(def: &StdioDef, cwd: &Path) -> crate::Result<Stdio> {
     let stdio = match def {
-        StdioDef::File(path) => {
+        StdioDef::File { path, .. } => {
             let stream_path = if path.is_relative() {
                 cwd.join(path)
             } else {

--- a/crates/tako/src/program.rs
+++ b/crates/tako/src/program.rs
@@ -5,10 +5,13 @@ use std::path::PathBuf;
 
 /// What should happen with a file, once its owning task finishes executing?
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
 pub enum FileOnCloseBehavior {
     /// Don't do anything
     #[default]
     None,
+    /// Remove the file if its task has finished successfully
+    RmIfFinished,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]

--- a/crates/tako/src/program.rs
+++ b/crates/tako/src/program.rs
@@ -3,11 +3,22 @@ use bstr::BString;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// What should happen with a file, once its owning task finishes executing?
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+pub enum FileOnCloseBehavior {
+    /// Don't do anything
+    #[default]
+    None,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
 pub enum StdioDef {
     #[default]
     Null,
-    File(PathBuf),
+    File {
+        path: PathBuf,
+        on_close: FileOnCloseBehavior,
+    },
     Pipe,
 }
 
@@ -18,7 +29,10 @@ impl StdioDef {
     {
         match self {
             StdioDef::Null => StdioDef::Null,
-            StdioDef::File(filename) => StdioDef::File(f(filename)),
+            StdioDef::File { path, on_close } => StdioDef::File {
+                path: f(path),
+                on_close,
+            },
             StdioDef::Pipe => StdioDef::Pipe,
         }
     }

--- a/docs/jobs/jobfile.md
+++ b/docs/jobs/jobfile.md
@@ -49,7 +49,7 @@ max_fails = 11
 
 [[task]]
 stdout = "testout-%{TASK_ID}
-stderr = "testerr-%{TASK_ID}"
+stderr = { path = "testerr-%{TASK_ID}", mode = "rm-if-finished" }
 task_dir = true
 time_limit = "1m 10s"
 priority = -1

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -337,6 +337,28 @@ If the message is longer than 2KiB, then it is truncated to 2KiB.
 
 If task terminates with zero return code, then the error file is ignored.
 
+## Automatic file cleanup
+If you create a lot of tasks and do not use [output streaming](streaming.md), a lot of `stdout`/`stderr`
+files can be created on the disk. In certain cases, you might not be interested in the contents of these files, especially
+if the task has finished successfully, and you instead want to remove them as soon as they are not needed.
+
+For that, you can use a file cleanup mode when specifying `stdout` and/or `stderr` to choose what should happen with
+the file when its task finishes. The mode is specified as a name following a colon (`:`) after the file path.
+Currently, one cleanup mode is implemented:
+
+- Remove the file if the task has [finished](#task-state) successfully:
+```bash
+$ hq submit --stdout="out.txt:rm-if-finished" /my-program
+```
+The file will not be deleted if the task fails or is cancelled.
+
+!!! Note
+    If you want to use the default `stdout`/`stderr` file path (and you don't want to look it up), you can also specify
+    just the cleanup mode without the file path:
+    ```bash
+    $ hq submit --stdout=":rm-if-finished" /my-program
+    ```
+
 ## Useful job commands
 Here is a list of useful job commands:
 

--- a/tests/job/test_file_cleanup.py
+++ b/tests/job/test_file_cleanup.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pytest
+
+from ..conftest import HqEnv
+from ..utils import wait_for_job_state
+from ..utils.cmd import python
+from ..utils.io import create_file
+from ..utils.job import default_task_output
+
+
+def program_wait_for_file_exists(file_name: str) -> str:
+    return f"""
+import os.path
+import time
+
+while True:
+    if os.path.isfile("{file_name}"):
+        break
+    time.sleep(0.1)
+"""
+
+
+@pytest.mark.parametrize("stream", ("stdout", "stderr"))
+def test_cleanup_stdout_on_success_default_path(hq_env: HqEnv, stream: str):
+    hq_env.start_server()
+    hq_env.start_worker()
+    hq_env.command(
+        [
+            "submit",
+            f"--{stream}=:rm-if-finished",
+            "--",
+            *python(program_wait_for_file_exists("finish")),
+        ]
+    )
+
+    output = default_task_output(type=stream)
+    wait_for_job_state(hq_env, 1, "RUNNING")
+    assert Path(output).is_file()
+    create_file("finish")
+
+    wait_for_job_state(hq_env, 1, "FINISHED")
+    assert not Path(output).is_file()
+
+
+@pytest.mark.parametrize("stream", ("stdout", "stderr"))
+def test_cleanup_stdout_on_success_custom_path(hq_env: HqEnv, stream: str):
+    hq_env.start_server()
+    hq_env.start_worker()
+
+    output = "foo.txt"
+    hq_env.command(
+        [
+            "submit",
+            f"--{stream}={output}:rm-if-finished",
+            "--",
+            *python(program_wait_for_file_exists("finish")),
+        ]
+    )
+
+    wait_for_job_state(hq_env, 1, "RUNNING")
+    assert Path(output).is_file()
+    create_file("finish")
+
+    wait_for_job_state(hq_env, 1, "FINISHED")
+    assert not Path(output).is_file()
+
+
+@pytest.mark.parametrize("stream", ("stdout", "stderr"))
+def test_do_not_cleanup_stdout_on_fail(hq_env: HqEnv, stream: str):
+    hq_env.start_server()
+    hq_env.start_worker()
+    hq_env.command(["submit", f"--{stream}=:rm-if-finished", "--", "/non-existent"])
+
+    output = default_task_output(type=stream)
+    wait_for_job_state(hq_env, 1, "FAILED")
+    assert Path(output).is_file()

--- a/tests/utils/io.py
+++ b/tests/utils/io.py
@@ -16,6 +16,10 @@ def write_file(path: str, content: str):
         f.write(content)
 
 
+def create_file(path: str):
+    write_file(path, "")
+
+
 def find_free_port():
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         s.bind(("", 0))


### PR DESCRIPTION
If a task succeeds, often we do not care about its stdout/stderr output. This PR adds a "file closing mode" to stdout/stderr, which makes HQ automatically remove the files from disk if their task succeeds.

Documentation and changelog isn't done yet, I first want to bakeshed the various names and flags :)