### PR TITLE
Disable stack traces for normal errors in release mode

### DIFF
--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -362,7 +362,15 @@ async fn main() -> hyperqueue::Result<()> {
     }));
 
     // Also enable backtraces by default.
+    // This enables backtraces when panicking, but also for normal anyhow errors.
     std::env::set_var("RUST_BACKTRACE", "full");
+
+    // This further disables backtraces for normal anyhow errors.
+    // They should not be printed to users in release mode.
+    #[cfg(not(debug_assertions))]
+    {
+        std::env::set_var("RUST_LIB_BACKTRACE", "0");
+    }
 
     let matches = RootOptions::command().get_matches();
     let top_opts = match RootOptions::from_arg_matches(&matches) {


### PR DESCRIPTION
Since the recent panic/debuginfo/stacktrace changes, HQ has been printing a stacktrace even when a normal error was propagated back to `main`, not just for panics. That is quite annoying to users, and we should just not do that in release mode (also because of performance, although that's probably not *that* important in this case, as errors should be rare).