### PR TITLE
Simplify a few CI actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,9 @@ jobs:
           key: x64
 
       - name: Compile
-        uses: actions-rs/cargo@v1
         env:
           HQ_BUILD_VERSION: ${{ needs.set-env.outputs.version }}
-        with:
-          command: build
-          args: --profile dist
+        run: cargo build --profile dist
 
       - name: Compress debuginfo
         run: objcopy --compress-debug-sections=zlib-gnu target/dist/hq
@@ -162,11 +159,9 @@ jobs:
           cat version-expected.txt
           cmp --silent version-expected.txt version.txt
       - name: Compile
-        uses: actions-rs/cargo@v1
         env:
           HQ_BUILD_VERSION: ${{ needs.set-env.outputs.version }}
-        with:
-          command: build
+        run: cargo build
       - name: Test Python wheel
         run: |
           source venv/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,16 +29,10 @@ jobs:
         run: python scripts/check_package_versions.py
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all --all-targets
+        run: cargo build --workspace --all-targets
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
+        run: cargo test --workspace
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -72,16 +66,10 @@ jobs:
           path: artifacts.tar
 
       - name: Lint Rust
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all -- -D warnings
+        run: cargo clippy --workspace -- -D warnings
 
       - name: Check Rust formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Lint Python
         run: python -m ruff check


### PR DESCRIPTION
The `actions-rs/cargo@v1` action is not needed in most cases, and `--all` has been deprecated in favour of `--workspace`.