### PR TITLE
Add CI workflow for testing compatibility mode on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,3 +93,47 @@ jobs:
         run: |
           python -m pip install -r docs/requirements.txt
           mkdocs build
+
+  compatibility_mode:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.os }}
+
+      - name: Build HyperQueue
+        run: cargo build --no-default-features
+      - name: Run HyperQueue
+        run: cargo run --no-default-features -- --version
+
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.8"
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install -r tests/requirements.txt
+
+      - name: Install coreutils
+        run: brew install coreutils
+
+      - name: Build Python binding
+        run: |
+          maturin build --manifest-path crates/pyhq/Cargo.toml --out wheels
+          WHEEL=`realpath wheels/*.whl`
+          python -m pip install $WHEEL[all]

--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ Check out the [documentation](https://it4innovations.github.io/hyperqueue/).
 
 * **What operating systems does HQ support?**
 
-  HyperQueue currently only officially supports Linux (Ubuntu, Debian, CentOS, etc.). It shouldn't be that difficult to
-  compile it for other operating systems with minor modifications, however we do not provide any support nor promise to
-  fix any bugs for other operating systems.
+  HyperQueue currently only officially supports Linux (Ubuntu, Debian, CentOS, etc.). It might be possible to
+  compile it for other operating systems, however we do not provide any support nor promise to fix any bugs for other
+  operating systems.
 
 * **Is it safe to run HQ on a login node shared by other users?**
 

--- a/crates/tako/src/launcher.rs
+++ b/crates/tako/src/launcher.rs
@@ -168,6 +168,7 @@ pub fn command_from_definitions(definition: &ProgramDefinition) -> crate::Result
 
     let mut command = Command::new(definition.args[0].to_os_str_lossy());
 
+    #[cfg(target_os = "linux")]
     unsafe {
         command.pre_exec(|| {
             // We need to create a new process group for the task, so that we can


### PR DESCRIPTION
This PR enables compilation of HQ on macOS with a single `#[cfg]` directive, and adds a CI workflow that checks that it can still be compiled on macOS (both the binary and the Python binding).

Fixes: https://github.com/It4innovations/hyperqueue/issues/688, https://github.com/It4innovations/hyperqueue/issues/690