### PR TITLE
CI: update Python version to 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-13
             target: x86_64-apple-darwin
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Should hopefully fix the compatibility mode CI job.