### PR TITLE
Improve panics in distributed builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.70.0
+          toolchain: 1.72.0
           override: true
 
       - uses: Swatinem/rust-cache@v1
@@ -95,7 +95,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.70.0
+          toolchain: 1.72.0
           override: true
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,9 @@ jobs:
           command: build
           args: --profile dist
 
+      - name: Compress debuginfo
+        run: objcopy --compress-debug-sections=zlib-gnu target/dist/hq
+
       - name: Prepare archive
         id: archive
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.70.0
+          toolchain: 1.72.0
           override: true
           components: clippy, rustfmt
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 edition = "2021"
 authors = ["Ada Böhm <ada@kreatrix.org>", "Jakub Beránek <berykubik@gmail.com>"]
 
@@ -52,4 +52,4 @@ panic = "abort"
 inherits = "release"
 lto = true
 codegen-units = 1
-strip = "debuginfo"
+debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.70.0"
+rust-version = "1.72.0"
 edition = "2021"
 authors = ["Ada Böhm <ada@kreatrix.org>", "Jakub Beránek <berykubik@gmail.com>"]
 

--- a/crates/hyperqueue/src/server/autoalloc/queue/common.rs
+++ b/crates/hyperqueue/src/server/autoalloc/queue/common.rs
@@ -144,10 +144,15 @@ pub fn build_worker_args(
         .unwrap_or_else(get_default_worker_idle_time);
     let idle_timeout = humantime::format_duration(idle_timeout);
 
+    let mut env = String::new();
+    if let Ok(log_env) = std::env::var("RUST_LOG") {
+        write!(env, "RUST_LOG={log_env} ").unwrap();
+    }
+
     let mut args = format!(
-        "{} worker start --idle-timeout \"{idle_timeout}\" --manager \"{manager}\" --server-dir \"{}\"",
-        hq_path.display(),
-        server_dir.display()
+        "{env}{hq} worker start --idle-timeout \"{idle_timeout}\" --manager \"{manager}\" --server-dir \"{server_dir}\"",
+        hq = hq_path.display(),
+        server_dir = server_dir.display()
     );
 
     if !queue_info.worker_args.is_empty() {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,4 @@
+# Bless tests
+```bash
+$ python -m pytest --inline-snapshot=create
+```


### PR DESCRIPTION
1) Enable (compressed) debuginfo in `dist` builds
2) Enable backtraces by default
3) Add a custom panic hook
4) Propagate `RUST_LOG` in autoalloc

Best reviewed commit by commit.