### PR TITLE
Extended worker info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## DEV
+
+### New features
+
+* `hq worker info` contains more information
+* `hq job forget` tries to free more memory
+
 ## 0.22.0
 
 ### New features

--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -243,7 +243,7 @@ async fn command_worker_info(
     opts: WorkerInfoOpts,
 ) -> anyhow::Result<()> {
     let mut session = get_client_session(gsettings.server_directory()).await?;
-    let response = get_worker_info(&mut session, opts.worker_id).await?;
+    let response = get_worker_info(&mut session, opts.worker_id, true).await?;
 
     if let Some(worker) = response {
         gsettings.printer().print_worker_info(worker);
@@ -289,7 +289,7 @@ async fn command_worker_address(
     opts: WorkerAddressOpts,
 ) -> anyhow::Result<()> {
     let mut session = get_client_session(gsettings.server_directory()).await?;
-    let response = get_worker_info(&mut session, opts.worker_id).await?;
+    let response = get_worker_info(&mut session, opts.worker_id, false).await?;
 
     match response {
         Some(info) => println!("{}", info.configuration.hostname),

--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -172,6 +172,7 @@ pub async fn start_hq_worker(
         started: Utc::now(),
         ended: None,
         runtime_info: None,
+        last_task_started: None,
     });
     worker.run().await?;
     log::info!("Worker stopping");

--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -171,6 +171,7 @@ pub async fn start_hq_worker(
         configuration: worker.configuration.clone(),
         started: Utc::now(),
         ended: None,
+        runtime_info: None,
     });
     worker.run().await?;
     log::info!("Worker stopping");
@@ -358,11 +359,13 @@ pub async fn get_worker_list(
 pub async fn get_worker_info(
     session: &mut ClientSession,
     worker_id: WorkerId,
+    runtime_info: bool,
 ) -> crate::Result<Option<WorkerInfo>> {
     let msg = rpc_call!(
         session.connection(),
         FromClientMessage::WorkerInfo(WorkerInfoRequest {
             worker_id,
+            runtime_info,
         }),
         ToClientMessage::WorkerInfoResponse(r) => r
     )

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -6,18 +6,18 @@ use anyhow::Error;
 use chrono::{DateTime, Utc};
 use serde::{Serialize, Serializer};
 use serde_json;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
-use tako::Map;
 use tako::gateway::ResourceRequest;
 use tako::program::{ProgramDefinition, StdioDef};
 use tako::resources::{ResourceDescriptor, ResourceDescriptorItem, ResourceDescriptorKind};
 use tako::worker::WorkerConfiguration;
+use tako::Map;
 
 use crate::client::job::WorkerMap;
-use crate::client::output::Verbosity;
-use crate::client::output::common::{TaskToPathsMap, group_jobs_by_status, resolve_task_paths};
+use crate::client::output::common::{group_jobs_by_status, resolve_task_paths, TaskToPathsMap};
 use crate::client::output::outputs::{Output, OutputStream};
+use crate::client::output::Verbosity;
 use crate::common::arraydef::IntArray;
 use crate::common::manager::info::{GetManagerInfo, ManagerType};
 use crate::server::autoalloc::{Allocation, AllocationState, QueueId};
@@ -503,6 +503,7 @@ fn format_worker_info(worker_info: WorkerInfo) -> serde_json::Value {
             },
         started,
         ended,
+        runtime_info,
     } = worker_info;
 
     json!({
@@ -522,6 +523,7 @@ fn format_worker_info(worker_info: WorkerInfo) -> serde_json::Value {
             "manager": FormattedManagerType(info.manager),
             "id": info.allocation_id
         })),
+        "runtime_info": runtime_info,
         "started": format_datetime(started),
         "ended": ended.map(|info| json!({
             "at": format_datetime(info.ended_at)

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -6,18 +6,18 @@ use anyhow::Error;
 use chrono::{DateTime, Utc};
 use serde::{Serialize, Serializer};
 use serde_json;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
+use tako::Map;
 use tako::gateway::ResourceRequest;
 use tako::program::{ProgramDefinition, StdioDef};
 use tako::resources::{ResourceDescriptor, ResourceDescriptorItem, ResourceDescriptorKind};
 use tako::worker::WorkerConfiguration;
-use tako::Map;
 
 use crate::client::job::WorkerMap;
-use crate::client::output::common::{group_jobs_by_status, resolve_task_paths, TaskToPathsMap};
-use crate::client::output::outputs::{Output, OutputStream};
 use crate::client::output::Verbosity;
+use crate::client::output::common::{TaskToPathsMap, group_jobs_by_status, resolve_task_paths};
+use crate::client::output::outputs::{Output, OutputStream};
 use crate::common::arraydef::IntArray;
 use crate::common::manager::info::{GetManagerInfo, ManagerType};
 use crate::server::autoalloc::{Allocation, AllocationState, QueueId};
@@ -504,6 +504,7 @@ fn format_worker_info(worker_info: WorkerInfo) -> serde_json::Value {
         started,
         ended,
         runtime_info,
+        last_task_started,
     } = worker_info;
 
     json!({
@@ -524,6 +525,7 @@ fn format_worker_info(worker_info: WorkerInfo) -> serde_json::Value {
             "id": info.allocation_id
         })),
         "runtime_info": runtime_info,
+        "last_task_started": last_task_started,
         "started": format_datetime(started),
         "ended": ended.map(|info| json!({
             "at": format_datetime(info.ended_at)

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -1175,7 +1175,7 @@ mod tests {
         let allocs = get_allocations(&state, queue_id);
 
         for id in [0u32, 1] {
-            on_worker_added(&s, queue_id, &mut state, &allocs[0].id, id.into());
+            on_worker_added(&s, queue_id, &mut state, &allocs[0].id, id);
         }
         check_running_workers(
             get_allocations(&state, queue_id).first().unwrap(),
@@ -2079,12 +2079,12 @@ mod tests {
 
     fn fail_allocation(queue_id: QueueId, autoalloc: &mut AutoAllocState, allocation_id: &str) {
         let s = EventStreamer::new(None);
-        on_worker_added(&s, queue_id, autoalloc, &allocation_id, 0);
+        on_worker_added(&s, queue_id, autoalloc, allocation_id, 0);
         on_worker_lost(
             &s,
             queue_id,
             autoalloc,
-            &allocation_id,
+            allocation_id,
             0,
             lost_worker_quick(LostWorkerReason::ConnectionLost),
         );

--- a/crates/hyperqueue/src/server/backend.rs
+++ b/crates/hyperqueue/src/server/backend.rs
@@ -119,7 +119,8 @@ impl Backend {
                         | ToGatewayMessage::Error(_)
                         | ToGatewayMessage::ServerInfo(_)
                         | ToGatewayMessage::WorkerStopped
-                        | ToGatewayMessage::NewWorkerAllocationQueryResponse(_) => {
+                        | ToGatewayMessage::NewWorkerAllocationQueryResponse(_)
+                        | ToGatewayMessage::WorkerInfo(_) => {
                             let response = senders
                                 .backend
                                 .inner

--- a/crates/hyperqueue/src/server/event/streamer.rs
+++ b/crates/hyperqueue/src/server/event/streamer.rs
@@ -5,7 +5,7 @@ use crate::server::event::journal::{EventStreamMessage, EventStreamSender};
 use crate::server::event::payload::EventPayload;
 use crate::transfer::messages::{AllocationQueueParams, JobDescription, SubmitRequest};
 use crate::{JobId, JobTaskId, WorkerId};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use smallvec::SmallVec;
 use tako::gateway::LostWorkerReason;
 use tako::worker::{WorkerConfiguration, WorkerOverview};
@@ -33,20 +33,23 @@ impl EventStreamer {
     }
 
     pub fn on_worker_added(&self, id: WorkerId, configuration: WorkerConfiguration) {
-        self.send_event(EventPayload::WorkerConnected(id, Box::new(configuration)));
+        self.send_event(
+            EventPayload::WorkerConnected(id, Box::new(configuration)),
+            None,
+        );
     }
 
     pub fn on_worker_lost(&self, id: WorkerId, reason: LostWorkerReason) {
-        self.send_event(EventPayload::WorkerLost(id, reason));
+        self.send_event(EventPayload::WorkerLost(id, reason), None);
     }
 
     #[inline]
     pub fn on_overview_received(&self, worker_overview: WorkerOverview) {
-        self.send_event(EventPayload::WorkerOverviewReceived(worker_overview));
+        self.send_event(EventPayload::WorkerOverviewReceived(worker_overview), None);
     }
 
     pub fn on_job_opened(&self, job_id: JobId, job_desc: JobDescription) {
-        self.send_event(EventPayload::JobOpen(job_id, job_desc));
+        self.send_event(EventPayload::JobOpen(job_id, job_desc), None);
     }
 
     pub fn on_job_submitted(
@@ -61,17 +64,20 @@ impl EventStreamer {
                 return Ok(());
             }
         }
-        self.send_event(EventPayload::Submit {
-            job_id,
-            closed_job: submit_request.job_id.is_none(),
-            serialized_desc: Serialized::new(submit_request)?,
-        });
+        self.send_event(
+            EventPayload::Submit {
+                job_id,
+                closed_job: submit_request.job_id.is_none(),
+                serialized_desc: Serialized::new(submit_request)?,
+            },
+            None,
+        );
         Ok(())
     }
 
     #[inline]
-    pub fn on_job_completed(&self, job_id: JobId) {
-        self.send_event(EventPayload::JobCompleted(job_id));
+    pub fn on_job_completed(&self, job_id: JobId, now: DateTime<Utc>) {
+        self.send_event(EventPayload::JobCompleted(job_id), Some(now));
     }
 
     #[inline]
@@ -81,42 +87,55 @@ impl EventStreamer {
         task_id: JobTaskId,
         instance_id: InstanceId,
         worker_ids: SmallVec<[WorkerId; 1]>,
+        now: DateTime<Utc>,
     ) {
-        self.send_event(EventPayload::TaskStarted {
-            job_id,
-            task_id,
-            instance_id,
-            workers: worker_ids,
-        });
+        self.send_event(
+            EventPayload::TaskStarted {
+                job_id,
+                task_id,
+                instance_id,
+                workers: worker_ids,
+            },
+            Some(now),
+        );
     }
 
     #[inline]
-    pub fn on_task_finished(&self, job_id: JobId, task_id: JobTaskId) {
-        self.send_event(EventPayload::TaskFinished { job_id, task_id });
+    pub fn on_task_finished(&self, job_id: JobId, task_id: JobTaskId, now: DateTime<Utc>) {
+        self.send_event(EventPayload::TaskFinished { job_id, task_id }, Some(now));
     }
 
-    pub fn on_task_canceled(&self, job_id: JobId, task_id: JobTaskId) {
-        self.send_event(EventPayload::TaskCanceled { job_id, task_id });
+    pub fn on_task_canceled(&self, job_id: JobId, task_id: JobTaskId, now: DateTime<Utc>) {
+        self.send_event(EventPayload::TaskCanceled { job_id, task_id }, Some(now));
     }
 
     #[inline]
-    pub fn on_task_failed(&self, job_id: JobId, task_id: JobTaskId, error: String) {
-        self.send_event(EventPayload::TaskFailed {
-            job_id,
-            task_id,
-            error,
-        });
+    pub fn on_task_failed(
+        &self,
+        job_id: JobId,
+        task_id: JobTaskId,
+        error: String,
+        now: DateTime<Utc>,
+    ) {
+        self.send_event(
+            EventPayload::TaskFailed {
+                job_id,
+                task_id,
+                error,
+            },
+            Some(now),
+        );
     }
 
     pub fn on_allocation_queue_created(&self, id: QueueId, parameters: AllocationQueueParams) {
-        self.send_event(EventPayload::AllocationQueueCreated(
-            id,
-            Box::new(parameters),
-        ))
+        self.send_event(
+            EventPayload::AllocationQueueCreated(id, Box::new(parameters)),
+            None,
+        )
     }
 
     pub fn on_allocation_queue_removed(&self, id: QueueId) {
-        self.send_event(EventPayload::AllocationQueueRemoved(id))
+        self.send_event(EventPayload::AllocationQueueRemoved(id), None)
     }
 
     pub fn on_allocation_queued(
@@ -125,28 +144,37 @@ impl EventStreamer {
         allocation_id: AllocationId,
         worker_count: u64,
     ) {
-        self.send_event(EventPayload::AllocationQueued {
-            queue_id,
-            allocation_id,
-            worker_count,
-        })
+        self.send_event(
+            EventPayload::AllocationQueued {
+                queue_id,
+                allocation_id,
+                worker_count,
+            },
+            None,
+        )
     }
 
     pub fn on_allocation_started(&self, queue_id: QueueId, allocation_id: AllocationId) {
-        self.send_event(EventPayload::AllocationStarted(queue_id, allocation_id));
+        self.send_event(
+            EventPayload::AllocationStarted(queue_id, allocation_id),
+            None,
+        );
     }
 
     pub fn on_allocation_finished(&self, queue_id: QueueId, allocation_id: AllocationId) {
-        self.send_event(EventPayload::AllocationFinished(queue_id, allocation_id));
+        self.send_event(
+            EventPayload::AllocationFinished(queue_id, allocation_id),
+            None,
+        );
     }
 
-    fn send_event(&self, payload: EventPayload) {
+    fn send_event(&self, payload: EventPayload, now: Option<DateTime<Utc>>) {
         let mut inner = self.inner.get_mut();
         if inner.storage_sender.is_none() && inner.client_listeners.is_empty() {
             return;
         }
         let event = Event {
-            time: Utc::now(),
+            time: now.unwrap_or_else(Utc::now),
             payload,
         };
         inner
@@ -160,13 +188,16 @@ impl EventStreamer {
     }
 
     pub fn on_server_stop(&self) {
-        self.send_event(EventPayload::ServerStop);
+        self.send_event(EventPayload::ServerStop, None);
     }
 
     pub fn on_server_start(&self, server_uid: &str) {
-        self.send_event(EventPayload::ServerStart {
-            server_uid: server_uid.to_string(),
-        });
+        self.send_event(
+            EventPayload::ServerStart {
+                server_uid: server_uid.to_string(),
+            },
+            None,
+        );
     }
 
     pub fn replay_journal(&self, history_sender: mpsc::UnboundedSender<Event>) {

--- a/crates/hyperqueue/src/server/state.rs
+++ b/crates/hyperqueue/src/server/state.rs
@@ -184,10 +184,20 @@ impl State {
             } => {
                 let (job_id, task_id) = unwrap_tako_id(msg.id);
                 let job = self.get_job_mut(job_id).unwrap();
-                job.set_running_state(task_id, worker_ids.clone(), context);
-                senders
-                    .events
-                    .on_task_started(job_id, task_id, instance_id, worker_ids.clone());
+                let now = Utc::now();
+                job.set_running_state(task_id, worker_ids.clone(), context, now);
+                for worker_id in &worker_ids {
+                    if let Some(worker) = self.workers.get_mut(worker_id) {
+                        worker.update_task_started(job_id, task_id, now);
+                    }
+                }
+                senders.events.on_task_started(
+                    job_id,
+                    task_id,
+                    instance_id,
+                    worker_ids.clone(),
+                    now,
+                );
             }
             TaskState::Finished => {
                 let now = Utc::now();

--- a/crates/hyperqueue/src/server/worker.rs
+++ b/crates/hyperqueue/src/server/worker.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use tako::gateway::LostWorkerReason;
+use tako::gateway::{LostWorkerReason, WorkerRuntimeInfo};
 use tako::worker::WorkerConfiguration;
 
 use crate::WorkerId;
@@ -74,8 +74,9 @@ impl Worker {
         matches!(self.state, WorkerState::Online(_))
     }
 
-    pub fn make_info(&self) -> WorkerInfo {
+    pub fn make_info(&self, runtime_info: Option<WorkerRuntimeInfo>) -> WorkerInfo {
         WorkerInfo {
+            runtime_info,
             id: self.worker_id,
             configuration: self.configuration.clone(),
             started: self.started_at(),

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -419,12 +419,20 @@ pub struct WorkerExitInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TaskTimestamp {
+    pub job_id: JobId,
+    pub task_id: JobTaskId,
+    pub time: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WorkerInfo {
     pub id: WorkerId,
     pub configuration: WorkerConfiguration,
     pub started: DateTime<Utc>,
     pub ended: Option<WorkerExitInfo>,
     pub runtime_info: Option<WorkerRuntimeInfo>,
+    pub last_task_started: Option<TaskTimestamp>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::server::event::Event;
-use tako::gateway::{LostWorkerReason, ResourceRequestVariants};
+use tako::gateway::{LostWorkerReason, ResourceRequestVariants, WorkerRuntimeInfo};
 use tako::program::ProgramDefinition;
 use tako::worker::WorkerConfiguration;
 
@@ -261,6 +261,7 @@ pub struct StopWorkerMessage {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct WorkerInfoRequest {
     pub worker_id: WorkerId,
+    pub runtime_info: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -423,6 +424,7 @@ pub struct WorkerInfo {
     pub configuration: WorkerConfiguration,
     pub started: DateTime<Utc>,
     pub ended: Option<WorkerExitInfo>,
+    pub runtime_info: Option<WorkerRuntimeInfo>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/tako/src/gateway.rs
+++ b/crates/tako/src/gateway.rs
@@ -183,6 +183,7 @@ pub enum FromGatewayMessage {
     CancelTasks(CancelTasks),
     GetTaskInfo(TaskInfoRequest),
     ServerInfo,
+    WorkerInfo(WorkerId),
     StopWorker(StopWorkerRequest),
     NewWorkerQuery(NewWorkerQuery),
     TryReleaseMemory,
@@ -240,6 +241,18 @@ pub struct TaskFailedMessage {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ServerInfo {
     pub worker_listen_port: u16,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum WorkerRuntimeInfo {
+    SingleNodeTasks {
+        assigned_tasks: u32,
+        running_tasks: u32,
+        is_reserved: bool,
+    },
+    MultiNodeTask {
+        main_node: bool,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -320,6 +333,7 @@ pub enum ToGatewayMessage {
     TaskInfo(TasksInfoResponse),
     Error(ErrorResponse),
     ServerInfo(ServerInfo),
+    WorkerInfo(Option<WorkerRuntimeInfo>),
     NewWorker(NewWorkerMessage),
     LostWorker(LostWorkerMessage),
     WorkerOverview(WorkerOverview),

--- a/crates/tako/src/internal/server/client.rs
+++ b/crates/tako/src/internal/server/client.rs
@@ -65,9 +65,11 @@ pub(crate) async fn process_client_message(
         ),
         FromGatewayMessage::ServerInfo => {
             let core = core_ref.get();
-            assert!(client_sender
-                .send(ToGatewayMessage::ServerInfo(core.get_server_info()))
-                .is_ok());
+            assert!(
+                client_sender
+                    .send(ToGatewayMessage::ServerInfo(core.get_server_info()))
+                    .is_ok()
+            );
             None
         }
         FromGatewayMessage::GetTaskInfo(request) => {
@@ -94,11 +96,13 @@ pub(crate) async fn process_client_message(
                     }
                 })
                 .collect();
-            assert!(client_sender
-                .send(ToGatewayMessage::TaskInfo(TasksInfoResponse {
-                    tasks: task_infos
-                }))
-                .is_ok());
+            assert!(
+                client_sender
+                    .send(ToGatewayMessage::TaskInfo(TasksInfoResponse {
+                        tasks: task_infos
+                    }))
+                    .is_ok()
+            );
             None
         }
         FromGatewayMessage::CancelTasks(msg) => {
@@ -107,12 +111,14 @@ pub(crate) async fn process_client_message(
             let mut comm = comm_ref.get_mut();
             let (cancelled_tasks, already_finished) =
                 on_cancel_tasks(&mut core, &mut *comm, &msg.tasks);
-            assert!(client_sender
-                .send(ToGatewayMessage::CancelTasksResponse(CancelTasksResponse {
-                    cancelled_tasks,
-                    already_finished
-                }))
-                .is_ok());
+            assert!(
+                client_sender
+                    .send(ToGatewayMessage::CancelTasksResponse(CancelTasksResponse {
+                        cancelled_tasks,
+                        already_finished
+                    }))
+                    .is_ok()
+            );
             None
         }
         FromGatewayMessage::StopWorker(msg) => {
@@ -145,9 +151,11 @@ pub(crate) async fn process_client_message(
                 let core = core_ref.get();
                 compute_new_worker_query(&core, &msg.worker_queries)
             };
-            assert!(client_sender
-                .send(ToGatewayMessage::NewWorkerAllocationQueryResponse(response))
-                .is_ok());
+            assert!(
+                client_sender
+                    .send(ToGatewayMessage::NewWorkerAllocationQueryResponse(response))
+                    .is_ok()
+            );
             None
         }
         FromGatewayMessage::TryReleaseMemory => {
@@ -161,9 +169,11 @@ pub(crate) async fn process_client_message(
                 .get_worker_map()
                 .get(&worker_id)
                 .map(|w| w.worker_info(core.task_map()));
-            assert!(client_sender
-                .send(ToGatewayMessage::WorkerInfo(response))
-                .is_ok());
+            assert!(
+                client_sender
+                    .send(ToGatewayMessage::WorkerInfo(response))
+                    .is_ok()
+            );
             None
         }
     }
@@ -217,10 +227,12 @@ fn handle_new_tasks(
     }
     on_new_tasks(core, comm, tasks);
 
-    assert!(client_sender
-        .send(ToGatewayMessage::NewTasksResponse(NewTasksResponse {
-            n_waiting_for_workers: 0 // TODO
-        }))
-        .is_ok());
+    assert!(
+        client_sender
+            .send(ToGatewayMessage::NewTasksResponse(NewTasksResponse {
+                n_waiting_for_workers: 0 // TODO
+            }))
+            .is_ok()
+    );
     None
 }

--- a/crates/tako/src/internal/server/client.rs
+++ b/crates/tako/src/internal/server/client.rs
@@ -65,11 +65,9 @@ pub(crate) async fn process_client_message(
         ),
         FromGatewayMessage::ServerInfo => {
             let core = core_ref.get();
-            assert!(
-                client_sender
-                    .send(ToGatewayMessage::ServerInfo(core.get_server_info()))
-                    .is_ok()
-            );
+            assert!(client_sender
+                .send(ToGatewayMessage::ServerInfo(core.get_server_info()))
+                .is_ok());
             None
         }
         FromGatewayMessage::GetTaskInfo(request) => {
@@ -96,13 +94,11 @@ pub(crate) async fn process_client_message(
                     }
                 })
                 .collect();
-            assert!(
-                client_sender
-                    .send(ToGatewayMessage::TaskInfo(TasksInfoResponse {
-                        tasks: task_infos
-                    }))
-                    .is_ok()
-            );
+            assert!(client_sender
+                .send(ToGatewayMessage::TaskInfo(TasksInfoResponse {
+                    tasks: task_infos
+                }))
+                .is_ok());
             None
         }
         FromGatewayMessage::CancelTasks(msg) => {
@@ -111,14 +107,12 @@ pub(crate) async fn process_client_message(
             let mut comm = comm_ref.get_mut();
             let (cancelled_tasks, already_finished) =
                 on_cancel_tasks(&mut core, &mut *comm, &msg.tasks);
-            assert!(
-                client_sender
-                    .send(ToGatewayMessage::CancelTasksResponse(CancelTasksResponse {
-                        cancelled_tasks,
-                        already_finished
-                    }))
-                    .is_ok()
-            );
+            assert!(client_sender
+                .send(ToGatewayMessage::CancelTasksResponse(CancelTasksResponse {
+                    cancelled_tasks,
+                    already_finished
+                }))
+                .is_ok());
             None
         }
         FromGatewayMessage::StopWorker(msg) => {
@@ -151,16 +145,25 @@ pub(crate) async fn process_client_message(
                 let core = core_ref.get();
                 compute_new_worker_query(&core, &msg.worker_queries)
             };
-            assert!(
-                client_sender
-                    .send(ToGatewayMessage::NewWorkerAllocationQueryResponse(response))
-                    .is_ok()
-            );
+            assert!(client_sender
+                .send(ToGatewayMessage::NewWorkerAllocationQueryResponse(response))
+                .is_ok());
             None
         }
         FromGatewayMessage::TryReleaseMemory => {
             let mut core = core_ref.get_mut();
             core.try_release_memory();
+            None
+        }
+        FromGatewayMessage::WorkerInfo(worker_id) => {
+            let core = core_ref.get();
+            let response = core
+                .get_worker_map()
+                .get(&worker_id)
+                .map(|w| w.worker_info(core.task_map()));
+            assert!(client_sender
+                .send(ToGatewayMessage::WorkerInfo(response))
+                .is_ok());
             None
         }
     }
@@ -214,12 +217,10 @@ fn handle_new_tasks(
     }
     on_new_tasks(core, comm, tasks);
 
-    assert!(
-        client_sender
-            .send(ToGatewayMessage::NewTasksResponse(NewTasksResponse {
-                n_waiting_for_workers: 0 // TODO
-            }))
-            .is_ok()
-    );
+    assert!(client_sender
+        .send(ToGatewayMessage::NewTasksResponse(NewTasksResponse {
+            n_waiting_for_workers: 0 // TODO
+        }))
+        .is_ok());
     None
 }

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -3,13 +3,13 @@ use std::rc::Rc;
 use std::time::Duration;
 use thin_vec::ThinVec;
 
-use crate::internal::common::stablemap::ExtractKey;
+use crate::WorkerId;
 use crate::internal::common::Set;
+use crate::internal::common::stablemap::ExtractKey;
 use crate::internal::messages::worker::{ComputeTaskMsg, ToWorkerMessage};
 use crate::internal::server::taskmap::TaskMap;
-use crate::WorkerId;
-use crate::{static_assert_size, TaskId};
 use crate::{InstanceId, Priority};
+use crate::{TaskId, static_assert_size};
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct WaitingInfo {

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -3,13 +3,13 @@ use std::rc::Rc;
 use std::time::Duration;
 use thin_vec::ThinVec;
 
-use crate::WorkerId;
-use crate::internal::common::Set;
 use crate::internal::common::stablemap::ExtractKey;
+use crate::internal::common::Set;
 use crate::internal::messages::worker::{ComputeTaskMsg, ToWorkerMessage};
 use crate::internal::server::taskmap::TaskMap;
+use crate::WorkerId;
+use crate::{static_assert_size, TaskId};
 use crate::{InstanceId, Priority};
-use crate::{TaskId, static_assert_size};
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct WaitingInfo {
@@ -130,8 +130,8 @@ impl Task {
         matches!(self.state, TaskRuntimeState::Running { .. })
     }
 
-    #[cfg(test)]
     #[inline]
+    #[cfg(test)]
     pub(crate) fn is_mn_running(&self) -> bool {
         matches!(self.state, TaskRuntimeState::RunningMultiNode { .. })
     }

--- a/tests/output/test_json.py
+++ b/tests/output/test_json.py
@@ -53,6 +53,7 @@ def test_print_worker_info(hq_env: HqEnv):
             "allocation": None,
             "started": str,
             "ended": None,
+            "runtime_info": {"SingleNodeTasks": {"assigned_tasks": 0, "is_reserved": False, "running_tasks": 0}},
             "id": 1,
         }
     )

--- a/tests/output/test_json.py
+++ b/tests/output/test_json.py
@@ -54,6 +54,7 @@ def test_print_worker_info(hq_env: HqEnv):
             "started": str,
             "ended": None,
             "runtime_info": {"SingleNodeTasks": {"assigned_tasks": 0, "is_reserved": False, "running_tasks": 0}},
+            "last_task_started": None,
             "id": 1,
         }
     )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -317,8 +317,8 @@ def test_deploy_ssh_error(hq_env: HqEnv):
     with hq_env.mock.mock_program_with_code(
         "ssh",
         """
-exit(42)
-""",
+    exit(42)
+    """,
     ):
         nodefile = prepare_localhost_nodefile()
         hq_env.command(["worker", "deploy-ssh", nodefile], expect_fail="Worker exited with code 42")
@@ -351,9 +351,9 @@ def test_deploy_ssh_wait_for_worker(hq_env: HqEnv):
     with hq_env.mock.mock_program_with_code(
         "ssh",
         """
-import time
-time.sleep(1)
-""",
+    import time
+    time.sleep(1)
+    """,
     ):
         nodefile = prepare_localhost_nodefile()
         hq_env.command(["worker", "deploy-ssh", nodefile])
@@ -364,12 +364,12 @@ def test_deploy_ssh_multiple_workers(hq_env: HqEnv):
     with hq_env.mock.mock_program_with_code(
         "ssh",
         """
-import os
-
-os.makedirs("workers", exist_ok=True)
-with open(f"workers/{os.getpid()}", "w") as f:
-    f.write(str(os.getpid()))
-""",
+    import os
+    
+    os.makedirs("workers", exist_ok=True)
+    with open(f"workers/{os.getpid()}", "w") as f:
+        f.write(str(os.getpid()))
+    """,
     ):
         nodefile = prepare_localhost_nodefile(count=3)
         hq_env.command(["worker", "deploy-ssh", nodefile])
@@ -381,8 +381,8 @@ def test_deploy_ssh_show_output(hq_env: HqEnv):
     with hq_env.mock.mock_program_with_code(
         "ssh",
         """
-print("FOOBAR")
-""",
+    print("FOOBAR")
+    """,
     ):
         nodefile = prepare_localhost_nodefile(count=3)
         output = hq_env.command(["worker", "deploy-ssh", "--show-output", nodefile])
@@ -409,3 +409,21 @@ def prepare_localhost_nodefile(count: int = 1) -> str:
         for _ in range(count):
             print("localhost", file=f)
     return path
+
+
+def test_worker_state_info(hq_env: HqEnv):
+    hq_env.start_server()
+    hq_env.start_worker()
+    hq_env.command(["submit", "--array=1-2", "--", "sleep", "1"])
+    wait_for_job_state(hq_env, 1, "RUNNING")
+    table = hq_env.command(["worker", "info", "1"], as_table=True)
+    table.check_row_value("State", "RUNNING")
+    table.check_row_value("Runtime Info", "Assigned tasks: 2; Running tasks: 1")
+    hq_env.start_worker()
+    hq_env.command(["submit", "--nodes=2", "--", "sleep", "1"])
+    wait_for_job_state(hq_env, 2, "RUNNING")
+    table = hq_env.command(["worker", "info", "1"], as_table=True)
+    a = table.get_row_value("Runtime Info")
+    table = hq_env.command(["worker", "info", "2"], as_table=True)
+    b = table.get_row_value("Runtime Info")
+    assert {a, b} == {"Running multinode task; main node", "Running multinode task; secondary node"}

--- a/tests/utils/mock.py
+++ b/tests/utils/mock.py
@@ -29,7 +29,9 @@ class ProgramMock:
 
     @contextlib.contextmanager
     def mock_program_with_code(self, name: str, code: str):
-        content = f"#!{sys.executable}\n{code}"
+        import textwrap
+
+        content = f"#!{sys.executable}\n{textwrap.dedent(code)}"
         program_path = self.directory / name
         assert not program_path.is_file()
 


### PR DESCRIPTION
`hq worker info` now shows state and runtime info (a information from the scheduler about assigned and running tasks).

Idea occured in #784.
