### PR TITLE
Unify format of all durations in CLI and add examples to them

### DIFF
--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -1,3 +1,4 @@
+use crate::client::commands::duration_doc;
 use std::time::Duration;
 
 use clap::Parser;
@@ -81,8 +82,12 @@ struct SharedQueueOpts {
     #[arg(long, short, default_value_t = 1, value_parser = parse_backlog)]
     backlog: u32,
 
-    /// Time limit (walltime) of PBS/Slurm allocations
-    #[arg(long, short('t'), value_parser = parse_hms_or_human_time)]
+    #[arg(
+        long,
+        short('t'),
+        value_parser = parse_hms_or_human_time,
+        help = duration_doc!("Time limit (walltime) of PBS/Slurm allocations.")
+    )]
     time_limit: Duration,
 
     /// How many workers (nodes) should be spawned in each allocation
@@ -122,13 +127,17 @@ struct SharedQueueOpts {
     #[arg(long)]
     worker_stop_cmd: Option<String>,
 
-    /// Time limit after which workers in the submitted allocations will be stopped.
-    /// By default, it is set to the time limit of the allocation.
-    /// However, if you want the workers to be stopped sooner, for example to give `worker_stop_cmd`
-    /// more time to execute before the allocation is killed, you can lower the worker time limit.
-    ///
-    /// The limit must not be larger than the allocation time limit.
-    #[arg(long, value_parser = parse_hms_or_human_time)]
+    #[arg(
+        long,
+        value_parser = parse_hms_or_human_time,
+        help = duration_doc!(r#"
+Time limit after which workers in the submitted allocations will be stopped.
+By default, it is set to the time limit of the allocation.
+However, if you want the workers to be stopped sooner, for example to give `worker_stop_cmd`
+more time to execute before the allocation is killed, you can lower the worker time limit.
+
+The limit must not be larger than the allocation time limit."#)
+    )]
     worker_time_limit: Option<Duration>,
 
     /// Additional arguments passed to the submit command

--- a/crates/hyperqueue/src/client/commands/mod.rs
+++ b/crates/hyperqueue/src/client/commands/mod.rs
@@ -6,3 +6,24 @@ pub mod server;
 pub mod submit;
 pub mod wait;
 pub mod worker;
+
+/// Helper macro for generating CLI help for a `Duration` (or `Option<Duration>`) value
+/// that can be specified either using the HMS or humantime formats.
+macro_rules! duration_doc {
+    ($text:expr) => {
+        concat!(
+            $text,
+            "\n\n",
+            r#"You can use either the `HH:MM:SS` format or a "humantime" format.
+For example:
+- 01:00:00 => 1 hour
+- 02:05:10 => 2 hours, 5 minutes, 10 seconds
+- 1h => 1 hour
+- 2h5m10s => 2 hours, 5 minutes, 10 seconds
+- 3h 10m 5s => 3 hours, 10 minutes, 5 seconds
+- 2 hours 5 minutes => 2 hours, 5 minutes"#
+        )
+    };
+}
+
+pub(crate) use duration_doc;

--- a/crates/hyperqueue/src/client/commands/server.rs
+++ b/crates/hyperqueue/src/client/commands/server.rs
@@ -1,10 +1,11 @@
+use crate::client::commands::duration_doc;
 use crate::client::globalsettings::GlobalSettings;
 use crate::client::server::client_stop_server;
 use crate::common::serverdir::{
     load_access_record, store_access_record, ConnectAccessRecordPart, FullAccessRecord,
 };
 use crate::common::utils::network::get_hostname;
-use crate::common::utils::time::parse_human_time;
+use crate::common::utils::time::parse_hms_or_human_time;
 use crate::server::bootstrap::{
     generate_server_uid, get_client_session, init_hq_server, ServerConfig,
 };
@@ -73,8 +74,11 @@ struct ServerStartOpts {
     #[arg(long)]
     host: Option<String>,
 
-    /// Duration after which will an idle worker automatically stop
-    #[arg(long, value_parser = parse_human_time)]
+    #[arg(
+        long,
+        value_parser = parse_hms_or_human_time,
+        help = duration_doc!("Duration after which will an idle worker automatically stop.")
+    )]
     idle_timeout: Option<Duration>,
 
     /// Port for client connections (used e.g. for `hq submit`)
@@ -89,8 +93,12 @@ struct ServerStartOpts {
     #[arg(long)]
     journal: Option<PathBuf>,
 
-    #[arg(long, value_parser = parse_human_time, default_value = "30s")]
-    /// Configure how often should be the journal written, default: 30s
+    #[arg(
+        long,
+        value_parser = parse_hms_or_human_time,
+        default_value = "30s",
+        help = duration_doc!("Configure how often should be the journal written.")
+    )]
     journal_flush_period: Duration,
 
     /// Path to access file that is used for configuration of secret keys and ports

--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -1,3 +1,4 @@
+use crate::client::commands::duration_doc;
 use anyhow::bail;
 use chrono::Utc;
 use std::path::PathBuf;
@@ -19,6 +20,7 @@ use crate::client::globalsettings::GlobalSettings;
 use crate::client::utils::{passthrough_parser, PassThroughArgument};
 use crate::common::manager::info::{ManagerInfo, WORKER_EXTRA_MANAGER_KEY};
 use crate::common::utils::network::get_hostname;
+use crate::common::utils::time::parse_hms_or_human_time;
 use crate::common::utils::time::parse_human_time;
 use crate::transfer::connection::ClientSession;
 use crate::transfer::messages::{
@@ -79,7 +81,8 @@ pub struct SharedWorkerStartOpts {
     /// Examples:{n}
     /// - `--resource gpus=[0,1,2,3]`{n}
     /// - `--resource "memory=sum(1024)"`
-    #[arg(long, action = clap::ArgAction::Append, value_parser = passthrough_parser(parse_resource_definition))]
+    #[arg(long, action = clap::ArgAction::Append, value_parser = passthrough_parser(parse_resource_definition)
+    )]
     pub resource: Vec<PassThroughArgument<ResourceDescriptorItem>>,
 
     /// Manual configuration of worker's group
@@ -97,8 +100,11 @@ pub struct SharedWorkerStartOpts {
     #[arg(long = "no-hyper-threading")]
     pub no_hyper_threading: bool,
 
-    /// Duration after which will an idle worker automatically stop
-    #[arg(long, value_parser = parse_human_time)]
+    #[arg(
+        long,
+        value_parser = parse_hms_or_human_time,
+        help = duration_doc!("Duration after which will an idle worker automatically stop.")
+    )]
     pub idle_timeout: Option<Duration>,
 
     /// How often should the worker send its overview status (e.g. HW usage, task status)
@@ -112,12 +118,19 @@ pub struct WorkerStartOpts {
     #[clap(flatten)]
     shared: SharedWorkerStartOpts,
 
-    /// How often should the worker announce its existence to the server.
-    #[arg(long, default_value = "8s", value_parser = parse_human_time)]
+    #[arg(
+        long,
+        default_value = "8s",
+        value_parser = parse_hms_or_human_time,
+        help = duration_doc!("How often should the worker announce its existence to the server.")
+    )]
     pub heartbeat: Duration,
 
-    /// Worker time limit. Worker exits after given time.
-    #[arg(long, value_parser = parse_human_time)]
+    #[arg(
+        long,
+        value_parser = parse_hms_or_human_time,
+        help = duration_doc!("Worker time limit. Worker exits after given time.")
+    )]
     pub time_limit: Option<Duration>,
 
     /// What HPC job manager should be used by the worker.


### PR DESCRIPTION
This PR unifies all duration parsers in the CLI to support both `HH:MM:SS` and humantime formats (to be consistent), and also adds a shared documentation string to them, to provide examples.

Fixes: https://github.com/It4innovations/hyperqueue/issues/832