### PR TITLE
New "resubmit" mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Dev
 
 ## Breaking change
+
 * The output format of the `job info` command with JSON output mode has been changed. Note that
 the JSON output mode is still unstable.
 

--- a/crates/hyperqueue/src/client/commands/job.rs
+++ b/crates/hyperqueue/src/client/commands/job.rs
@@ -8,13 +8,12 @@ use crate::client::status::{job_status, Status};
 use crate::common::cli::{parse_last_all_range, parse_last_range, TaskSelectorArg};
 use crate::common::utils::str::pluralize;
 use crate::rpc_call;
-use crate::transfer::connection::{ClientConnection, ClientSession};
+use crate::transfer::connection::ClientSession;
 use crate::transfer::messages::{
     CancelJobResponse, CancelRequest, ForgetJobRequest, FromClientMessage, IdSelector, JobDetail,
     JobDetailRequest, JobInfoRequest, TaskIdSelector, TaskSelector, TaskStatusSelector,
     ToClientMessage,
 };
-use crate::JobId;
 
 #[derive(Parser)]
 pub struct JobListOpts {
@@ -105,28 +104,6 @@ pub struct JobCatOpts {
     /// Type of output stream to display
     #[arg(value_enum)]
     pub stream: OutputStream,
-}
-
-pub async fn get_last_job_id(connection: &mut ClientConnection) -> crate::Result<Option<JobId>> {
-    let message = FromClientMessage::JobInfo(JobInfoRequest {
-        selector: IdSelector::LastN(1),
-    });
-    let response = rpc_call!(connection, message, ToClientMessage::JobInfoResponse(r) => r).await?;
-
-    Ok(response.jobs.last().map(|job| job.id))
-}
-
-pub async fn get_job_ids(connection: &mut ClientConnection) -> crate::Result<Option<Vec<JobId>>> {
-    let message = FromClientMessage::JobInfo(JobInfoRequest {
-        selector: IdSelector::All,
-    });
-    let response = rpc_call!(connection, message, ToClientMessage::JobInfoResponse(r) => r).await?;
-
-    let mut ids: Vec<JobId> = Vec::new();
-    for job in response.jobs {
-        ids.push(job.id);
-    }
-    Ok(Option::from(ids))
 }
 
 pub async fn output_job_list(

--- a/crates/hyperqueue/src/client/commands/job.rs
+++ b/crates/hyperqueue/src/client/commands/job.rs
@@ -59,6 +59,18 @@ pub struct JobForgetOpts {
     pub filter: Vec<CompletedJobStatus>,
 }
 
+#[derive(Parser)]
+pub struct JobTaskIdsOpts {
+    /// Single ID, ID range or `last` to display the most recently submitted job
+    #[arg(value_parser = parse_last_all_range)]
+    pub selector: IdSelector,
+
+    /// Select only tasks with given state(s)
+    /// You can use multiple states separated by a comma.
+    #[arg(long, value_delimiter(','), value_enum)]
+    pub filter: Vec<Status>,
+}
+
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub enum CompletedJobStatus {
     Finished,

--- a/crates/hyperqueue/src/client/commands/submit/command.rs
+++ b/crates/hyperqueue/src/client/commands/submit/command.rs
@@ -681,7 +681,7 @@ pub(crate) async fn send_submit_request(
         )
         .await?;
     } else if progress {
-        wait_for_jobs_with_progress(session, vec![info]).await?;
+        wait_for_jobs_with_progress(session, &[info]).await?;
     }
     Ok(())
 }

--- a/crates/hyperqueue/src/client/commands/submit/command.rs
+++ b/crates/hyperqueue/src/client/commands/submit/command.rs
@@ -714,7 +714,7 @@ fn get_ids_and_entries(opts: &JobSubmitOpts) -> anyhow::Result<(IntArray, Option
                     })
                     .collect(),
             );
-            IntArray::from_ids(id_set.iter().copied())
+            IntArray::from_sorted_ids(id_set.into_iter())
         } else {
             array.clone()
         }

--- a/crates/hyperqueue/src/client/commands/wait.rs
+++ b/crates/hyperqueue/src/client/commands/wait.rs
@@ -104,7 +104,7 @@ pub async fn wait_for_jobs_with_progress(
             let response = rpc_call!(
                 session.connection(),
                 FromClientMessage::JobInfo(JobInfoRequest {
-                    selector: IdSelector::Specific(IntArray::from_ids(remaining_job_ids.iter().map(|x| x.as_num()))),
+                    selector: IdSelector::Specific(IntArray::from_sorted_ids(remaining_job_ids.iter().map(|x| x.as_num()))),
                 }),
                 ToClientMessage::JobInfoResponse(r) => r
             )

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -35,6 +35,7 @@ use crate::client::output::common::{
 };
 use crate::client::output::json::format_datetime;
 use crate::client::output::Verbosity;
+use crate::common::arraydef::IntArray;
 use crate::common::utils::str::{pluralize, select_plural, truncate_middle};
 use crate::worker::start::WORKER_EXTRA_PROCESS_PID;
 use anyhow::Error;
@@ -422,6 +423,12 @@ impl Output for CliOutput {
             "successfully".color(colored::Color::Green),
             job.info.id
         );
+    }
+
+    fn print_task_ids(&self, job_task_ids: Vec<(JobId, IntArray)>) {
+        for (_, array) in &job_task_ids {
+            println!("{}", array);
+        }
     }
 
     fn print_job_list(&self, jobs: Vec<JobInfo>, total_jobs: usize) {

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -426,8 +426,12 @@ impl Output for CliOutput {
     }
 
     fn print_task_ids(&self, job_task_ids: Vec<(JobId, IntArray)>) {
-        for (_, array) in &job_task_ids {
-            println!("{}", array);
+        if job_task_ids.len() == 1 {
+            println!("{}", job_task_ids[0].1);
+        } else {
+            for (job_id, array) in &job_task_ids {
+                println!("{}: {}", job_id, array);
+            }
         }
     }
 

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 
@@ -17,6 +18,7 @@ use crate::client::job::WorkerMap;
 use crate::client::output::common::{group_jobs_by_status, resolve_task_paths, TaskToPathsMap};
 use crate::client::output::outputs::{Output, OutputStream};
 use crate::client::output::Verbosity;
+use crate::common::arraydef::IntArray;
 use crate::common::manager::info::{GetManagerInfo, ManagerType};
 use crate::server::autoalloc::{Allocation, AllocationState, QueueId};
 use crate::server::job::{JobTaskInfo, JobTaskState, StartedTaskData};
@@ -197,6 +199,14 @@ impl Output for JsonOutput {
     ) {
         let map = resolve_task_paths(&job.1, server_uid);
         self.print(format_tasks(tasks, map));
+    }
+
+    fn print_task_ids(&self, job_task_ids: Vec<(JobId, IntArray)>) {
+        let map: HashMap<JobId, Vec<u32>> = job_task_ids
+            .into_iter()
+            .map(|(key, value)| (key, value.iter().collect()))
+            .collect();
+        self.print(json!(map));
     }
 
     fn print_summary(&self, filename: &Path, summary: Summary) {

--- a/crates/hyperqueue/src/client/output/outputs.rs
+++ b/crates/hyperqueue/src/client/output/outputs.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 
 use crate::client::output::common::TaskToPathsMap;
 use crate::client::output::Verbosity;
+use crate::common::arraydef::IntArray;
 use crate::server::job::JobTaskInfo;
 use crate::JobId;
 use core::time::Duration;
@@ -77,6 +78,7 @@ pub trait Output {
         server_uid: &str,
         verbosity: Verbosity,
     );
+    fn print_task_ids(&self, jobs_task_id: Vec<(JobId, IntArray)>);
 
     // Log
     fn print_summary(&self, filename: &Path, summary: Summary);

--- a/crates/hyperqueue/src/client/output/quiet.rs
+++ b/crates/hyperqueue/src/client/output/quiet.rs
@@ -13,6 +13,7 @@ use crate::client::output::common::{
 };
 use crate::client::output::outputs::{Output, OutputStream};
 use crate::client::status::{job_status, Status};
+use crate::common::arraydef::IntArray;
 use crate::server::autoalloc::Allocation;
 use crate::server::job::JobTaskInfo;
 use crate::stream::reader::logfile::Summary;
@@ -129,6 +130,8 @@ impl Output for Quiet {
         _verbosity: Verbosity,
     ) {
     }
+
+    fn print_task_ids(&self, _job_task_ids: Vec<(JobId, IntArray)>) {}
 
     // Log
     fn print_summary(&self, _filename: &Path, _summary: Summary) {}

--- a/crates/hyperqueue/src/client/task.rs
+++ b/crates/hyperqueue/src/client/task.rs
@@ -155,7 +155,7 @@ pub async fn output_job_task_ids(
         .map(|(job_id, detail)| {
             Ok((
                 *job_id,
-                IntArray::from_ids(
+                IntArray::from_sorted_ids(
                     detail
                         .as_ref()
                         .ok_or_else(|| HqError::GenericError("Job Id not found".to_string()))?

--- a/crates/hyperqueue/src/common/arraydef.rs
+++ b/crates/hyperqueue/src/common/arraydef.rs
@@ -38,19 +38,22 @@ impl IntArray {
         IntArray { ranges }
     }
 
-    pub fn from_ids(ids: Vec<u32>) -> IntArray {
+    // ids has to be sorted!
+    pub fn from_ids(ids: impl Iterator<Item = u32>) -> IntArray {
         let mut ranges: Vec<IntRange> = Vec::new();
+        let mut last_id = None;
         for id in ids {
-            if let Some(pos) = ranges.iter().position(|x| id == (x.start + x.count)) {
-                ranges[pos].count += 1;
+            if last_id.map(|last_id| last_id + 1 == id).unwrap_or(false) {
+                ranges.last_mut().unwrap().count += 1;
             } else {
                 ranges.push(IntRange::new(id, 1, 1));
             }
+            last_id = Some(id)
         }
         IntArray { ranges }
     }
     pub fn from_id(id: u32) -> IntArray {
-        Self::from_ids(vec![id])
+        Self::from_ids([id].iter().copied())
     }
 
     pub fn from_range(start: u32, count: u32) -> Self {
@@ -104,7 +107,11 @@ impl fmt::Display for IntArray {
                 ));
             }
         }
-        write!(f, "{}", &str[0..str.len() - 2])
+        if str.len() >= 2 {
+            write!(f, "{}", &str[0..str.len() - 2])
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/crates/hyperqueue/src/common/cli.rs
+++ b/crates/hyperqueue/src/common/cli.rs
@@ -9,7 +9,7 @@ use tako::WorkerId;
 use crate::client::commands::autoalloc::AutoAllocOpts;
 use crate::client::commands::event::EventLogOpts;
 use crate::client::commands::job::{
-    JobCancelOpts, JobCatOpts, JobForgetOpts, JobInfoOpts, JobListOpts,
+    JobCancelOpts, JobCatOpts, JobForgetOpts, JobInfoOpts, JobListOpts, JobTaskIdsOpts,
 };
 use crate::client::commands::log::LogOpts;
 use crate::client::commands::server::ServerOpts;
@@ -320,6 +320,8 @@ pub enum JobCommand {
     Wait(JobWaitOpts),
     /// Interactively observe the execution of a job
     Progress(JobProgressOpts),
+    /// Print tasks Ids for given job
+    TaskIds(JobTaskIdsOpts),
 }
 
 #[derive(Parser)]

--- a/crates/hyperqueue/src/common/cli.rs
+++ b/crates/hyperqueue/src/common/cli.rs
@@ -320,7 +320,7 @@ pub enum JobCommand {
     Wait(JobWaitOpts),
     /// Interactively observe the execution of a job
     Progress(JobProgressOpts),
-    /// Print tasks Ids for given job
+    /// Print task Ids for given job
     TaskIds(JobTaskIdsOpts),
 }
 

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -194,7 +194,7 @@ pub async fn handle_resubmit(
 
                         ids.sort_unstable();
                         JobDescription::Array {
-                            ids: IntArray::from_ids(ids.iter().copied()),
+                            ids: IntArray::from_sorted_ids(ids.into_iter()),
                             entries: entries.clone(),
                             task_desc: task_desc.clone(),
                         }

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -194,7 +194,7 @@ pub async fn handle_resubmit(
 
                         ids.sort_unstable();
                         JobDescription::Array {
-                            ids: IntArray::from_ids(ids),
+                            ids: IntArray::from_ids(ids.iter().copied()),
                             entries: entries.clone(),
                             task_desc: task_desc.clone(),
                         }

--- a/crates/pyhq/src/client/job.rs
+++ b/crates/pyhq/src/client/job.rs
@@ -234,9 +234,9 @@ pub fn wait_for_jobs_impl(
 
         loop {
             let selector =
-                IdSelector::Specific(IntArray::from_ids(remaining_job_ids.iter().copied()));
+                IdSelector::Specific(IntArray::from_sorted_ids(remaining_job_ids.iter().copied()));
 
-            response = hyperqueue::rpc_call!(
+            response = rpc_call!(
                 ctx.session.connection(),
                 FromClientMessage::JobInfo(JobInfoRequest {
                     selector,
@@ -310,7 +310,7 @@ pub fn get_failed_tasks_impl(
 ) -> PyResult<FailedTaskMap> {
     run_future(async move {
         let message = FromClientMessage::JobDetail(JobDetailRequest {
-            job_id_selector: IdSelector::Specific(IntArray::from_ids(job_ids.into_iter())),
+            job_id_selector: IdSelector::Specific(IntArray::from_sorted_ids(job_ids.into_iter())),
             task_selector: Some(TaskSelector {
                 id_selector: TaskIdSelector::All,
                 status_selector: TaskStatusSelector::Specific(vec![Status::Failed]),

--- a/crates/pyhq/src/client/job.rs
+++ b/crates/pyhq/src/client/job.rs
@@ -233,9 +233,8 @@ pub fn wait_for_jobs_impl(
         let mut response: JobInfoResponse;
 
         loop {
-            let selector = IdSelector::Specific(IntArray::from_ids(
-                remaining_job_ids.iter().copied().collect(),
-            ));
+            let selector =
+                IdSelector::Specific(IntArray::from_ids(remaining_job_ids.iter().copied()));
 
             response = hyperqueue::rpc_call!(
                 ctx.session.connection(),
@@ -311,7 +310,7 @@ pub fn get_failed_tasks_impl(
 ) -> PyResult<FailedTaskMap> {
     run_future(async move {
         let message = FromClientMessage::JobDetail(JobDetailRequest {
-            job_id_selector: IdSelector::Specific(IntArray::from_ids(job_ids)),
+            job_id_selector: IdSelector::Specific(IntArray::from_ids(job_ids.into_iter())),
             task_selector: Some(TaskSelector {
                 id_selector: TaskIdSelector::All,
                 status_selector: TaskStatusSelector::Specific(vec![Status::Failed]),

--- a/docs/jobs/arrays.md
+++ b/docs/jobs/arrays.md
@@ -104,7 +104,7 @@ and the other with `HQ_ENTRY` set to `{"batch_size": 8, "learning_rate": 0.001}`
 ### Combining with `--each-line`/`--from-json` with `--array`
 
 Option `--each-line` or `--from-json` can be combined with option `--array`.
-In such case, only a subset of lines/json will be submited.
+In such case, only a subset of lines/json will be submitted.
 If `--array` defines an ID that exceeds the number of lines in the file (or the number of elements in JSON), then the ID is silently removed.
 
 

--- a/docs/jobs/arrays.md
+++ b/docs/jobs/arrays.md
@@ -100,3 +100,19 @@ If `items.json` contained this content:
 ```
 then HyperQueue would create two tasks, one with `HQ_ENTRY` set to `{"batch_size": 4, "learning_rate": 0.01}`
 and the other with `HQ_ENTRY` set to `{"batch_size": 8, "learning_rate": 0.001}`.
+
+### Combining with `--each-line`/`--from-json` with `--array`
+
+Option `--each-line` or `--from-json` can be combined with option `--array`.
+In such case, only a subset of lines/json will be submited.
+If `--array` defines an ID that exceeds the number of lines in the file (or the number of elements in JSON), then the ID is silently removed.
+
+
+For example:
+
+```commandline
+$ hq submit --each-line input.txt --array "2, 8-10"
+```
+
+If `input.txt` has sufficiently many lines then it will create array job with four tasks. One for 3rd line of file and three tasks for 9th-11th line
+(note that first line has id 0). It analogously works for `--from-json`.

--- a/docs/jobs/failure.md
+++ b/docs/jobs/failure.md
@@ -7,7 +7,7 @@ However, in case of [task arrays](arrays.md), different tasks may end in differe
 recompute only tasks with a specific status (e.g. failed tasks).
 
 By following combination of commands you may recompute only failed tasks. Let us assume that we want to recompute
-all failed jobs in job 5:
+all failed tasks in job 5:
 
 ```commandline
 $ hq submit --array=`hq job task-ids 5 --filter=failed` ./my-computation

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -123,7 +123,8 @@ def test_each_line_with_array(hq_env: HqEnv):
         [
             "submit",
             "--each-line=input",
-            "--array", "2-4, 6",
+            "--array",
+            "2-4, 6",
             "--",
             "bash",
             "-c",
@@ -154,7 +155,8 @@ def test_json_with_array(hq_env: HqEnv):
         [
             "submit",
             "--from-json=input",
-            "--array", "2-3, 5, 6, 7, 1000",
+            "--array",
+            "2-3, 5, 6, 7, 1000",
             "--",
             "bash",
             "-c",

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -110,3 +110,65 @@ def test_entries_invalid_from_json_entry(hq_env: HqEnv):
                 "echo $HQ_ENTRY",
             ]
         )
+
+
+def test_each_line_with_array(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.start_worker(cpus=2)
+
+    with open("input", "w") as f:
+        f.write("One\nTwo\nThree\nFour\nFive\nSix\nSeven")
+
+    hq_env.command(
+        [
+            "submit",
+            "--each-line=input",
+            "--array", "2-4, 6",
+            "--",
+            "bash",
+            "-c",
+            "echo $HQ_ENTRY,$HQ_TASK_ID",
+        ]
+    )
+    wait_for_job_state(hq_env, 1, "FINISHED")
+
+    for i, test in enumerate([None, None, "Three,2\n", "Four,3\n", "Five,4\n", None, "Seven,6\n"]):
+        filename = default_task_output(job_id=1, task_id=i)
+        if test is None:
+            assert not os.path.exists(filename)
+        else:
+            check_file_contents(filename, test)
+
+    table = hq_env.command(["job", "info", "1"], as_table=True)
+    assert table.get_row_value("State").split("\n")[-1] == "FINISHED (4)"
+
+
+def test_json_with_array(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.start_worker(cpus=2)
+
+    with open("input", "w") as f:
+        f.write('["One", "Two", "Three", "Four", "Five", "Six", "Seven"]')
+
+    hq_env.command(
+        [
+            "submit",
+            "--from-json=input",
+            "--array", "2-3, 5, 6, 7, 1000",
+            "--",
+            "bash",
+            "-c",
+            "echo $HQ_ENTRY,$HQ_TASK_ID",
+        ]
+    )
+    wait_for_job_state(hq_env, 1, "FINISHED")
+
+    for i, test in enumerate([None, None, '"Three",2\n', '"Four",3\n', None, '"Six",5\n', '"Seven",6\n']):
+        filename = default_task_output(job_id=1, task_id=i)
+        if test is None:
+            assert not os.path.exists(filename)
+        else:
+            check_file_contents(filename, test)
+
+    table = hq_env.command(["job", "info", "1"], as_table=True)
+    assert table.get_row_value("State").split("\n")[-1] == "FINISHED (4)"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -702,10 +702,10 @@ def test_job_resubmit_with_status(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FAILED")
 
     table = hq_env.command(["job", "resubmit", "1", "--filter=failed"], as_table=True)
-    table.check_row_value("Tasks", "4; Ids: 4-6, 8")
+    table.check_row_value("Tasks", "4; Ids: 4-6,8")
 
     table = hq_env.command(["job", "resubmit", "1", "--filter=finished"], as_table=True)
-    table.check_row_value("Tasks", "3; Ids: 3, 7, 9")
+    table.check_row_value("Tasks", "3; Ids: 3,7,9")
 
 
 def test_job_resubmit_all(hq_env: HqEnv):
@@ -715,7 +715,7 @@ def test_job_resubmit_all(hq_env: HqEnv):
     wait_for_job_state(hq_env, 1, "FINISHED")
 
     table = hq_env.command(["job", "resubmit", "1"], as_table=True)
-    table.check_row_value("Tasks", "3; Ids: 2, 7, 9")
+    table.check_row_value("Tasks", "3; Ids: 2,7,9")
 
 
 def test_job_resubmit_empty(hq_env: HqEnv):
@@ -1477,21 +1477,30 @@ time.sleep(3600)
     wait_for_pid_exit(parent)
     wait_for_pid_exit(child)
 
+
 def test_job_task_ids(hq_env: HqEnv):
     hq_env.start_server()
-    hq_env.command(["submit", "--array=2,7,9,20-30", "--", "python", "-c", "import os; assert os.environ['HQ_TASK_ID'] not in ['25', '26', '27', '28']"])
+    hq_env.command(
+        [
+            "submit",
+            "--array=2,7,9,20-30",
+            "--",
+            "python",
+            "-c",
+            "import os; assert os.environ['HQ_TASK_ID'] not in ['25', '26', '27', '28']",
+        ]
+    )
     hq_env.start_workers(1, cpus=1)
     wait_for_job_state(hq_env, 1, "FAILED")
 
     result = hq_env.command(["job", "task-ids", "1"])
-    assert result == "2, 7, 9, 20-30\n"
+    assert result == "2,7,9,20-30\n"
 
     result = hq_env.command(["job", "task-ids", "1", "--filter", "finished"])
-    assert result == "2, 7, 9, 20-24, 29-30\n"
+    assert result == "2,7,9,20-24,29-30\n"
 
     result = hq_env.command(["job", "task-ids", "1", "--filter", "failed"])
     assert result == "25-28\n"
 
     result = hq_env.command(["job", "task-ids", "1", "--filter", "canceled"])
     assert result == "\n"
-

--- a/tests/test_jobfile.py
+++ b/tests/test_jobfile.py
@@ -219,7 +219,7 @@ command = ["sleep", "0"]
     """)
     hq_env.command(["job", "submit-file", "job.toml"])
     r = hq_env.command(["job", "info", "1"], as_table=True)
-    r.check_row_value("Tasks", "7; Ids: 2, 10-14, 120")
+    r.check_row_value("Tasks", "7; Ids: 2,10-14,120")
 
 
 def test_job_file_fail_mixing_array_and_tasks(hq_env: HqEnv, tmp_path):


### PR DESCRIPTION
The preparation for removing resubmit.

It allows "resubmit" via:
```commandline
hq submit --array=`hq job task-ids --filter=filter` ... 
```

(This PR does not removes resubmit yet)