### PR TITLE
Refresh autoalloc queues when a worker disconnect

### DIFF
--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -127,7 +127,7 @@ async fn handle_message(
                     "Worker {id} disconnected to an unknown allocation {}",
                     manager_info.allocation_id
                 );
-                None
+                Some(RefreshReason::UpdateAllQueues)
             }
         }
         AutoAllocMessage::JobCreated(id) => {


### PR DESCRIPTION
When a worker disconnects from an unknown allocation, we should refresh queues, because there are now less computational resources available.

Fixes: https://github.com/It4innovations/hyperqueue/issues/648