### PR TITLE
Use download-artifact v3 and upload-artifact v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           echo "::set-output name=archive-name::$ARCHIVE_NAME"
 
       - name: Store archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: archive-x64
           path: ${{ steps.archive.outputs.archive-name }}
@@ -127,7 +127,7 @@ jobs:
           echo "::set-output name=archive-name::$ARCHIVE_NAME"
 
       - name: Store archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: archive-${{ matrix.name }}
           path: ${{ steps.archive.outputs.archive-name }}
@@ -178,7 +178,7 @@ jobs:
           source venv/bin/activate
           python3 -m pytest tests/pyapi
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: archive-pyhq
           path: wheels/hyperqueue-*.whl

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,13 +19,13 @@ jobs:
         run: |
           echo "HQ version: ${{ env.HQ_VERSION }}"
   build-artifacts:
-    needs: [set-env]
+    needs: [ set-env ]
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.set-env.outputs.version }}
   create-tag:
     runs-on: ubuntu-latest
-    needs: [set-env, build-artifacts]
+    needs: [ set-env, build-artifacts ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
           message: Nightly build ${{ needs.set-env.outputs.version }}
   create-release:
     runs-on: ubuntu-latest
-    needs: [create-tag]
+    needs: [ create-tag ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
         run: python3 scripts/extract_changelog.py DEV > generated-changelog.md
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
 
       - name: Prepare release name
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check package versions
         run: python scripts/check_package_versions.py
   set-env:
-    needs: [version-check]
+    needs: [ version-check ]
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ env.SHA }}
@@ -49,14 +49,14 @@ jobs:
           echo "Tag: ${{ env.TAG }}"
           echo "Pre-release: ${{ env.PRERELEASE }}"
   build-artifacts:
-    needs: [set-env]
+    needs: [ set-env ]
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.set-env.outputs.tag }}
       sha: ${{ needs.set-env.outputs.sha }}
   create-release:
     runs-on: ubuntu-latest
-    needs: [set-env, build-artifacts]
+    needs: [ set-env, build-artifacts ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -67,7 +67,7 @@ jobs:
         run: python3 scripts/extract_changelog.py ${{ needs.set-env.outputs.tag }} > generated-changelog.md
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
 
       - name: Create release
         uses: ncipollo/release-action@v1
@@ -83,11 +83,11 @@ jobs:
           artifacts: archive-*/**
   upload-python-wheel:
     runs-on: ubuntu-latest
-    needs: [set-env, create-release]
+    needs: [ set-env, create-release ]
     if: ${{ !fromJSON(needs.set-env.outputs.prerelease) }}
     steps:
       - name: Download archive
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
       - name: Install twine
         run: python -m pip install twine
       - name: Upload wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         run: tar -cvf artifacts.tar /tmp/pytest-*
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: always() && steps.python_test.outcome == 'failure'
         with:
           name: pytest artifacts


### PR DESCRIPTION
We need to use the older version to avoid issues with Node 20 being used with no way to opt-out, because Node 20 is not supported with our old glibc version that we use on CI.