### PR TITLE
Update output streaming documentation

### DIFF
--- a/crates/hyperqueue/src/worker/streamer.rs
+++ b/crates/hyperqueue/src/worker/streamer.rs
@@ -74,10 +74,12 @@ impl Streamer {
                 stream_path.display()
             );
             if !stream_path.is_dir() {
-                return Err(HqError::GenericError(format!(
-                    "Stream path {} is not a directory.",
-                    stream_path.display()
-                )));
+                std::fs::create_dir_all(stream_path).map_err(|error| {
+                    HqError::GenericError(format!(
+                        "Cannot create stream directory {}: {error:?}",
+                        stream_path.display()
+                    ))
+                })?;
             }
             let (queue_sender, queue_receiver) = channel(STREAMER_BUFFER_SIZE);
             let stream = StreamDescriptor {

--- a/docs/deployment/worker.md
+++ b/docs/deployment/worker.md
@@ -19,7 +19,7 @@ $ hq worker start
 ```
 
 Each worker will be assigned a unique ID that you can use in later commands to query information about the worker or to
-[stop](#stopping-worker) it.
+[stop](#stopping-workers) it.
 
 By default, the worker will try to connect to a server using the default [server directory](server.md#server-directory).
 If you want to connect to a different server, use the `--server-dir` option.

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -192,21 +192,21 @@ If no priority is specified, then each task will have priority `0`.
 ### Placeholders
 
 You can use special variables when setting certain job parameters ([working directory](#working-directory),
-[output](#output) paths, [log](streaming.md#redirecting-output-to-the-log) path). These variables, called
+[output](#output) paths, [stream](streaming.md#redirecting-task-output) path). These variables, called
 **Placeholders**, will be replaced by job or task-specific information before the job is executed.
 
 Placeholders are enclosed in curly braces (`{}`) and prefixed with a percent (`%`) sign.
 
 You can use the following placeholders:
 
-| Placeholder      | Will be replaced by                         | Available for                    |
-|------------------|---------------------------------------------|----------------------------------|
-| `%{JOB_ID}`      | Job ID                                      | `stdout`, `stderr`, `cwd`, `log` |
-| `%{TASK_ID}`     | Task ID                                     | `stdout`, `stderr`, `cwd`        |
-| `%{INSTANCE_ID}` | [Instance ID](failure.md#task-restart)      | `stdout`, `stderr`, `cwd`        |
-| `%{SUBMIT_DIR}`  | Directory from which the job was submitted. | `stdout`, `stderr`, `cwd`, `log` |
-| `%{CWD}`         | Working directory of the task.              | `stdout`, `stderr`               |
-| `%{SERVER_UID}`  | Unique server ID.                           | `stdout`, `stderr`, `cwd`, `log` |
+| Placeholder      | Will be replaced by                         | Available for                           |
+|------------------|---------------------------------------------|-----------------------------------------|
+| `%{JOB_ID}`      | Job ID                                      | `stdout`, `stderr`, `cwd`, `stream-dir` |
+| `%{TASK_ID}`     | Task ID                                     | `stdout`, `stderr`, `cwd`               |
+| `%{INSTANCE_ID}` | [Instance ID](failure.md#task-restart)      | `stdout`, `stderr`, `cwd`               |
+| `%{SUBMIT_DIR}`  | Directory from which the job was submitted. | `stdout`, `stderr`, `cwd`, `stream-dir` |
+| `%{CWD}`         | Working directory of the task.              | `stdout`, `stderr`                      |
+| `%{SERVER_UID}`  | Unique server ID.                           | `stdout`, `stderr`, `cwd`, `stream-dir` |
 
 `SERVER_UID` is a random string that is unique for each new server execution (each `hq server start` gets a separate
 value).

--- a/docs/jobs/streaming.md
+++ b/docs/jobs/streaming.md
@@ -1,6 +1,4 @@
-Jobs containing [many tasks](arrays.md) will generate a large amount of `stdout` and `stderr` files, which can be
-problematic, especially on network-based shared filesystems, such as Lustre. For example, when you submit the following
-task array:
+Jobs containing [many tasks](arrays.md) will generate a large amount of `stdout` and `stderr` files, which can cause performance issues, especially on network-based shared filesystems, such as Lustre. For example, when you submit the following task array:
 
 ```bash
 $ hq submit --array=1-10000 my-computation.sh
@@ -8,8 +6,8 @@ $ hq submit --array=1-10000 my-computation.sh
 
 `20000` files (`10000` for stdout and `10000` for stderr) will be created on the disk.
 
-To avoid this situation, HyperQueue can optionally stream the `stdout` and `stderr` output of
-tasks into a compact format that do not create a file per task.
+To avoid this issue, HyperQueue can optionally stream the `stdout` and `stderr` output of
+tasks into a smaller number of files stored in a compact binary format.
 
 !!! note
 
@@ -19,26 +17,23 @@ tasks into a compact format that do not create a file per task.
 <img width="600" src="../../imgs/streaming.png">
 </p>
 
-## Redirecting output to the stream
+## Redirecting task output
 
-You can redirect the output of `stdout` and `stderr` to a log file and thus enable output streaming by passing a path
-to a filename where the log will be stored with the `--stream` option:
+You can enable output streaming by using the `--stream` option of the `submit` command. You should pass it a path to a directory on disk where the streamed `stdout` and `stderr` output will be stored.
 
 ```
-$ hq submit --stream=<output-log-path> --array=1-10_000 ...
+$ hq submit --stream=<stream-dir> --array=1-10_000 ...
 ```
 
-Output log path has to be a directory and it the user responsibility to ensure existence of the directory
-and visibility of each worker.
+!!! warning
 
-This command would cause the `stdout` and `stderr` of all `10_000` tasks to be streamed into the server, which will
-write them to files in `<output-log-path>`. The streamed data is written in a compact way independently on the number of
-tasks. The format also contains additional metadata,
-which allows the resulting file to be filtered/sorted by tasks or channel.
+    It is the user's responsibility to ensure that the `<stream-dir>` path is accessible and writable by each worker that might execute tasks of the submitted job. See also [Working with a non-shared file system](#working-with-a-non-shared-file-system).
+
+The command above will cause the `stdout` and `stderr` of all `10_000` tasks to be streamed in a compact way into a small number of files located in `<stream-dir>`. Note that the number of files created in the directory will be independent of the number of tasks of the job, thus alleviating the performance issue on networked filesystems. The created binary files will also contain additional metadata, which allows the resulting files to be filtered/sorted by tasks or channel.
 
 !!! tip
 
-    You can use selected [placeholders](jobs.md#placeholders) inside the stream path.
+    You can use selected [placeholders](jobs.md#placeholders) inside the stream directory path.
 
 ### Partial redirection
 
@@ -71,55 +66,53 @@ streaming file. With the following two exceptions:
 - When a task is `Canceled` or task fails because of [time limit](jobs.md#time-management) is reached, then the part of
   its stream that was buffered in the worker is dropped to avoid spending additional resources for this task.
 
-## Inspecting the stream files
+## Inspecting the stream data
 
-HyperQueue lets you inspect the data stored inside the stream file using various subcommands. All these commands have
-the following structure:
+HyperQueue lets you inspect the data stored inside the stream directory using various subcommands. All these commands have the following structure:
 
 ```bash
-$ hq output-log <output-log-path> <subcommand> <subcommand-args>
+$ hq output-log <stream-dir> <subcommand> <subcommand-args>
 ```
 
 ### Stream summary
 
-You can display a summary of a log file using the `summary` subcommand:
+You can display a summary of a stream directory using the `summary` subcommand:
 
 ```bash
-$ hq output-log <output-log-path> summary
+$ hq output-log <stream-dir> summary
 ```
 
 ### Stream jobs
 
-To print all job IDs that streaming in the stream path, you can run the following command:
+To print all job IDs that streaming in the stream directory, you can run the following command:
 
 ```bash
-$ hq output-log <output-log-path> jobs
+$ hq output-log <stream-dir> jobs
 ```
 
 ### Printing stream content
 
-If you want to simply print the (textual) content of the log file, without any associating metadata, you can use the
-`cat` subcommand:
+If you want to simply print the (textual) content of the stream directory contents, without any associating metadata, you can use the `cat` subcommand:
 
 ```bash
-$ hq output-log <output-log-path> cat <job-id> <stdout/stderr>
+$ hq output-log <stream-dir> cat <job-id> <stdout/stderr>
 ```
 
 It will print the raw content of either `stdout` or `stderr`, ordered by task id. All outputs will be concatenated one
 after another. You can use this to process the streamed data e.g. by a postprocessing script.
 
 By default, this command will fail if there is an unfinished stream (i.e. when some task is still running and streaming
-data into the log). If you want to use `cat` even when the log is not finished yet, use the `--allow-unfinished` option.
+data into the streaming directory). If you want to use `cat` even when streaming has not finished yet, use the `--allow-unfinished` option.
 
 If you want to see the output of a specific task, you can use the `--task=<task-id>` option.
 
 ### Stream metadata
 
-If you want to inspect the contents of the log, along with its inner metadata that shows which task and which channel
+If you want to inspect the contents of the stream directory along with its inner metadata that shows which task and which channel
 has produced which part of the data, you can use the `show` subcommand:
 
 ```commandline
-$ hq output-log <log-file-path> show
+$ hq output-log <stream-directory> show
 ```
 
 The output will have the form `J.T:C> DATA` where `J` is a job id, `T` is a task id and `C` is `0` for `stdout` channel
@@ -127,15 +120,15 @@ and `1` for `stderr` channel.
 
 You can filter a specific channel with the `--channel=stdout/stderr` flag.
 
-### Exporting log
+### Exporting the stream data
 
-Log can be exported into JSON by the following command:
+The contents of the stream directory can be exported into JSON by the following command:
 
 ```commandline
-$ hq output-log <log-file-path> export
+$ hq output-log <stream-dir> export
 ```
 
-This prints the log file into a JSON format on standard output.
+This prints the streamed data into a JSON format to standard output.
 
 ### Superseded streams
 
@@ -145,23 +138,23 @@ hence HyperQueue streaming is able to avoid mixing
 outputs from different executions of the same task, when a task is restarted.
 
 HyperQueue automatically marks all output from previous instance of a task except the last instance as *superseded*.
-You can see statistics about superseded data via `hq output-log <output-log-path> summary` command.
+You can see statistics about superseded data via `hq output-log <stream-dir> summary` command.
 In the current version, superseded data is ignored by all other commands.
 
-## More server instances
+## Multiple server instances
 
 HyperQueue supports writing streams from the different server instances into the same directory.
-If you run `hq output-log` commands over such directory then it will detect the situation and prints all server uids
-that writes into the directory. You have to specify the server instance
+If you run `hq output-log` commands over such directory then it will detect the situation and print all server UIDs
+that write into the directory. You have to specify the server instance
 via `hq output-log --server-uid=<SERVER_UID> ...`
-when working with such a output log directory.
+when working with such a streaming directory.
 
 !!! note
 
-    When a server is restored from a journal file, it will maintain the same server UID. When a server is 
-    started "from a scratch" a new server uid is generated.
+    When a server is restored from a journal file, it will maintain the same server UID. When a server is started "from a scratch" a new server UID is generated.
 
-## Working with non-shared file system
+## Working with a non-shared file system
 
-You do not need to have a shared file system when working with streaming. It is just your responsibility to
-collect all generated files into one directory before using `hq output-log` commands.
+You do not need to have a shared file system when working with streaming. You just have to collect all generated files from the streaming directories in the different file systems into a single directory before using the `hq output-log` commands.
+
+For example, you could use `/tmp/hq-stream` as a stream directory, which can be a local disk path on each worker, and then merge the contents of all such directories and use `hq output-log` on the resulting merged directory.


### PR DESCRIPTION
It was a bit outdated in a few places.

This PR also creates the streaming directory if it does not exist, instead of returning an error, to match the documentation. I'm not sure if the creation was problematic for some reason, if so, we should add a comment explaining why that is.