### PR TITLE
Update `upload-artifact` and `download-artifact` actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           echo "::set-output name=archive-name::$ARCHIVE_NAME"
 
       - name: Store archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: archive-x64
           path: ${{ steps.archive.outputs.archive-name }}
@@ -118,7 +118,7 @@ jobs:
           echo "::set-output name=archive-name::$ARCHIVE_NAME"
 
       - name: Store archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: archive-${{ matrix.name }}
           path: ${{ steps.archive.outputs.archive-name }}
@@ -167,7 +167,7 @@ jobs:
           source venv/bin/activate
           python3 -m pytest tests/pyapi
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: archive-pyhq
           path: wheels/hyperqueue-*.whl

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
         run: python3 scripts/extract_changelog.py DEV > generated-changelog.md
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Prepare release name
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         run: python3 scripts/extract_changelog.py ${{ needs.set-env.outputs.tag }} > generated-changelog.md
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Create release
         uses: ncipollo/release-action@v1
@@ -87,7 +87,7 @@ jobs:
     if: ${{ !fromJSON(needs.set-env.outputs.prerelease) }}
     steps:
       - name: Download archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Install twine
         run: python -m pip install twine
       - name: Upload wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         run: tar -cvf artifacts.tar /tmp/pytest-*
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && steps.python_test.outcome == 'failure'
         with:
           name: pytest artifacts


### PR DESCRIPTION
We no longer rely on old glibc and old NodeJS versions, so we can update these actions.