### PR TITLE
Fix size check macro

### DIFF
--- a/crates/hyperqueue/src/server/event/payload.rs
+++ b/crates/hyperqueue/src/server/event/payload.rs
@@ -69,4 +69,4 @@ pub enum EventPayload {
 }
 
 // Keep the size of the event structure in check
-static_assert_size!(EventPayload, 136);
+static_assert_size!(EventPayload, 176);

--- a/crates/tako/src/internal/common/utils.rs
+++ b/crates/tako/src/internal/common/utils.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 #[macro_export]
 macro_rules! static_assert_size {
     ($ty:ty, $size:expr) => {
-        #[cfg(target_arch = "x86_x64")]
+        #[cfg(target_arch = "x86_64")]
         const _: [(); $size] = [(); ::std::mem::size_of::<$ty>()];
     };
 }

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -114,7 +114,7 @@ pub struct Task {
 }
 
 // Task is a critical data structure, so we should keep its size in check
-static_assert_size!(Task, 168);
+static_assert_size!(Task, 112);
 
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
It was using the wrong `target_arch`. Found using the new cfg checks that have appeared in Rust 1.80.