### PR TITLE
Make allocation status sync more robust

### DIFF
--- a/crates/hyperqueue/src/client/autoalloc.rs
+++ b/crates/hyperqueue/src/client/autoalloc.rs
@@ -7,7 +7,7 @@ impl AllocationState {
                 disconnected_workers,
                 ..
             } => disconnected_workers.all_crashed(),
-            AllocationState::Invalid { failed, .. } => *failed,
+            AllocationState::FinishedUnexpectedly { failed, .. } => *failed,
             AllocationState::Queued | AllocationState::Running { .. } => false,
         }
     }

--- a/crates/hyperqueue/src/client/autoalloc.rs
+++ b/crates/hyperqueue/src/client/autoalloc.rs
@@ -8,7 +8,7 @@ impl AllocationState {
                 ..
             } => disconnected_workers.all_crashed(),
             AllocationState::FinishedUnexpectedly { failed, .. } => *failed,
-            AllocationState::Queued | AllocationState::Running { .. } => false,
+            AllocationState::Queued { .. } | AllocationState::Running { .. } => false,
         }
     }
 }

--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -452,7 +452,7 @@ fn filter_allocations(allocations: &mut Vec<Allocation>, filter: Option<Allocati
         allocations.retain(|allocation| {
             let status = &allocation.status;
             match filter {
-                AllocationStateFilter::Queued => matches!(status, AllocationState::Queued),
+                AllocationStateFilter::Queued => matches!(status, AllocationState::Queued { .. }),
                 AllocationStateFilter::Running => {
                     matches!(status, AllocationState::Running { .. })
                 }

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -1014,7 +1014,7 @@ fn stdio_to_str(stdio: &StdioDef) -> &str {
 // Allocation
 fn allocation_status_to_cell(status: &AllocationState) -> CellStruct {
     match status {
-        AllocationState::Queued => "QUEUED".cell().foreground_color(Some(Color::Yellow)),
+        AllocationState::Queued { .. } => "QUEUED".cell().foreground_color(Some(Color::Yellow)),
         AllocationState::Running { .. } => "RUNNING".cell().foreground_color(Some(Color::Blue)),
         AllocationState::Finished { .. } | AllocationState::FinishedUnexpectedly { .. } => {
             match status.is_failed() {
@@ -1030,7 +1030,7 @@ fn allocation_times_from_alloc(allocation: &Allocation) -> AllocationTimes {
     let mut finished = None;
 
     match &allocation.status {
-        AllocationState::Queued => {}
+        AllocationState::Queued { .. } => {}
         AllocationState::Running { started_at, .. } => {
             started = Some(started_at);
         }

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -1016,7 +1016,7 @@ fn allocation_status_to_cell(status: &AllocationState) -> CellStruct {
     match status {
         AllocationState::Queued => "QUEUED".cell().foreground_color(Some(Color::Yellow)),
         AllocationState::Running { .. } => "RUNNING".cell().foreground_color(Some(Color::Blue)),
-        AllocationState::Finished { .. } | AllocationState::Invalid { .. } => {
+        AllocationState::Finished { .. } | AllocationState::FinishedUnexpectedly { .. } => {
             match status.is_failed() {
                 true => "FAILED".cell().foreground_color(Some(Color::Red)),
                 false => "FINISHED".cell().foreground_color(Some(Color::Green)),
@@ -1042,7 +1042,7 @@ fn allocation_times_from_alloc(allocation: &Allocation) -> AllocationTimes {
             started = Some(started_at);
             finished = Some(finished_at);
         }
-        AllocationState::Invalid {
+        AllocationState::FinishedUnexpectedly {
             started_at,
             finished_at,
             ..

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -452,7 +452,7 @@ fn format_allocation(allocation: Allocation) -> serde_json::Value {
     } = allocation;
 
     let status_name = match &status {
-        AllocationState::Queued => "queued",
+        AllocationState::Queued { .. } => "queued",
         AllocationState::Running { .. } => "running",
         AllocationState::Finished { .. } | AllocationState::FinishedUnexpectedly { .. } => {
             match status.is_failed() {

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -454,7 +454,7 @@ fn format_allocation(allocation: Allocation) -> serde_json::Value {
     let status_name = match &status {
         AllocationState::Queued => "queued",
         AllocationState::Running { .. } => "running",
-        AllocationState::Finished { .. } | AllocationState::Invalid { .. } => {
+        AllocationState::Finished { .. } | AllocationState::FinishedUnexpectedly { .. } => {
             match status.is_failed() {
                 true => "failed",
                 false => "finished",

--- a/crates/hyperqueue/src/server/autoalloc/config.rs
+++ b/crates/hyperqueue/src/server/autoalloc/config.rs
@@ -42,3 +42,14 @@ pub const SUBMISSION_DELAYS: [Duration; 5] = [
     Duration::from_secs(30 * 60),
     Duration::from_secs(60 * 60),
 ];
+
+/// Maximum number of status errors that can be received for a queued allocation
+/// before that allocation will be assumed to be finished.
+pub const MAX_QUEUED_STATUS_ERROR_COUNT: u32 = 10;
+
+/// Maximum number of status errors that can be received for a running allocation
+/// before that allocation will be assumed to be finished.
+///
+/// We don't want to end running allocations too quickly, so we give a bit more leeway here than
+/// for queued allocations.
+pub const MAX_RUNNING_STATUS_ERROR_COUNT: u32 = 20;

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -502,6 +502,10 @@ async fn refresh_queue_allocations(
     match result {
         Ok(mut status_map) => {
             let queue = get_or_return!(autoalloc.get_queue_mut(id));
+            log::debug!(
+                "Active allocations of queue {id} before update\n{:?}",
+                queue.active_allocations().collect::<Vec<_>>()
+            );
             for allocation_id in allocation_ids {
                 let status = status_map.remove(&allocation_id).unwrap_or_else(|| {
                     Ok(AllocationExternalStatus::Failed {
@@ -524,6 +528,10 @@ async fn refresh_queue_allocations(
                     }
                 }
             }
+            log::debug!(
+                "Active allocations of queue {id} after update\n{:?}",
+                queue.active_allocations().collect::<Vec<_>>()
+            );
         }
         Err(error) => {
             log::error!("Failed to get allocations status from queue {id}: {error:?}");

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -394,7 +394,7 @@ async fn process_queue(
     let try_to_submit = {
         let queue = get_or_return!(autoalloc.get_queue_mut(id));
         if !queue.state().is_running() {
-            false
+            return;
         } else {
             let limiter = queue.limiter_mut();
 
@@ -846,6 +846,9 @@ async fn remove_inactive_directories(autoalloc: &mut AutoAllocState) {
 
 fn try_pause_queue(autoalloc: &mut AutoAllocState, id: QueueId) {
     let queue = get_or_return!(autoalloc.get_queue_mut(id));
+    if !queue.state().is_running() {
+        return;
+    }
     let limiter = queue.limiter();
 
     let status = limiter.submission_status();

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -262,7 +262,7 @@ pub struct DisconnectedWorkers {
 }
 
 impl DisconnectedWorkers {
-    pub fn on_worker_lost(&mut self, worker_id: WorkerId, details: LostWorkerDetails) {
+    pub fn add_lost_worker(&mut self, worker_id: WorkerId, details: LostWorkerDetails) {
         self.workers.insert(worker_id, details);
     }
     pub fn count(&self) -> u64 {

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -112,7 +112,13 @@ impl AutoAllocState {
 pub type QueueId = u32;
 
 pub enum AllocationQueueState {
+    /// The queue is being processed as normal.
     Running,
+    /// The queue is paused. Its allocations are still being refreshed, but no new allocations
+    /// will be submitted until the queue is resumed.
+    ///
+    /// A queue can be paused manually by a user, or automatically by autoalloc itself, after too
+    /// many submission/allocation failures.
     Paused,
 }
 

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -306,7 +306,7 @@ pub enum AllocationState {
         disconnected_workers: DisconnectedWorkers,
     },
     // Zero (or not enough) workers have connected, but the allocation has been finished.
-    Invalid {
+    FinishedUnexpectedly {
         connected_workers: Set<WorkerId>,
         disconnected_workers: DisconnectedWorkers,
         started_at: Option<SystemTime>,

--- a/tests/autoalloc/mock/manager.py
+++ b/tests/autoalloc/mock/manager.py
@@ -3,7 +3,7 @@ import datetime
 import enum
 from abc import ABC
 from subprocess import Popen
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from ...conftest import HqEnv
 from .handler import CommandResponse, MockInput, response, response_error
@@ -19,6 +19,9 @@ class Manager(ABC):
     async def handle_delete(self, input: MockInput) -> Optional[CommandResponse]:
         return response_error()
 
+    def parse_status_job_ids(self, input: MockInput) -> List[str]:
+        raise NotImplementedError()
+
 
 class WrappedManager(Manager):
     def __init__(self, inner: Manager):
@@ -32,6 +35,9 @@ class WrappedManager(Manager):
 
     async def handle_delete(self, input: MockInput) -> Optional[CommandResponse]:
         return await self.inner.handle_delete(input)
+
+    def parse_status_job_ids(self, input: MockInput) -> List[str]:
+        return self.inner.parse_status_job_ids(input)
 
 
 class JobStatus(enum.Enum):

--- a/tests/autoalloc/mock/mock.py
+++ b/tests/autoalloc/mock/mock.py
@@ -29,8 +29,8 @@ def prepare_redirector(path: Path, port: int, key: str):
 
 class MockJobManager:
     """
-    Creates a mock job manager that intercepts job manager (PBS) in the given `hq_env` and passes
-    them to the given `handler`.
+    Creates a mock job manager that intercepts job manager (PBS/Slurm) in the given `hq_env` and
+    passes them to the given `handler`.
     """
 
     def __init__(

--- a/tests/autoalloc/mock/pbs.py
+++ b/tests/autoalloc/mock/pbs.py
@@ -42,15 +42,18 @@ def adapt_pbs(handler: Manager) -> CommandHandler:
 
 
 class PbsManager(DefaultManager):
-    async def handle_status(self, input: MockInput) -> CommandResponse:
+    def parse_status_job_ids(self, input: MockInput) -> List[str]:
         job_ids = []
         args = input.arguments
         for index, arg in enumerate(args[:-1]):
             if arg == "-f":
                 job_ids.append(args[index + 1])
-
         if not job_ids:
             raise Exception(f"Did not find -f in arguments: {args}")
+        return job_ids
+
+    async def handle_status(self, input: MockInput) -> CommandResponse:
+        job_ids = self.parse_status_job_ids(input)
         for job_id in job_ids:
             assert job_id[0].isdigit()
 

--- a/tests/autoalloc/mock/slurm.py
+++ b/tests/autoalloc/mock/slurm.py
@@ -1,6 +1,6 @@
 import datetime
 from subprocess import Popen
-from typing import Optional
+from typing import Optional, List
 
 from aiohttp.web_request import Request
 
@@ -50,9 +50,15 @@ def to_slurm_duration(duration: datetime.timedelta) -> str:
 
 
 class SlurmManager(DefaultManager):
-    async def handle_status(self, input: MockInput) -> CommandResponse:
+    def parse_status_job_ids(self, input: MockInput) -> List[str]:
         assert input.arguments[:2] == ["show", "job"]
         job_id = input.arguments[2]
+        return [job_id]
+
+    async def handle_status(self, input: MockInput) -> CommandResponse:
+        job_ids = self.parse_status_job_ids(input)
+        assert len(job_ids) == 1
+        job_id = job_ids[0]
 
         content = ""
         job_data = self.jobs[job_id]


### PR DESCRIPTION
This PR refactors the status updates of allocations in autoalloc, based on external events that come from the allocation manager. It also tries to make the status updates more robust, in order to solve https://github.com/It4innovations/hyperqueue/issues/764.

(Hopefully) fixes: https://github.com/It4innovations/hyperqueue/issues/764