### PR TITLE
Handle transition from waiting to failed state in HQ

### DIFF
--- a/crates/hyperqueue/src/client/output/common.rs
+++ b/crates/hyperqueue/src/client/output/common.rs
@@ -41,7 +41,10 @@ pub fn resolve_task_paths(job: &JobDetail, server_uid: &str) -> TaskToPathsMap {
                 }
                 | JobTaskState::Running { started_data, .. }
                 | JobTaskState::Finished { started_data, .. }
-                | JobTaskState::Failed { started_data, .. } => {
+                | JobTaskState::Failed {
+                    started_data: Some(started_data),
+                    ..
+                } => {
                     let ctx = CompletePlaceholderCtx {
                         job_id: job.info.id,
                         task_id: task.task_id,

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -342,7 +342,9 @@ fn format_tasks(tasks: Vec<JobTaskInfo>, map: TaskToPathsMap) -> serde_json::Val
                     end_date,
                     error,
                 } => {
-                    fill_task_started_data(&mut data, started_data);
+                    if let Some(started_data) = started_data {
+                        fill_task_started_data(&mut data, started_data);
+                    }
                     data["finished_at"] = format_datetime(end_date);
                     data["error"] = error.into();
                 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,11 +164,13 @@ class HqEnv(Env):
         wait_for_start=True,
         on_server_lost="stop",
         server_dir=None,
+        work_dir: Optional[str] = None,
     ) -> subprocess.Popen:
         self.id_counter += 1
         worker_id = self.id_counter
         worker_env = self.make_default_env()
-        work_dir = f"workdir{worker_id}"
+        if work_dir is None:
+            work_dir = f"workdir{worker_id}"
 
         if env:
             worker_env.update(env)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1431,6 +1431,18 @@ def test_kill_task_subprocess_when_worker_is_stopped(hq_env: HqEnv):
     check_child_process_exited(hq_env, stop_worker)
 
 
+def test_fail_to_start_issue629(hq_env: HqEnv, tmpdir):
+    """
+    Regression test for https://github.com/It4innovations/hyperqueue/issues/629.
+    By using an invalid stdout path, we should cause task spawning to fail, which should be handled gracefully.
+    """
+    hq_env.start_server()
+    hq_env.start_worker()
+
+    hq_env.command(["submit", "--stdout=/dev/null/foo.txt", "ls"])
+    wait_for_job_state(hq_env, 1, "FAILED")
+
+
 def check_child_process_exited(hq_env: HqEnv, stop_fn: Callable[[subprocess.Popen], None]):
     """
     Creates a task that spawns a child, and then calls `stop_fn`, which should kill either the task


### PR DESCRIPTION
This can happen if the task failed to start (e.g. if stdout/stderr file path preparation has failed). I also took the liberty of expanding several error messages created when a task fails to start.

Fixes: https://github.com/It4innovations/hyperqueue/issues/629