### PR TITLE
Stream "live" boundary

### DIFF
--- a/crates/hyperqueue/src/client/commands/journal/mod.rs
+++ b/crates/hyperqueue/src/client/commands/journal/mod.rs
@@ -73,11 +73,15 @@ async fn stream_json(gsettings: &GlobalSettings, opts: StreamOpts) -> anyhow::Re
     let mut stdout = BufWriter::new(stdout);
     while let Some(event) = connection.connection().receive().await {
         let event = event?;
-        if let ToClientMessage::Event(e) = event {
-            writeln!(stdout, "{}", format_event(e))?;
-            stdout.flush()?;
-        } else {
-            anyhow::bail!("Invalid message receive, not ToClientMessage::Event");
+        match event {
+            ToClientMessage::Event(e) => {
+                writeln!(stdout, "{}", format_event(e))?;
+                stdout.flush()?;
+            }
+            ToClientMessage::EventLiveBoundary => { /* Do nothing */ }
+            _ => {
+                anyhow::bail!("Invalid message receive, not ToClientMessage::Event");
+            }
         }
     }
     Ok(())

--- a/crates/hyperqueue/src/dashboard/data/fetch.rs
+++ b/crates/hyperqueue/src/dashboard/data/fetch.rs
@@ -1,6 +1,6 @@
 use crate::server::event::Event;
 use crate::transfer::connection::ClientSession;
-use crate::transfer::messages::{FromClientMessage, ToClientMessage};
+use crate::transfer::messages::{FromClientMessage, StreamEvents, ToClientMessage};
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
 
@@ -10,7 +10,9 @@ pub async fn create_data_fetch_process(
 ) -> anyhow::Result<()> {
     session
         .connection()
-        .send(FromClientMessage::StreamEvents)
+        .send(FromClientMessage::StreamEvents(StreamEvents {
+            history_only: false,
+        }))
         .await?;
 
     const CAPACITY: usize = 1024;

--- a/crates/hyperqueue/src/server/client/mod.rs
+++ b/crates/hyperqueue/src/server/client/mod.rs
@@ -185,6 +185,7 @@ pub async fn client_rpc_loop<
                         senders.events.replay_journal(tx1);
                         stream_history_events(&mut tx, rx1).await;
                         if let Some((rx2, listener_id)) = live {
+                            let _ = tx.send(ToClientMessage::EventLiveBoundary).await;
                             stream_events(&mut tx, &mut rx, rx2).await;
                             senders.events.unregister_listener(listener_id);
                         }

--- a/crates/hyperqueue/src/server/event/journal/stream.rs
+++ b/crates/hyperqueue/src/server/event/journal/stream.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 
 pub enum EventStreamMessage {
     Event(Event),
-    RegisterListener(mpsc::UnboundedSender<Event>),
+    ReplayJournal(mpsc::UnboundedSender<Event>),
     PruneJournal {
         callback: tokio::sync::oneshot::Sender<()>,
         live_jobs: Set<JobId>,
@@ -88,7 +88,7 @@ async fn streaming_process(
                             break
                         }
                     }
-                    Some(EventStreamMessage::RegisterListener(tx)) => {
+                    Some(EventStreamMessage::ReplayJournal(tx)) => {
                         /* We are blocking the thread here, but it is intended.
                            But we are blocking just a thread managing log file, not the whole HQ
                            And while this read is performed, we cannot allow modification of the file,

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -41,7 +41,7 @@ pub enum FromClientMessage {
     // This command switches the connection into streaming connection,
     // it will no longer reacts to any other client messages
     // and client will only receive ToClientMessage::Event
-    StreamEvents,
+    StreamEvents(StreamEvents),
     PruneJournal,
     FlushJournal,
 }
@@ -84,6 +84,11 @@ pub struct TaskKindProgram {
     pub program: ProgramDefinition,
     pub pin_mode: PinMode,
     pub task_dir: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct StreamEvents {
+    pub history_only: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -41,6 +41,7 @@ pub enum FromClientMessage {
     // This command switches the connection into streaming connection,
     // it will no longer reacts to any other client messages
     // and client will only receive ToClientMessage::Event
+    // or ToClientMessage::EventLiveBoundary
     StreamEvents(StreamEvents),
     PruneJournal,
     FlushJournal,
@@ -348,6 +349,9 @@ pub enum ToClientMessage {
     Error(String),
     ServerInfo(ServerInfo),
     Event(Event),
+    // This indicates in live event streaming when old events where
+    // old streamed, and now we are getting new ones
+    EventLiveBoundary,
     Finished, // Generic response, now used only for journal pruning/flushing
 }
 

--- a/tests/autoalloc/test_autoalloc.py
+++ b/tests/autoalloc/test_autoalloc.py
@@ -88,7 +88,8 @@ def test_slurm_queue_sbatch_additional_output(hq_env: HqEnv):
     class Handler(SlurmCommandHandler):
         async def handle_submit(self, input: CommandInput) -> CommandOutput:
             output = await super().handle_submit(input)
-            return response(f"""
+            return response(
+                f"""
 No reservation for this job
 --> Verifying valid submit host (login)...OK
 --> Verifying valid jobname...OK
@@ -96,7 +97,8 @@ No reservation for this job
 --> Verifying access to desired queue (normal)...OK
 --> Checking available allocation...OK
 {output.stdout}
-""")
+"""
+            )
 
     with MockJobManager(hq_env, Handler(DefaultManager())):
         hq_env.start_server()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -64,6 +64,14 @@ def test_worker_stream_events2(hq_env: HqEnv, tmp_path):
         assert events[2]["event"]["desc"]["name"] == "uname"
 
 
+def test_worker_stream_history_only(hq_env: HqEnv, tmp_path):
+    journal = tmp_path.joinpath("test.journal")
+    hq_env.start_server(args=["--journal", journal])
+    r = hq_env.command(["journal", "stream", "--history-only"])
+    msg = json.loads(r)
+    assert msg["event"]["type"] == "server-start"
+
+
 def test_worker_connected_event(hq_env: HqEnv):
     def body():
         hq_env.start_worker()
@@ -154,21 +162,21 @@ def test_worker_capture_amd_gpu_state(hq_env: HqEnv):
         with hq_env.mock.mock_program_with_code(
             "rocm-smi",
             """
-import json
-data = {
-    "card0": {
-        "GPU use (%)": "1.5",
-        "GPU memory use (%)": "12.5",
-        "PCI Bus": "FOOBAR1"
-    },
-    "card1": {
-        "GPU use (%)": "12.5",
-        "GPU memory use (%)": "64.0",
-        "PCI Bus": "FOOBAR2"
+    import json
+    data = {
+        "card0": {
+            "GPU use (%)": "1.5",
+            "GPU memory use (%)": "12.5",
+            "PCI Bus": "FOOBAR1"
+        },
+        "card1": {
+            "GPU use (%)": "12.5",
+            "GPU memory use (%)": "64.0",
+            "PCI Bus": "FOOBAR2"
+        }
     }
-}
-print(json.dumps(data))
-        """,
+    print(json.dumps(data))
+            """,
         ):
             hq_env.start_worker(args=["--overview-interval", "10ms", "--resource", "gpus/amd=[0]"])
             wait_for_worker_state(hq_env, 1, "RUNNING")


### PR DESCRIPTION
Followup for #841.
It adds a message `ToClientMessage::EventLiveBoundary` that is sent when journal stream finishes its old events and new online events will be streamed.