### PR TITLE
Authentication and encryption can be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### New features
 
 * Added `hq doc` command for accessing documentation about various HQ features from the command-line.
+* `hq journal replay` added. It similar to `hq journal stream` but it will not wait for new events.
+* More robust initialization of dashboard
+* Authentication and encyrption of client/worker connection can be disabled. It is mostly for testing 
+  and benchmarking purpose. Do not use if you are not in 100% safe environment.
 
 ### Breaking change
 * The Python API now requires Python 3.9, up from Python 3.6.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 * Added `hq doc` command for accessing documentation about various HQ features from the command-line.
 * `hq journal replay` added. It similar to `hq journal stream` but it will not wait for new events.
 * More robust initialization of dashboard
-* Authentication and encyrption of client/worker connection can be disabled. It is mostly for testing 
+* Authentication and encryption of client/worker connection can be disabled. It is mostly for testing
   and benchmarking purpose. Do not use if you are not in 100% safe environment.
 
 ### Breaking change
+
 * The Python API now requires Python 3.9, up from Python 3.6.
 
 ## v0.21.1
@@ -20,7 +21,10 @@
 ## v0.21.0
 
 ### Breaking change
-* Pre-built HyperQueue releases available from our GitHub repository are now built with GLIBC `2.28`, instead of `2.17`. If you need to run HyperQueue on a system with an older GLIBC version, you might need to recompile it from source on your system. If you encounter any issues, please let us know.
+
+* Pre-built HyperQueue releases available from our GitHub repository are now built with GLIBC `2.28`, instead of `2.17`.
+  If you need to run HyperQueue on a system with an older GLIBC version, you might need to recompile it from source on
+  your system. If you encounter any issues, please let us know.
 
 ### Changes
 

--- a/benchmarks/src/environment/hq.py
+++ b/benchmarks/src/environment/hq.py
@@ -187,6 +187,9 @@ class HqEnvironment(Environment, EnvStateManager):
                 lambda: postprocess_events(self.binary_path, event_log_path, event_log_json_path, workdir)
             )
             args += ["--journal", str(event_log_path)]
+        if not self.info.encryption:
+            args.append("--disable-client-authentication-and-encryption")
+            args.append("--disable-worker-authentication-and-encryption")
 
         args = StartProcessArgs(
             args=args,
@@ -324,8 +327,6 @@ class HqEnvironment(Environment, EnvStateManager):
             "RUST_LOG": f"hyperqueue={'DEBUG' if self.info.debug else 'INFO'}",
             "HQ_AUTOALLOC_MAX_ALLOCATION_FAILS": "100",
         }
-        if not self.info.encryption:
-            env["HQ_SKIP_AUTHENTICATION"] = "1"
         if self.info.fast_spawn:
             env["HQ_FAST_SPAWN"] = "1"
         if self.info.skip_stream_log_write:

--- a/crates/hyperqueue/src/client/commands/server.rs
+++ b/crates/hyperqueue/src/client/commands/server.rs
@@ -107,13 +107,13 @@ struct ServerStartOpts {
 
     /// If set, client connection will NOT be AUTHENTICATED and ENCRYPTED.
     /// ANYONE CAN CONNECT TO THE SERVER AS CLIENT!
-    /// USE ON YOUR OWN RISK.
+    /// USE AT YOUR OWN RISK.
     #[arg(long)]
     disable_client_authentication_and_encryption: bool,
 
     /// If set, worker connection will NOT be AUTHENTICATED and ENCRYPTED.
     /// ANYONE CAN CONNECT TO THE SERVER AS WORKER!
-    /// USE ON YOUR OWN RISK.
+    /// USE AT YOUR OWN RISK.
     #[arg(long)]
     disable_worker_authentication_and_encryption: bool,
 }
@@ -167,7 +167,7 @@ async fn start_server(gsettings: &GlobalSettings, opts: ServerStartOpts) -> anyh
         journal_flush_period: opts.journal_flush_period,
         worker_secret_key: access_file
             .as_ref()
-            .map(|a| a.worker_key().clone())
+            .map(|a| a.worker_key().cloned())
             .unwrap_or_else(|| {
                 if opts.disable_worker_authentication_and_encryption {
                     None
@@ -177,7 +177,7 @@ async fn start_server(gsettings: &GlobalSettings, opts: ServerStartOpts) -> anyh
             }),
         client_secret_key: access_file
             .as_ref()
-            .map(|a| a.client_key().clone())
+            .map(|a| a.client_key().cloned())
             .unwrap_or_else(|| {
                 if opts.disable_client_authentication_and_encryption {
                     None

--- a/crates/hyperqueue/src/server/backend.rs
+++ b/crates/hyperqueue/src/server/backend.rs
@@ -50,7 +50,7 @@ impl Backend {
         state_ref: StateRef,
         events: EventStreamer,
         autoalloc: AutoAllocService,
-        key: Arc<SecretKey>,
+        key: Option<Arc<SecretKey>>,
         idle_timeout: Option<Duration>,
         worker_port: Option<u16>,
         worker_id_initial_value: WorkerId,
@@ -63,7 +63,7 @@ impl Backend {
         let server_uid = state_ref.get().server_info().server_uid.clone();
         let (server_ref, server_future) = tako::server::server_start(
             SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), worker_port.unwrap_or(0)),
-            Some(key),
+            key,
             msd,
             from_tako_sender.clone(),
             false,

--- a/crates/hyperqueue/src/server/client/mod.rs
+++ b/crates/hyperqueue/src/server/client/mod.rs
@@ -38,7 +38,7 @@ pub async fn handle_client_connections(
     server_dir: ServerDir,
     listener: TcpListener,
     end_flag: Arc<Notify>,
-    key: Arc<SecretKey>,
+    key: Option<Arc<SecretKey>>,
 ) {
     let group = TaskGroup::default();
     while let Ok((connection, _)) = group.run_until(listener.accept()).await {
@@ -64,7 +64,7 @@ async fn handle_client(
     state_ref: StateRef,
     carrier: &Senders,
     end_flag: Arc<Notify>,
-    key: Arc<SecretKey>,
+    key: Option<Arc<SecretKey>>,
 ) -> crate::Result<()> {
     log::debug!("New client connection");
     let socket = ServerConnection::accept_client(socket, key).await?;

--- a/crates/hyperqueue/src/worker/bootstrap.rs
+++ b/crates/hyperqueue/src/worker/bootstrap.rs
@@ -114,7 +114,7 @@ pub async fn initialize_worker(
     let ((worker_id, configuration), worker_future) = run_worker(
         server_addresses,
         configuration,
-        Some(record.worker.secret_key.clone()),
+        record.worker.secret_key.clone(),
         |server_uid, worker_id| {
             let streamer_ref = StreamerRef::new(server_uid, worker_id);
             Box::new(HqTaskLauncher::new(streamer_ref))

--- a/crates/tako/src/internal/server/core.rs
+++ b/crates/tako/src/internal/server/core.rs
@@ -470,8 +470,8 @@ impl Core {
         self.resource_map.resource_count()
     }
 
-    pub fn secret_key(&self) -> &Option<Arc<SecretKey>> {
-        &self.secret_key
+    pub fn secret_key(&self) -> Option<&Arc<SecretKey>> {
+        self.secret_key.as_ref()
     }
 }
 

--- a/crates/tako/src/internal/server/rpc.rs
+++ b/crates/tako/src/internal/server/rpc.rs
@@ -83,12 +83,12 @@ pub(crate) async fn worker_authentication(
 ) -> crate::Result<(ConnectionDescriptor, ConnectionRegistration)> {
     let (mut writer, mut reader) = make_protocol_builder().new_framed(stream).split();
 
-    let secret_key = core_ref.get().secret_key().clone();
+    let secret_key = core_ref.get().secret_key().cloned();
     let (sealer, mut opener) = do_authentication(
         0,
         "server".to_string(),
         "worker".to_string(),
-        secret_key.clone(),
+        secret_key,
         &mut writer,
         &mut reader,
     )

--- a/crates/tako/src/internal/transfer/auth.rs
+++ b/crates/tako/src/internal/transfer/auth.rs
@@ -174,25 +174,15 @@ impl Authenticator {
     }
 }
 
-/// Override for disabling encryption, mostly for benchmarking/debugging purposes.
-pub fn is_encryption_disabled() -> bool {
-    std::env::var("HQ_SKIP_AUTHENTICATION").is_ok()
-}
-
 pub async fn do_authentication<T: AsyncRead + AsyncWrite>(
     protocol: u32,
     my_role: String,
     peer_role: String,
-    mut secret_key: Option<Arc<SecretKey>>,
+    secret_key: Option<Arc<SecretKey>>,
     writer: &mut SplitSink<Framed<T, LengthDelimitedCodec>, bytes::Bytes>,
     reader: &mut SplitStream<Framed<T, LengthDelimitedCodec>>,
 ) -> crate::Result<(Option<StreamSealer>, Option<StreamOpener>)> {
     const AUTH_TIMEOUT: Duration = Duration::from_secs(15);
-
-    if is_encryption_disabled() {
-        secret_key = None;
-    }
-
     let mut authenticator = Authenticator::new(protocol, my_role, peer_role, secret_key);
 
     /* Send authentication message */

--- a/crates/tako/src/internal/worker/rpc.rs
+++ b/crates/tako/src/internal/worker/rpc.rs
@@ -79,6 +79,9 @@ pub async fn connect_to_server_and_authenticate(
     server_addresses: &[SocketAddr],
     secret_key: &Option<Arc<SecretKey>>,
 ) -> crate::Result<ConnectionDescriptor> {
+    if secret_key.is_none() {
+        log::warn!("No worker key: Unauthenticated and unencrypted connection to server");
+    }
     let (stream, address) = connect_to_server(server_addresses).await?;
     let (mut writer, mut reader) = make_protocol_builder().new_framed(stream).split();
     let (sealer, opener) = do_authentication(

--- a/crates/tako/src/internal/worker/rpc.rs
+++ b/crates/tako/src/internal/worker/rpc.rs
@@ -77,7 +77,7 @@ async fn connect_to_server(addresses: &[SocketAddr]) -> crate::Result<(TcpStream
 
 pub async fn connect_to_server_and_authenticate(
     server_addresses: &[SocketAddr],
-    secret_key: &Option<Arc<SecretKey>>,
+    secret_key: Option<&Arc<SecretKey>>,
 ) -> crate::Result<ConnectionDescriptor> {
     if secret_key.is_none() {
         log::warn!("No worker key: Unauthenticated and unencrypted connection to server");
@@ -88,7 +88,7 @@ pub async fn connect_to_server_and_authenticate(
         0,
         "worker".to_string(),
         "server".to_string(),
-        secret_key.clone(),
+        secret_key.cloned(),
         &mut writer,
         &mut reader,
     )
@@ -125,7 +125,7 @@ pub async fn run_worker(
         mut opener,
         mut sealer,
         ..
-    } = connect_to_server_and_authenticate(&scheduler_addresses, &secret_key).await?;
+    } = connect_to_server_and_authenticate(&scheduler_addresses, secret_key.as_ref()).await?;
     {
         let message = ConnectionRegistration::Worker(RegisterWorker {
             configuration: configuration.clone(),


### PR DESCRIPTION
This code removes the previous ugly benchmarking hack that bypass security function very deep in the auth & encryption code. So even if you had a key, you could get insecure connection. It also used "HQ_" prefixed env variable in Tako code.

This PR removes the hack and when keys should not be used, it is not present in the memory at all.
You can directly tell from access record if connection will be secured. 

It introduces flags `--disable-client-authentication-and-encryption` and `--disable-worker-authentication-and-encryption` that allows to disable connection security (Note: it is intentionally very long)

You will also get warnings when server/worker/client is started and the connection is not secured.


