### PR TITLE
Bump Python on CI to 3.9

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,9 @@ jobs:
           args: --all
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install Python dependencies
         run: |
@@ -121,9 +121,9 @@ jobs:
         run: cargo run --no-default-features -- --version
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools


### PR DESCRIPTION
We still kind of promise 3.6 Python ABI compabitility, so we should update that soon.