### PR TITLE
Fix command failing after a few seconds

### DIFF
--- a/crates/hyperqueue/src/worker/start/program.rs
+++ b/crates/hyperqueue/src/worker/start/program.rs
@@ -520,9 +520,8 @@ async fn create_task_future(
 
     log::trace!("Running command {:?}", command);
 
-    let mut child = tokio::task::spawn_blocking(move || command.spawn())
-        .await
-        .expect("Command spawning failed")
+    let mut child = command
+        .spawn()
         .map_err(|error| map_spawn_error(error, &program))?;
     let pid = match child.id() {
         Some(pid) => pid,

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -64,3 +64,16 @@ def test_task_info(hq_env: HqEnv):
     hq_env.command(["submit", "--", "bash", "-c", "uname"])
     r = hq_env.command(["task", "info", "last", "0"], as_table=True)
     assert r.get_row_value("Task ID") == "0"
+
+
+def test_long_running_task(hq_env: HqEnv):
+    """
+    We had a very nasty bug (https://github.com/It4innovations/hyperqueue/issues/820) where
+    tasks were getting killed when tokio periodically reaped blocking worker threads.
+    This is not a perfect test against that, but at least we can check that tasks can live longer
+    than ~15s...
+    """
+    hq_env.start_server()
+    hq_env.start_worker()
+    hq_env.command(["submit", "sleep", "20"])
+    wait_for_job_state(hq_env, 1, "FINISHED", timeout_s=30)


### PR DESCRIPTION
This is a fun one. Since https://github.com/It4innovations/hyperqueue/pull/798 (yeah, that was *not* a good idea...), commands are being spawned in a tokio worker thread to optimize spawning when a lot of commands are being spawned at once.

This interacts poorly with our usage of `PR_SET_PDEATHSIG`, because the child process is not killed when the parent process (the worker) dies, but when the parent *thread* dies. This is very unfortunate, because now the parent thread is some random tokio blocking worker thread which gets pruned by tokio periodically. When that happens, the executed command gets a SIGTERM (which we don't even report in the error message, which I'll fix in another PR). This was causing very random looking failures.

Fixes: https://github.com/It4innovations/hyperqueue/discussions/815
Fixes: https://github.com/It4innovations/hyperqueue/issues/818
Fixes: https://github.com/It4innovations/hyperqueue/issues/820