### PR TITLE
Set workspace resolver to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ default-members = [
     "crates/hyperqueue",
     "crates/tako"
 ]
+resolver = "2"
 
 [workspace.package]
 rust-version = "1.64.0"


### PR DESCRIPTION
To have better dependency trees and also to silence the annoying warning :)