### PR TITLE
Optimize data (de)serialization in output streaming

### DIFF
--- a/crates/hyperqueue/src/transfer/stream.rs
+++ b/crates/hyperqueue/src/transfer/stream.rs
@@ -21,6 +21,7 @@ pub struct DataMsg {
     pub task: JobTaskId,
     pub instance: InstanceId,
     pub channel: ChannelId,
+    #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
 }
 


### PR DESCRIPTION
The bytes were (de)serialized one by one, instead as a byte array. 15% perf. boost with 10k tasks and 100 KiB output per task streamed.