### PR TITLE
Update glibc version from 2.17 to 2.28

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,12 +8,6 @@
   "schedule": [
     "at 7:00am on monday"
   ],
-  // These deps require NodeJS 20, which we can't use yet on CI due to old glibc version
-  "ignoreDeps": [
-    "Swatinem/rust-cache",
-    "actions/download-artifact",
-    "actions/upload-artifact"
-  ],
   // Group Rust updates into a single PR
   "packageRules": [
     {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       sha: ${{ env.HQ_SHA }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set version
         run: |
           echo "HQ_VERSION=${{ inputs.version || 'dev' }}" | tee -a $GITHUB_ENV
@@ -33,19 +33,13 @@ jobs:
   build-binaries-x64:
     needs: [ set-env ]
     runs-on: ubuntu-latest
-    env:
-      # We need to avoid using NodeJS v20, because it doesn't work with glibc 2.17.
-      # See https://github.com/actions/checkout/issues/1809.
-      ACTIONS_RUNNER_FORCED_INTERNAL_NODE_VERSION: node16
-      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-    # Use a container with GLIBC 2.17
-    container: quay.io/pypa/manylinux2014_x86_64
+    # Use a container with GLIBC 2.28
+    container: quay.io/pypa/manylinux_2_28_x86_64
     steps:
       - name: Show GLIBC
         run: ldd --version
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.set-env.outputs.sha }}
       - name: Install stable toolchain
@@ -96,7 +90,7 @@ jobs:
             name: arm64-linux
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.set-env.outputs.sha }}
       - name: Install stable toolchain
@@ -136,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2.7.0
         with:
           key: pyhq
@@ -148,7 +142,7 @@ jobs:
         with:
           docker-options: -e HQ_BUILD_VERSION=${{ needs.set-env.outputs.version }}
           maturin-version: 1.3.0
-          manylinux: 2014
+          manylinux: 2_28
           command: build
           args: --manifest-path crates/pyhq/Cargo.toml --profile dist --out wheels
       - name: Install Python wheel

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
       version: ${{ env.HQ_VERSION }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set HQ nightly version
         run: |
           echo "HQ_VERSION=nightly-$(date +'%Y-%m-%d')-${{ github.sha }}" >> $GITHUB_ENV
@@ -28,7 +28,7 @@ jobs:
     needs: [ set-env, build-artifacts ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create tag
         uses: rickstaa/action-create-tag@v1
         with:
@@ -40,7 +40,7 @@ jobs:
     needs: [ create-tag ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate changelog
         run: python3 scripts/extract_changelog.py DEV > generated-changelog.md

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -44,12 +44,12 @@ jobs:
           echo "Tag: ${{ env.TAG }}"
   build:
     runs-on: ubuntu-latest
-    needs: [set-env]
+    needs: [ set-env ]
     env:
       container: ghcr.io/it4innovations/hyperqueue
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.set-env.outputs.sha }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Dev
 
+### Breaking change
+* Pre-built HyperQueue releases available from our GitHub repository are now built with GLIBC `2.28`, instead of `2.17`. If you need to run HyperQueue on a system with an older GLIBC version, you might need to recompile it from source on your system. If you encounter any issues, please let us know.
+
 ### Changes
 
 * `hq event-log` command renamed to `hq journal`
@@ -615,7 +618,7 @@ would pass `OMP_NUM_THREADS=4` to the executed `<program>`.
   is `hq submit`, which is now a shortcut for `hq job submit`. Here is a table of changed commands:
 
   | **Previous command** | **New command**    |
-            |----------------------|--------------------|
+                |----------------------|--------------------|
   | `hq jobs`            | `hq job list`    |
   | `hq job`             | `hq job info`    |
   | `hq resubmit`        | `hq job resubmit` |
@@ -731,7 +734,7 @@ would pass `OMP_NUM_THREADS=4` to the executed `<program>`.
 
 * Generic resource management has been added. You can find out more in
   the [documentation](https://it4innovations.github.io/hyperqueue/stable/jobs/gresources/).
-    * HyperQueue can now automatically detect how many Nvidia GPUs are present on a worker node.
+  * HyperQueue can now automatically detect how many Nvidia GPUs are present on a worker node.
 * You can now submit a task array where each task will receive one element of a JSON array using
   `hq submit --from-json`. You can find out more in
   the [documentation](https://it4innovations.github.io/hyperqueue/stable/jobs/arrays/#json-array).
@@ -739,10 +742,10 @@ would pass `OMP_NUM_THREADS=4` to the executed `<program>`.
 ### Changes
 
 * There have been a few slight CLI changes:
-    * `hq worker list` no longer has `--offline` and `--online` flags. It will now display only running
-      workers by default. If you want to show also offline workers, use the `--all` flag.
-    * `hq alloc add` no longer has a required `--queue/--partition` option. The PBS queue/Slurm partition
-      should now be passed as a trailing argument after `--`: `hq alloc add pbs -- -qqprod`.
+  * `hq worker list` no longer has `--offline` and `--online` flags. It will now display only running
+    workers by default. If you want to show also offline workers, use the `--all` flag.
+  * `hq alloc add` no longer has a required `--queue/--partition` option. The PBS queue/Slurm partition
+    should now be passed as a trailing argument after `--`: `hq alloc add pbs -- -qqprod`.
 * Server subdirectories generated for each run of the HyperQueue server are now named with a numeric ID instead of
   a date.
 * The documentation has been [rewritten](https://it4innovations.github.io/hyperqueue).


### PR DESCRIPTION
This is required because GitHub Actions no longer allows us to run the legacy base images with glibc 2.17. If you want to run HQ on a system with an older glibc version, you might need to recompile it from source.