### PR TITLE
Improve documentation of starting workers on Slurm/PBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ with the HyperQueue developers, you can use our [Zulip](https://hyperqueue.zulip
       - Start worker on all nodes of a Slurm job
 
         ```bash
-        $ sbatch <your-params-of-sbatch> --wrap "srun hq worker start"
+        $ sbatch <your-params-of-sbatch> --wrap "srun --overlap hq worker start"
         ```
 
 * Monitor the state of jobs

--- a/docs/deployment/worker.md
+++ b/docs/deployment/worker.md
@@ -52,7 +52,7 @@ Example submission script:
 
     # Run a worker on all allocated nodes
     ml OpenMPI
-    mpirun /<path-to-hyperqueue>/hq worker start --manager pbs
+    pbsdsh /<path-to-hyperqueue>/hq worker start --manager pbs
     ```
 
 === "Slurm"
@@ -66,7 +66,7 @@ Example submission script:
 
     # Run a worker on all allocated nodes
     ml OpenMPI
-    mpirun /<path-to-hyperqueue>/hq worker start --manager slurm
+    srun --overlap /<path-to-hyperqueue>/hq worker start --manager slurm
     ```
 
 The worker will try to automatically detect that it is started under a PBS/Slurm job, but you can also explicitly pass


### PR DESCRIPTION
It won't be perfect on all clusters, but these commands should be better than `mpirun`.