### PR TITLE
Remove assert from `test_submit_sleeps_more_cpus2`

### DIFF
--- a/crates/tako/src/internal/tests/integration/test_resources.rs
+++ b/crates/tako/src/internal/tests/integration/test_resources.rs
@@ -194,7 +194,6 @@ async fn test_submit_sleeps_more_cpus2() {
 
         let duration = start.elapsed().as_millis();
         assert!(duration >= 2000);
-        assert!(duration <= 2300);
     })
     .await;
 }


### PR DESCRIPTION
The duration is not always upheld on CI. I assume that it should be enough to check that the duration took >= 2 seconds (i.e. no more than 3 tasks were running at a time?).