### PR TITLE
Fix alloc resume message

### DIFF
--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -442,7 +442,7 @@ async fn resume_queue(mut session: ClientSession, opts: ResumeQueueOpts) -> anyh
     )
     .await?;
 
-    log::info!("Allocation queue {queue_id} successfully paused");
+    log::info!("Allocation queue {queue_id} successfully resumed");
 
     Ok(())
 }


### PR DESCRIPTION
Currently resuming a paused alloc prints the same message as pausing it. This is probably a remnant of some copy-and-pasting.

This commit fixes the message to properly show the word "resumed" instead of "paused".