### PR TITLE
Update `swatinem/rust-cache`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           toolchain: 1.76.0
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.7.0
         with:
           key: x64
 
@@ -106,7 +106,7 @@ jobs:
           toolchain: 1.76.0
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.7.0
         with:
           key: ${{ matrix.arch }}
 
@@ -137,7 +137,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.7.0
         with:
           key: pyhq
       - uses: messense/maturin-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           override: true
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.7.0
 
       - name: Check package versions
         run: python scripts/check_package_versions.py
@@ -111,7 +111,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.7.0
         with:
           key: ${{ matrix.os }}
 


### PR DESCRIPTION
This is the latest version that still uses Node 16.