### PR TITLE
Allow passing empty `stdout`/`stderr` to Python function tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   (e.g. if hostname is "cn690.karolina.it4i.cz", only "cn690" is written into node list)
   You can read ``HQ_HOST_FILE`` if you need to get full hostnames without stripping.
 
+## Fixes
+
+* Enable passing of empty `stdout`/`stderr` to Python function tasks in the Python
+  API (https://github.com/It4innovations/hyperqueue/issues/691).
 
 # v0.18.0
 

--- a/crates/pyhq/python/hyperqueue/output.py
+++ b/crates/pyhq/python/hyperqueue/output.py
@@ -13,6 +13,7 @@ class StdioDef:
     """
     If `path` is `None`, then the default HQ path will be used.
     """
+
     path: Optional[GenericPath]
     on_close: FileOnCloseBehavior
 

--- a/crates/pyhq/python/hyperqueue/output.py
+++ b/crates/pyhq/python/hyperqueue/output.py
@@ -10,6 +10,9 @@ FileOnCloseBehavior = Literal["none", "rm-if-finished"]
 
 @dataclasses.dataclass
 class StdioDef:
+    """
+    If `path` is `None`, then the default HQ path will be used.
+    """
     path: Optional[GenericPath]
     on_close: FileOnCloseBehavior
 

--- a/crates/pyhq/python/hyperqueue/task/task.py
+++ b/crates/pyhq/python/hyperqueue/task/task.py
@@ -58,12 +58,14 @@ class Task:
         raise NotImplementedError
 
 
-def build_stdio(stdio: Stdio, stream: str) -> StdioDef:
+def build_stdio(stdio: Optional[Stdio], stream: str) -> Optional[StdioDef]:
     if isinstance(stdio, (str, Path)):
         return StdioDef.from_path(stdio)
     elif isinstance(stdio, StdioDef):
         return stdio
+    elif stdio is None:
+        return None
     else:
         raise ValidationException(
-            f"Invalid value provided for `{stream}`: {type(stdio)}. Expected str, Path or `StdioDef`."
+            f"Invalid value provided for `{stream}`: {type(stdio)}. Expected str, Path or `StdioDef` or `None`."
         )

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -1,5 +1,7 @@
 import datetime
+import os.path
 import random
+import sys
 import time
 from pathlib import Path
 
@@ -74,6 +76,24 @@ def test_submit_stdio(hq_env: HqEnv):
     wait_for_job_state(hq_env, submitted_job.id, "FINISHED")
     check_file_contents("out", "Test1\nHello\n")
     check_file_contents("err", "Test2\n")
+
+
+def test_empty_stdio(hq_env: HqEnv):
+    (job, client) = prepare_job_client(hq_env)
+
+    def foo():
+        print("Hello")
+        print("Hello", file=sys.stderr)
+
+    job.function(
+        foo,
+        stdout=None,
+        stderr=None,
+    )
+    submitted_job = client.submit(job)
+    wait_for_job_state(hq_env, submitted_job.id, "FINISHED")
+    assert not os.path.isfile("0.stdout")
+    assert not os.path.isfile("0.stderr")
 
 
 def test_stdio_rm_if_finished(hq_env: HqEnv):


### PR DESCRIPTION
Fixes: https://github.com/It4innovations/hyperqueue/issues/691