### PR TITLE
Do not create working directory if it already exists

### DIFF
--- a/crates/tako/src/launcher.rs
+++ b/crates/tako/src/launcher.rs
@@ -189,8 +189,11 @@ pub fn command_from_definitions(definition: &ProgramDefinition) -> crate::Result
     command.kill_on_drop(true);
     command.args(definition.args[1..].iter().map(|x| x.to_os_str_lossy()));
 
-    std::fs::create_dir_all(&definition.cwd)
-        .map_err(|error| GenericError(format!("Could not create working directory: {error:?}")))?;
+    if !definition.cwd.is_dir() {
+        std::fs::create_dir_all(&definition.cwd).map_err(|error| {
+            GenericError(format!("Could not create working directory: {error:?}"))
+        })?;
+    }
     command.current_dir(&definition.cwd);
 
     command.stdout(create_output_stream(&definition.stdout, &definition.cwd)?);


### PR DESCRIPTION
For very short tasks (~1ms), this can be a non-trivial performance improvements on networked filesystems.