### PR TITLE
Feat:  Add empty json output mode

### DIFF
--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -522,8 +522,10 @@ async fn main() -> hyperqueue::Result<()> {
 
     if let Err(e) = result {
         gsettings.printer().print_error(e);
+        gsettings.printer().finalize_output();
         std::process::exit(1);
+    } else {
+        gsettings.printer().finalize_output();
+        Ok(())
     }
-
-    Ok(())
 }

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -1177,6 +1177,8 @@ impl Output for CliOutput {
         output_file(&path);
         Ok(())
     }
+
+    fn finalize_output(&self) {}
 }
 
 struct AllocationTimes {

--- a/crates/hyperqueue/src/client/output/outputs.rs
+++ b/crates/hyperqueue/src/client/output/outputs.rs
@@ -99,4 +99,7 @@ pub trait Output {
     fn print_error(&self, error: anyhow::Error);
 
     fn print_explanation(&self, task_id: TaskId, explanation: &TaskExplanation);
+
+    /// Finish the output.
+    fn finalize_output(&self);
 }

--- a/crates/hyperqueue/src/client/output/quiet.rs
+++ b/crates/hyperqueue/src/client/output/quiet.rs
@@ -161,6 +161,8 @@ impl Output for Quiet {
     }
 
     fn print_explanation(&self, _task_id: TaskId, _explanation: &TaskExplanation) {}
+
+    fn finalize_output(&self) {}
 }
 
 fn format_status(status: &Status) -> &str {

--- a/tests/autoalloc/utils.py
+++ b/tests/autoalloc/utils.py
@@ -32,6 +32,7 @@ def add_queue(
     max_workers_per_alloc=1,
     additional_worker_args: List[str] = None,
     additional_args=None,
+    additional_hq_args: List[str] = None,
     time_limit="1h",
     worker_time_limit: Optional[str] = None,
     dry_run=False,
@@ -40,7 +41,11 @@ def add_queue(
     wrap_cmd: Optional[str] = None,
     **kwargs,
 ) -> str:
-    args = ["alloc", "add", manager]
+    args = []
+    if additional_hq_args is not None:
+        args += additional_hq_args
+
+    args += ["alloc", "add", manager]
     if not dry_run:
         args.append("--no-dry-run")
     if name is not None:

--- a/tests/output/test_json.py
+++ b/tests/output/test_json.py
@@ -6,6 +6,7 @@ from typing import List
 import iso8601
 from schema import Schema
 
+from ..autoalloc.utils import add_queue
 from ..conftest import HqEnv
 from ..utils import wait_for_job_state
 from ..utils.job import default_task_output
@@ -289,3 +290,11 @@ def test_print_job_summary(hq_env: HqEnv):
         }
     )
     schema.validate(output)
+
+
+def test_add_queue_json_output_nonempty(hq_env: HqEnv):
+    hq_env.start_server()
+    output = add_queue(
+        hq_env, manager="slurm", additional_hq_args=["--output-mode", "json"], ignore_stderr=True, as_json=True
+    )
+    assert output == {}


### PR DESCRIPTION
[✅] Add `print_empty` to the `Output`trait
[✅] Implemented `print_empty` for `JSON`, `Cli` and `Quiet` 

Fixes: #830