### PR TITLE
Monitor CPU time in benchmarks

### DIFF
--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -3,7 +3,7 @@ gitpython==3.1.37
 git+https://code.it4i.cz/def/cluster.git@428bd7f6c15525942358f5ff6b54d07b3828025f
 pandas==1.3.3
 tqdm==4.62.3
-mashumaro==2.9
+pyserde==0.12.3
 psutil==5.8.0
 humanize==3.12.0
 git+https://github.com/it4innovations/snailwatch@4d590c55e6b1e404e0398e8005dd998f5bc50be9#subdirectory=client

--- a/benchmarks/src/benchmark/identifier.py
+++ b/benchmarks/src/benchmark/identifier.py
@@ -3,14 +3,12 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from mashumaro import DataClassDictMixin
-
 from ..environment import EnvironmentDescriptor
 from ..workloads import Workload
 
 
 @dataclasses.dataclass(frozen=True)
-class BenchmarkIdentifier(DataClassDictMixin):
+class BenchmarkIdentifier:
     # Name of the workload
     workload: str
     # Environment type

--- a/benchmarks/src/benchmark/result.py
+++ b/benchmarks/src/benchmark/result.py
@@ -1,10 +1,8 @@
 import dataclasses
 
-from mashumaro import DataClassDictMixin
-
 
 @dataclasses.dataclass(frozen=True)
-class BenchmarkResult(DataClassDictMixin):
+class BenchmarkResult:
     pass
 
 

--- a/benchmarks/src/monitoring/record.py
+++ b/benchmarks/src/monitoring/record.py
@@ -18,10 +18,19 @@ class ResourceRecord:
 
 
 @dataclasses.dataclass
+class ProcessCpuTimes:
+    user: float
+    system: float
+    children_user: float
+    children_system: float
+
+
+@dataclasses.dataclass
 class ProcessRecord:
     rss: int
     vm: int
     cpu: float
+    cpu_times: ProcessCpuTimes
 
 
 @dataclasses.dataclass
@@ -65,7 +74,16 @@ def record_processes(processes: List[psutil.Process]) -> Dict[str, ProcessRecord
         try:
             memory_info = process.memory_info()
             cpu_utilization = process.cpu_percent()
-            data[str(process.pid)] = ProcessRecord(rss=memory_info.rss, vm=memory_info.vms, cpu=cpu_utilization)
+            cpu_times = process.cpu_times()
+            cpu_times = ProcessCpuTimes(
+                user=cpu_times.user,
+                system=cpu_times.system,
+                children_user=cpu_times.children_user,
+                children_system=cpu_times.children_system,
+            )
+            data[str(process.pid)] = ProcessRecord(
+                rss=memory_info.rss, vm=memory_info.vms, cpu=cpu_utilization, cpu_times=cpu_times
+            )
         except BaseException as e:
             logging.error(e)
     return data

--- a/benchmarks/src/postprocessing/monitor.py
+++ b/benchmarks/src/postprocessing/monitor.py
@@ -131,11 +131,11 @@ def render_node_per_cpu_pct_utilization(figure: Figure, df: pd.DataFrame):
         key = f"cpu_{i}"
         data[key] = cpu / 100.0
         data[f"{key}_x"] = cpu.index
-        tooltips.append((f"CPU #{i}", f"@{key}"))
+        tooltips.append((f"CPU #{i}", f"@{key}{{0.00}}"))
 
     data["cpu_mean"] = cpu_mean / 100.0
     data["cpu_mean_x"] = cpu_mean.index
-    tooltips.append(("CPU avg.", "@cpu_mean"))
+    tooltips.append(("CPU avg.", "@cpu_mean{0.00}"))
 
     figure.add_tools(HoverTool(tooltips=tooltips))
 

--- a/benchmarks/src/submit/options.py
+++ b/benchmarks/src/submit/options.py
@@ -3,11 +3,11 @@ import datetime
 from pathlib import Path
 from typing import Optional
 
-from mashumaro import DataClassJSONMixin
+from ..utils.io import from_json, to_json
 
 
 @dataclasses.dataclass(frozen=True)
-class PBSSubmitOptions(DataClassJSONMixin):
+class PBSSubmitOptions:
     queue: str
     nodes: int
     walltime: datetime.timedelta
@@ -18,9 +18,9 @@ class PBSSubmitOptions(DataClassJSONMixin):
 
 def serialize_submit_options(options: PBSSubmitOptions, path: Path):
     with open(path, "w") as f:
-        f.write(options.to_json())
+        to_json(options, f)
 
 
 def deserialize_submit_options(path: Path) -> PBSSubmitOptions:
     with open(path) as f:
-        return PBSSubmitOptions.from_json(f.read())
+        return from_json(PBSSubmitOptions, f)

--- a/benchmarks/src/utils/io.py
+++ b/benchmarks/src/utils/io.py
@@ -1,0 +1,19 @@
+import typing
+from typing import TypeVar
+
+Type = TypeVar("Type")
+
+
+def from_json(cls: type[Type], input: typing.Union[typing.TextIO, str]) -> Type:
+    from serde import json
+
+    if not isinstance(input, str):
+        input = input.read()
+    return json.from_json(cls, input)
+
+
+def to_json(object: typing.Any, file: typing.TextIO):
+    from serde import json
+
+    serialized = json.to_json(object)
+    file.write(serialized)


### PR DESCRIPTION
This PR adds monitoring of spent CPU time to the benchmark suite. We can see how much CPU time does the HQ server use when scheduling tasks and managing workers.

Note: I'll be doing many improvements to the benchmark suite in order to facilitate running benchmarks (for my thesis, among other reasons). Since these changes should be contained to the `benchmarks` directory, I'll be self-approving them.