### PR TITLE
Crash counter increased only when worker fails

### DIFF
--- a/crates/tako/src/internal/server/reactor.rs
+++ b/crates/tako/src/internal/server/reactor.rs
@@ -55,7 +55,7 @@ pub(crate) fn on_remove_worker(
                     task.set_fresh_flag(true);
                     ready_to_assign.push(task_id);
                     if task.is_sn_running() {
-                        if task.increment_crash_counter() {
+                        if reason.is_failure() && task.increment_crash_counter() {
                             crashed_tasks.push(task_id);
                         } else {
                             running_tasks.push(task_id);


### PR DESCRIPTION
When worker does not failed (it is explicitly stopped or time limit is reached then crash counters are not increased).

This is motivated by #739. Now you can stop workers `hq worker stop ...` without worring about crash counters.