### PR TITLE
Task task id refactoring

### DIFF
--- a/crates/hyperqueue/src/client/commands/submit/command.rs
+++ b/crates/hyperqueue/src/client/commands/submit/command.rs
@@ -741,6 +741,12 @@ pub(crate) async fn send_submit_request(
         SubmitResponse::TaskIdAlreadyExists(task_id) => {
             bail!("Task {task_id} already exists in job {job_id}.")
         }
+        SubmitResponse::NonUniqueTaskId(task_id) => {
+            bail!("Task {task_id} is defined more than once.")
+        }
+        SubmitResponse::InvalidDependencies(task_id) => {
+            bail!("Invalid dependancy on {task_id}")
+        }
     }
     Ok(())
 }

--- a/crates/hyperqueue/src/client/output/common.rs
+++ b/crates/hyperqueue/src/client/output/common.rs
@@ -42,8 +42,8 @@ pub fn resolve_task_paths(job: &JobDetail, server_uid: &str) -> TaskToPathsMap {
 
     job.tasks
         .iter()
-        .map(|task| {
-            let (submit_dir, task_desc) = task_to_desc_map.get(&task.task_id).unwrap();
+        .map(|(task_id, task)| {
+            let (submit_dir, task_desc) = task_to_desc_map.get(task_id).unwrap();
             let paths = match &task_desc.kind {
                 TaskKind::ExternalProgram(TaskKindProgram { program, .. }) => match &task.state {
                     JobTaskState::Canceled {
@@ -58,7 +58,7 @@ pub fn resolve_task_paths(job: &JobDetail, server_uid: &str) -> TaskToPathsMap {
                     } => {
                         let ctx = CompletePlaceholderCtx {
                             job_id: job.info.id,
-                            task_id: task.task_id,
+                            task_id: *task_id,
                             instance_id: started_data.context.instance_id,
                             submit_dir,
                             server_uid,
@@ -80,7 +80,7 @@ pub fn resolve_task_paths(job: &JobDetail, server_uid: &str) -> TaskToPathsMap {
                     _ => None,
                 },
             };
-            (task.task_id, paths)
+            (*task_id, paths)
         })
         .collect()
 }

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -362,7 +362,7 @@ fn format_job_info(info: &JobInfo) -> Value {
 
 fn format_tasks(tasks: &[(JobTaskId, JobTaskInfo)], map: TaskToPathsMap) -> Value {
     tasks
-        .into_iter()
+        .iter()
         .map(|(task_id, task)| {
             let state = &match task.state {
                 JobTaskState::Waiting => "waiting",

--- a/crates/hyperqueue/src/client/output/outputs.rs
+++ b/crates/hyperqueue/src/client/output/outputs.rs
@@ -14,7 +14,6 @@ use crate::server::job::JobTaskInfo;
 use crate::{JobId, JobTaskId};
 use core::time::Duration;
 use tako::resources::ResourceDescriptor;
-use tako::Map;
 
 pub const MAX_DISPLAYED_WORKERS: usize = 2;
 

--- a/crates/hyperqueue/src/client/output/outputs.rs
+++ b/crates/hyperqueue/src/client/output/outputs.rs
@@ -11,9 +11,10 @@ use crate::client::output::common::TaskToPathsMap;
 use crate::client::output::Verbosity;
 use crate::common::arraydef::IntArray;
 use crate::server::job::JobTaskInfo;
-use crate::JobId;
+use crate::{JobId, JobTaskId};
 use core::time::Duration;
 use tako::resources::ResourceDescriptor;
+use tako::Map;
 
 pub const MAX_DISPLAYED_WORKERS: usize = 2;
 
@@ -73,7 +74,7 @@ pub trait Output {
     fn print_task_info(
         &self,
         job: (JobId, JobDetail),
-        tasks: Vec<JobTaskInfo>,
+        tasks: &[(JobTaskId, JobTaskInfo)],
         worker_map: WorkerMap,
         server_uid: &str,
         verbosity: Verbosity,

--- a/crates/hyperqueue/src/client/output/quiet.rs
+++ b/crates/hyperqueue/src/client/output/quiet.rs
@@ -21,7 +21,7 @@ use crate::transfer::messages::{
     AutoAllocListResponse, JobDetail, JobInfo, ServerInfo, WaitForJobsResponse, WorkerExitInfo,
     WorkerInfo,
 };
-use crate::JobId;
+use crate::{JobId, JobTaskId};
 
 #[derive(Default)]
 pub struct Quiet;
@@ -129,7 +129,7 @@ impl Output for Quiet {
     fn print_task_info(
         &self,
         _job: (JobId, JobDetail),
-        _tasks: Vec<JobTaskInfo>,
+        _tasks: &[(JobTaskId, JobTaskInfo)],
         _worker_map: WorkerMap,
         _server_uid: &str,
         _verbosity: Verbosity,

--- a/crates/hyperqueue/src/client/task.rs
+++ b/crates/hyperqueue/src/client/task.rs
@@ -115,7 +115,7 @@ pub async fn output_job_task_info(
         Some(job) => {
             gsettings.printer().print_task_info(
                 (*job_id, job.clone()),
-                job.tasks.clone(),
+                &job.tasks,
                 get_worker_map(session).await?,
                 &response.server_uid,
                 verbosity,
@@ -161,7 +161,7 @@ pub async fn output_job_task_ids(
                         .ok_or_else(|| HqError::GenericError("Job Id not found".to_string()))?
                         .tasks
                         .iter()
-                        .map(|info| info.task_id.as_num()),
+                        .map(|(task_id, _)| task_id.as_num()),
                 ),
             ))
         })

--- a/crates/hyperqueue/src/lib.rs
+++ b/crates/hyperqueue/src/lib.rs
@@ -42,3 +42,28 @@ pub const HQ_VERSION: &str = {
         None => const_format::concatcp!(env!("CARGO_PKG_VERSION"), "-dev"),
     }
 };
+
+pub fn make_tako_id(job_id: JobId, task_id: JobTaskId) -> TakoTaskId {
+    TakoTaskId::new(((job_id.as_num() as u64) << 32) + task_id.as_num() as u64)
+}
+
+pub fn unwrap_tako_id(tako_task_id: TakoTaskId) -> (JobId, JobTaskId) {
+    let num = tako_task_id.as_num();
+    (
+        JobId::new((num >> 32) as u32),
+        JobTaskId::new((num & 0xffffffff) as u32),
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{make_tako_id, unwrap_tako_id, JobId, JobTaskId};
+
+    #[test]
+    fn test_make_tako_id() {
+        assert_eq!(
+            unwrap_tako_id(make_tako_id(JobId(123), JobTaskId(5))),
+            (JobId(123), JobTaskId(5))
+        );
+    }
+}

--- a/crates/hyperqueue/src/server/autoalloc/estimator.rs
+++ b/crates/hyperqueue/src/server/autoalloc/estimator.rs
@@ -58,7 +58,7 @@ pub fn get_server_task_state(state: &State, queue_info: &QueueInfo) -> ServerTas
 fn can_queue_execute_job(job: &Job, queue_info: &QueueInfo) -> bool {
     job.submit_descs
         .iter()
-        .all(|submit_desc| match &submit_desc.0.task_desc {
+        .all(|submit_desc| match &submit_desc.task_desc {
             JobTaskDescription::Array {
                 task_desc: TaskDescription { resources, .. },
                 ..

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -1804,7 +1804,7 @@ mod tests {
     fn attach_job(state: &mut State, job_id: u32, tasks: u32, min_time: TimeRequest) {
         let (job, submit) = create_job(job_id, tasks, min_time);
         state.add_job(job);
-        state.attach_submit(job_id.into(), submit, (job_id * 1_000).into());
+        state.attach_submit(job_id.into(), submit, (job_id as u64 * 1_000).into());
     }
 
     fn create_worker(allocation_id: &str) -> ManagerInfo {

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -1804,7 +1804,7 @@ mod tests {
     fn attach_job(state: &mut State, job_id: u32, tasks: u32, min_time: TimeRequest) {
         let (job, submit) = create_job(job_id, tasks, min_time);
         state.add_job(job);
-        state.attach_submit(job_id.into(), submit, (job_id as u64 * 1_000).into());
+        state.attach_submit(job_id.into(), submit);
     }
 
     fn create_worker(allocation_id: &str) -> ManagerInfo {

--- a/crates/hyperqueue/src/server/client/mod.rs
+++ b/crates/hyperqueue/src/server/client/mod.rs
@@ -30,7 +30,7 @@ mod submit;
 use crate::common::error::HqError;
 use crate::server::client::submit::handle_open_job;
 use crate::server::Senders;
-pub(crate) use submit::submit_job_desc;
+pub(crate) use submit::{submit_job_desc, validate_submit};
 
 pub async fn handle_client_connections(
     state_ref: StateRef,

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -412,6 +412,7 @@ pub(crate) fn handle_open_job(
 #[cfg(test)]
 mod tests {
     use crate::common::arraydef::IntArray;
+    use crate::make_tako_id;
     use crate::server::client::submit::build_tasks_graph;
     use crate::server::client::validate_submit;
     use crate::server::job::Job;
@@ -552,11 +553,29 @@ mod tests {
         ];
 
         let msg = build_tasks_graph(1.into(), &tasks, &PathBuf::from("foo"), None);
-        assert_eq!(msg.tasks[0].task_deps, vec![4.into(), 3.into()]);
-        assert_eq!(msg.tasks[1].task_deps, vec![2.into()]);
-        assert_eq!(msg.tasks[2].task_deps, vec![5.into(), 6.into()]);
+        assert_eq!(
+            msg.tasks[0].task_deps,
+            vec![
+                make_tako_id(1.into(), 2.into()),
+                make_tako_id(1.into(), 1.into())
+            ]
+        );
+        assert_eq!(
+            msg.tasks[1].task_deps,
+            vec![make_tako_id(1.into(), 0.into())]
+        );
+        assert_eq!(
+            msg.tasks[2].task_deps,
+            vec![
+                make_tako_id(1.into(), 3.into()),
+                make_tako_id(1.into(), 4.into())
+            ]
+        );
         assert_eq!(msg.tasks[3].task_deps, vec![]);
-        assert_eq!(msg.tasks[4].task_deps, vec![2.into()]);
+        assert_eq!(
+            msg.tasks[4].task_deps,
+            vec![make_tako_id(1.into(), 0.into()),]
+        );
     }
 
     fn check_shared_data(msg: &NewTasksMessage, expected: Vec<TaskDescription>) {

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -5,16 +5,14 @@ use std::time::Duration;
 
 use bstr::BString;
 use tako::Map;
-use tako::{ItemId, Set};
+use tako::Set;
 
 use tako::gateway::{
     FromGatewayMessage, NewTasksMessage, ResourceRequestVariants, SharedTaskConfiguration,
     TaskConfiguration, ToGatewayMessage,
 };
-use tako::TaskId;
 
 use crate::common::arraydef::IntArray;
-use crate::common::error::HqError;
 use crate::common::placeholders::{
     fill_placeholders_after_submit, fill_placeholders_log, normalize_path,
 };

--- a/crates/hyperqueue/src/server/state.rs
+++ b/crates/hyperqueue/src/server/state.rs
@@ -196,7 +196,7 @@ impl State {
 
     pub fn new_task_id(&mut self, task_count: JobTaskCount) -> TakoTaskId {
         let id = self.task_id_counter;
-        self.task_id_counter += task_count;
+        self.task_id_counter += task_count as u64;
         id.into()
     }
 

--- a/crates/hyperqueue/src/server/state.rs
+++ b/crates/hyperqueue/src/server/state.rs
@@ -92,7 +92,6 @@ impl State {
     }
 
     pub fn add_job(&mut self, job: Job) {
-        assert!(job.submit_descs.is_empty());
         let job_id = job.job_id;
         assert!(self.jobs.insert(job_id, job).is_none());
     }

--- a/crates/hyperqueue/src/server/state.rs
+++ b/crates/hyperqueue/src/server/state.rs
@@ -106,23 +106,29 @@ impl State {
                 job.tasks.reserve(ids.id_count() as usize);
                 ids.iter().enumerate().for_each(|(i, task_id)| {
                     let task_id = JobTaskId::new(task_id);
-                    job.tasks.insert(
-                        task_id,
-                        JobTaskInfo {
-                            state: JobTaskState::Waiting,
-                        },
-                    );
+                    assert!(job
+                        .tasks
+                        .insert(
+                            task_id,
+                            JobTaskInfo {
+                                state: JobTaskState::Waiting,
+                            },
+                        )
+                        .is_none());
                 })
             }
             JobTaskDescription::Graph { tasks } => {
                 job.tasks.reserve(tasks.len());
                 tasks.iter().enumerate().for_each(|(i, task)| {
-                    job.tasks.insert(
-                        task.id,
-                        JobTaskInfo {
-                            state: JobTaskState::Waiting,
-                        },
-                    );
+                    assert!(job
+                        .tasks
+                        .insert(
+                            task.id,
+                            JobTaskInfo {
+                                state: JobTaskState::Waiting,
+                            },
+                        )
+                        .is_none());
                 })
             }
         };

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -421,7 +421,7 @@ pub struct JobDetail {
     pub info: JobInfo,
     pub job_desc: JobDescription,
     pub submit_descs: Vec<Arc<JobSubmitDescription>>,
-    pub tasks: Vec<JobTaskInfo>,
+    pub tasks: Vec<(JobTaskId, JobTaskInfo)>,
     pub tasks_not_found: Vec<JobTaskId>,
 
     // Date when job was submitted

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -380,6 +380,8 @@ pub enum SubmitResponse {
     JobNotOpened,
     JobNotFound,
     TaskIdAlreadyExists(JobTaskId),
+    NonUniqueTaskId(JobTaskId),
+    InvalidDependencies(JobTaskId),
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/tako/src/internal/worker/test_util.rs
+++ b/crates/tako/src/internal/worker/test_util.rs
@@ -102,7 +102,7 @@ impl ResourceQueueBuilder {
         self.queue
             .try_start_tasks(&self.task_map, None)
             .into_iter()
-            .map(|(t, a, _)| (t.as_num() as u64, a))
+            .map(|(t, a, _)| (t.as_num(), a))
             .collect()
     }
 
@@ -110,7 +110,7 @@ impl ResourceQueueBuilder {
         self.queue
             .try_start_tasks(&self.task_map, Some(duration))
             .into_iter()
-            .map(|(t, a, _)| (t.as_num() as u64, a))
+            .map(|(t, a, _)| (t.as_num(), a))
             .collect()
     }
 }

--- a/crates/tako/src/lib.rs
+++ b/crates/tako/src/lib.rs
@@ -16,7 +16,7 @@ pub use crate::internal::common::WrappedRcRefCell;
 pub use crate::internal::common::{Map, Set};
 
 define_id_type!(WorkerId, u32);
-define_id_type!(TaskId, u32);
+define_id_type!(TaskId, u64);
 define_id_type!(InstanceId, u32);
 
 // Priority: Bigger number -> Higher priority

--- a/tests/job/test_job_cat.py
+++ b/tests/job/test_job_cat.py
@@ -146,7 +146,6 @@ assert os.environ['HQ_TASK_ID'] not in ['4', '5', '6', '8']
         ]
     )
     wait_for_job_state(hq_env, 1, "FAILED")
-
     output = hq_env.command(["job", "cat", "--task-status=finished", "1", "stdout", "--print-task-header"])
     assert (
         output


### PR DESCRIPTION
This PR makes Tako's TaskId as u64, this allows to encode JobId and JobTaskId directoly into TakoId. It allows to remove translation lookups between TakoId and JobTaskId/TakoId.  It also allows to have keys in the map of tasks in Job directly JobTaskIds (and not TakoTaskId), that allows to remove some creating ad-hoc sets of JobTaskIds and directly do a lookup into tasks.