### PR TITLE
Reconstruct events from current server state when streaming without a journal

### DIFF
--- a/crates/hyperqueue/src/client/commands/server.rs
+++ b/crates/hyperqueue/src/client/commands/server.rs
@@ -216,7 +216,7 @@ pub async fn print_server_info(gsettings: &GlobalSettings) -> anyhow::Result<()>
     gsettings
         .printer()
         // We are not using gsettings.server_directory() as it is local one
-        .print_server_description(None, &response);
+        .print_server_info(None, &response);
     Ok(())
 }
 

--- a/crates/hyperqueue/src/client/output/cli.rs
+++ b/crates/hyperqueue/src/client/output/cli.rs
@@ -389,27 +389,47 @@ impl Output for CliOutput {
         self.print_vertical_table(rows);
     }
 
-    fn print_server_description(&self, server_dir: Option<&Path>, info: &ServerInfo) {
+    fn print_server_info(&self, server_dir: Option<&Path>, info: &ServerInfo) {
+        let ServerInfo {
+            server_uid,
+            client_host,
+            worker_host,
+            client_port,
+            worker_port,
+            version,
+            pid,
+            start_date,
+            journal_path,
+        } = info;
+
         let mut rows = vec![
             vec![
                 "Server UID".cell().bold(true),
-                info.server_uid.to_string().cell(),
+                server_uid.to_string().cell(),
             ],
             vec![
                 "Client host".cell().bold(true),
-                info.client_host.to_string().cell(),
+                client_host.to_string().cell(),
             ],
-            vec!["Client port".cell().bold(true), info.client_port.cell()],
+            vec!["Client port".cell().bold(true), client_port.cell()],
             vec![
                 "Worker host".cell().bold(true),
-                info.worker_host.to_string().cell(),
+                worker_host.to_string().cell(),
             ],
-            vec!["Worker port".cell().bold(true), info.worker_port.cell()],
-            vec!["Version".cell().bold(true), info.version.to_string().cell()],
-            vec!["Pid".cell().bold(true), info.pid.cell()],
+            vec!["Worker port".cell().bold(true), worker_port.cell()],
+            vec!["Version".cell().bold(true), version.to_string().cell()],
+            vec!["Pid".cell().bold(true), pid.cell()],
             vec![
                 "Start date".cell().bold(true),
-                info.start_date.format("%F %T %Z").cell(),
+                start_date.format("%F %T %Z").cell(),
+            ],
+            vec![
+                "Journal path".cell().bold(true),
+                journal_path
+                    .as_ref()
+                    .map(|p| format!("{}", p.display()))
+                    .unwrap_or_else(|| "".to_string())
+                    .cell(),
             ],
         ];
         if let Some(dir) = server_dir {

--- a/crates/hyperqueue/src/client/output/common.rs
+++ b/crates/hyperqueue/src/client/output/common.rs
@@ -25,16 +25,21 @@ pub fn resolve_task_paths(job: &JobDetail, server_uid: &str) -> TaskToPathsMap {
         Default::default();
 
     for submit_desc in &job.submit_descs {
-        match &submit_desc.task_desc {
+        match &submit_desc.description().task_desc {
             JobTaskDescription::Array { task_desc, ids, .. } => {
                 for id in ids.iter() {
-                    task_to_desc_map
-                        .insert(JobTaskId(id), (submit_desc.submit_dir.as_path(), task_desc));
+                    task_to_desc_map.insert(
+                        JobTaskId(id),
+                        (submit_desc.description().submit_dir.as_path(), task_desc),
+                    );
                 }
             }
             JobTaskDescription::Graph { tasks } => {
                 for t in tasks {
-                    task_to_desc_map.insert(t.id, (submit_desc.submit_dir.as_path(), &t.task_desc));
+                    task_to_desc_map.insert(
+                        t.id,
+                        (submit_desc.description().submit_dir.as_path(), &t.task_desc),
+                    );
                 }
             }
         };

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -50,17 +50,30 @@ impl Output for JsonOutput {
         self.print(format_worker_info(worker_info));
     }
 
-    fn print_server_description(&self, server_dir: Option<&Path>, record: &ServerInfo) {
+    fn print_server_info(&self, server_dir: Option<&Path>, info: &ServerInfo) {
+        let ServerInfo {
+            server_uid,
+            client_host,
+            worker_host,
+            client_port,
+            worker_port,
+            version,
+            pid,
+            start_date,
+            journal_path,
+        } = info;
+
         let json = json!({
             "server_dir": server_dir,
-            "server_uid": record.server_uid,
-            "worker_host": record.worker_host,
-            "client_host": record.client_host,
-            "client_port": record.client_port,
-            "worker_port": record.worker_port,
-            "pid": record.pid,
-            "start_date": record.start_date,
-            "version": record.version,
+            "server_uid": server_uid,
+            "worker_host": worker_host,
+            "client_host": client_host,
+            "client_port": client_port,
+            "worker_port": worker_port,
+            "pid": pid,
+            "start_date": start_date,
+            "version": version,
+            "journal_path": journal_path
         });
         self.print(json);
     }

--- a/crates/hyperqueue/src/client/output/json.rs
+++ b/crates/hyperqueue/src/client/output/json.rs
@@ -129,7 +129,7 @@ impl Output for JsonOutput {
                                     "started_at": format_datetime(submission_date),
                                     "finished_at": finished_at.map(format_datetime),
                                     "submits": submit_descs.iter().map(|submit_desc|
-                match &submit_desc.task_desc {
+                match &submit_desc.description().task_desc {
                                     JobTaskDescription::Array { task_desc, .. } => {
                                         json!({
                                             "array": format_task_description(task_desc)

--- a/crates/hyperqueue/src/client/output/outputs.rs
+++ b/crates/hyperqueue/src/client/output/outputs.rs
@@ -38,7 +38,7 @@ pub trait Output {
     fn print_worker_info(&self, worker_info: WorkerInfo);
 
     // Server
-    fn print_server_description(&self, server_dir: Option<&Path>, record: &ServerInfo);
+    fn print_server_info(&self, server_dir: Option<&Path>, record: &ServerInfo);
 
     // Jobs
     fn print_job_submitted(&self, job: JobDetail);

--- a/crates/hyperqueue/src/client/output/quiet.rs
+++ b/crates/hyperqueue/src/client/output/quiet.rs
@@ -59,7 +59,7 @@ impl Output for Quiet {
     fn print_worker_info(&self, _worker_info: WorkerInfo) {}
 
     // Server
-    fn print_server_description(&self, server_dir: Option<&Path>, _record: &ServerInfo) {
+    fn print_server_info(&self, server_dir: Option<&Path>, _record: &ServerInfo) {
         if let Some(dir) = server_dir {
             println!("{}", dir.display());
         }

--- a/crates/hyperqueue/src/dashboard/data/data.rs
+++ b/crates/hyperqueue/src/dashboard/data/data.rs
@@ -23,6 +23,8 @@ pub struct DashboardData {
     time_mode: TimeMode,
     /// Is streaming from a live server enabled?
     stream_enabled: bool,
+    /// Warning that should be displayed to the user.
+    warning: Option<String>,
 }
 
 impl DashboardData {
@@ -33,7 +35,15 @@ impl DashboardData {
             alloc_timeline: Default::default(),
             time_mode,
             stream_enabled,
+            warning: None,
         }
+    }
+
+    pub fn get_warning(&self) -> Option<&str> {
+        self.warning.as_deref()
+    }
+    pub fn set_warning(&mut self, warning: Option<&str>) {
+        self.warning = warning.map(String::from);
     }
 
     pub fn push_new_events(&mut self, events: Vec<Event>) {

--- a/crates/hyperqueue/src/dashboard/ui_loop.rs
+++ b/crates/hyperqueue/src/dashboard/ui_loop.rs
@@ -31,10 +31,13 @@ pub async fn start_ui_loop(events: PreloadedEvents) -> anyhow::Result<()> {
         PreloadedEvents::FromServer { .. } => true,
     };
     let mut dashboard_data = DashboardData::new(time_mode, stream);
-    let (events, session) = match events {
+    let (mut events, session) = match events {
         PreloadedEvents::FromJournal(events) => (events, None),
         PreloadedEvents::FromServer { events, connection } => (events, Some(connection)),
     };
+
+    // Check that the events are sorted.
+    assert!(events.is_sorted_by_key(|e| e.time));
     dashboard_data.push_new_events(events);
 
     let mut root_screen = RootScreen::default();

--- a/crates/hyperqueue/src/server/autoalloc/estimator.rs
+++ b/crates/hyperqueue/src/server/autoalloc/estimator.rs
@@ -58,7 +58,7 @@ pub fn get_server_task_state(state: &State, queue_info: &QueueInfo) -> ServerTas
 fn can_queue_execute_job(job: &Job, queue_info: &QueueInfo) -> bool {
     job.submit_descs
         .iter()
-        .all(|submit_desc| match &submit_desc.task_desc {
+        .all(|submit_desc| match &submit_desc.description().task_desc {
             JobTaskDescription::Array {
                 task_desc: TaskDescription { resources, .. },
                 ..

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -1021,10 +1021,10 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
 
-    use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     use anyhow::anyhow;
+    use chrono::Utc;
     use derive_builder::Builder;
     use smallvec::smallvec;
     use tako::WorkerId;
@@ -1054,7 +1054,7 @@ mod tests {
         Allocation, AllocationId, AutoAllocResult, LostWorkerDetails, QueueId, QueueInfo,
     };
     use crate::server::event::streamer::EventStreamer;
-    use crate::server::job::Job;
+    use crate::server::job::{Job, SubmittedJobDescription};
     use crate::server::state::{State, StateRef};
     use crate::tests::utils::create_hq_state;
     use crate::transfer::messages::{
@@ -1946,25 +1946,28 @@ mod tests {
             },
             false,
         );
-        job.attach_submit(Arc::new(JobSubmitDescription {
-            task_desc: JobTaskDescription::Array {
-                ids: IntArray::from_range(0, tasks),
-                entries: None,
-                task_desc: TaskDescription {
-                    kind: TaskKind::ExternalProgram(TaskKindProgram {
-                        program: def,
-                        pin_mode: PinMode::None,
-                        task_dir: false,
-                    }),
-                    resources,
-                    time_limit: None,
-                    priority: 0,
-                    crash_limit: 5,
+        job.attach_submit(SubmittedJobDescription::at(
+            Utc::now(),
+            JobSubmitDescription {
+                task_desc: JobTaskDescription::Array {
+                    ids: IntArray::from_range(0, tasks),
+                    entries: None,
+                    task_desc: TaskDescription {
+                        kind: TaskKind::ExternalProgram(TaskKindProgram {
+                            program: def,
+                            pin_mode: PinMode::None,
+                            task_dir: false,
+                        }),
+                        resources,
+                        time_limit: None,
+                        priority: 0,
+                        crash_limit: 5,
+                    },
                 },
+                submit_dir: Default::default(),
+                stream_path: None,
             },
-            submit_dir: Default::default(),
-            stream_path: None,
-        }));
+        ));
         job
     }
 

--- a/crates/hyperqueue/src/server/bootstrap.rs
+++ b/crates/hyperqueue/src/server/bootstrap.rs
@@ -182,6 +182,7 @@ pub async fn initialize_server(
         worker_port: 0, // Will be set later
         pid: std::process::id(),
         start_date: Utc::now(),
+        journal_path: server_cfg.journal_path.clone(),
     });
 
     let (events, event_stream_fut) =
@@ -223,7 +224,7 @@ pub async fn initialize_server(
 
     gsettings
         .printer()
-        .print_server_description(Some(server_directory), state_ref.get().server_info());
+        .print_server_info(Some(server_directory), state_ref.get().server_info());
 
     let end_flag = Arc::new(Notify::new());
     let end_flag_check = end_flag.clone();

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
 
 use bstr::BString;
+use chrono::{DateTime, Utc};
 use tako::Map;
 use tako::Set;
 use thin_vec::ThinVec;
@@ -18,7 +18,7 @@ use crate::common::placeholders::{
     fill_placeholders_after_submit, fill_placeholders_log, normalize_path,
 };
 use crate::server::Senders;
-use crate::server::job::Job;
+use crate::server::job::{Job, SubmittedJobDescription};
 use crate::server::state::{State, StateRef};
 use crate::transfer::messages::{
     JobDescription, JobSubmitDescription, JobTaskDescription, OpenJobResponse, SubmitRequest,
@@ -57,6 +57,7 @@ pub(crate) fn submit_job_desc(
     state: &mut State,
     job_id: JobId,
     mut submit_desc: JobSubmitDescription,
+    submitted_at: DateTime<Utc>,
 ) -> NewTasksMessage {
     prepare_job(job_id, &mut submit_desc, state);
     let new_tasks = create_new_task_message(job_id, &mut submit_desc);
@@ -64,7 +65,7 @@ pub(crate) fn submit_job_desc(
     state
         .get_job_mut(job_id)
         .unwrap()
-        .attach_submit(Arc::new(submit_desc));
+        .attach_submit(SubmittedJobDescription::at(submitted_at, submit_desc));
     new_tasks
 }
 
@@ -180,7 +181,7 @@ pub(crate) async fn handle_submit(
         state.add_job(job);
     }
 
-    let new_tasks = submit_job_desc(&mut state, job_id, submit_desc);
+    let new_tasks = submit_job_desc(&mut state, job_id, submit_desc, Utc::now());
     senders.autoalloc.on_job_created(job_id);
 
     let job_detail = state
@@ -414,14 +415,14 @@ mod tests {
     use crate::make_tako_id;
     use crate::server::client::submit::build_tasks_graph;
     use crate::server::client::validate_submit;
-    use crate::server::job::Job;
+    use crate::server::job::{Job, SubmittedJobDescription};
     use crate::transfer::messages::{
         JobDescription, JobSubmitDescription, JobTaskDescription, PinMode, SubmitResponse,
         TaskDescription, TaskKind, TaskKindProgram, TaskWithDependencies,
     };
+    use chrono::Utc;
     use smallvec::smallvec;
     use std::path::PathBuf;
-    use std::sync::Arc;
     use std::time::Duration;
     use tako::Priority;
     use tako::gateway::{
@@ -466,15 +467,18 @@ mod tests {
             },
             true,
         );
-        job.attach_submit(Arc::new(JobSubmitDescription {
-            task_desc: JobTaskDescription::Array {
-                ids: IntArray::from_range(100, 10),
-                entries: None,
-                task_desc: task_desc(None, 0, 1),
+        job.attach_submit(SubmittedJobDescription::at(
+            Utc::now(),
+            JobSubmitDescription {
+                task_desc: JobTaskDescription::Array {
+                    ids: IntArray::from_range(100, 10),
+                    entries: None,
+                    task_desc: task_desc(None, 0, 1),
+                },
+                submit_dir: Default::default(),
+                stream_path: None,
             },
-            submit_dir: Default::default(),
-            stream_path: None,
-        }));
+        ));
 
         let job_task_desc = JobTaskDescription::Array {
             ids: IntArray::from_range(109, 2),

--- a/crates/hyperqueue/src/server/event/mod.rs
+++ b/crates/hyperqueue/src/server/event/mod.rs
@@ -18,3 +18,9 @@ pub struct Event {
     pub time: DateTime<Utc>,
     pub payload: EventPayload,
 }
+
+impl Event {
+    pub fn at(time: DateTime<Utc>, payload: EventPayload) -> Self {
+        Self { time, payload }
+    }
+}

--- a/crates/hyperqueue/src/server/event/streamer.rs
+++ b/crates/hyperqueue/src/server/event/streamer.rs
@@ -168,6 +168,10 @@ impl EventStreamer {
         );
     }
 
+    pub fn is_journal_enabled(&self) -> bool {
+        self.inner.get().storage_sender.is_some()
+    }
+
     fn send_event(&self, payload: EventPayload, now: Option<DateTime<Utc>>) {
         let mut inner = self.inner.get_mut();
         if inner.storage_sender.is_none() && inner.client_listeners.is_empty() {
@@ -200,7 +204,7 @@ impl EventStreamer {
         );
     }
 
-    pub fn replay_journal(&self, history_sender: mpsc::UnboundedSender<Event>) {
+    pub fn start_journal_replay(&self, history_sender: mpsc::UnboundedSender<Event>) {
         let inner = self.inner.get();
         if let Some(ref streamer) = inner.storage_sender {
             if streamer

--- a/crates/hyperqueue/src/tests/utils.rs
+++ b/crates/hyperqueue/src/tests/utils.rs
@@ -52,5 +52,6 @@ pub fn create_hq_state() -> StateRef {
         version: HQ_VERSION.to_string(),
         pid: std::process::id(),
         start_date: Utc::now(),
+        journal_path: None,
     })
 }

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -329,6 +329,7 @@ pub struct ServerInfo {
     pub version: String,
     pub pid: u32,
     pub start_date: DateTime<Utc>,
+    pub journal_path: Option<PathBuf>,
 }
 
 // Messages server -> client

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -7,11 +7,10 @@ use crate::client::status::Status;
 use crate::common::arraydef::IntArray;
 use crate::common::manager::info::ManagerType;
 use crate::server::autoalloc::{Allocation, QueueId, QueueInfo};
-use crate::server::job::{JobTaskCounters, JobTaskInfo};
+use crate::server::job::{JobTaskCounters, JobTaskInfo, SubmittedJobDescription};
 use crate::{JobId, JobTaskCount, JobTaskId, Map, WorkerId};
 use bstr::BString;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
 
 use crate::server::event::Event;
@@ -445,7 +444,7 @@ pub struct JobInfoResponse {
 pub struct JobDetail {
     pub info: JobInfo,
     pub job_desc: JobDescription,
-    pub submit_descs: Vec<Arc<JobSubmitDescription>>,
+    pub submit_descs: Vec<SubmittedJobDescription>,
     pub tasks: Vec<(JobTaskId, JobTaskInfo)>,
     pub tasks_not_found: Vec<JobTaskId>,
 

--- a/tests/output/test_json.py
+++ b/tests/output/test_json.py
@@ -90,7 +90,7 @@ def test_print_server_record(hq_env: HqEnv):
             "server_uid": str,
             "start_date": str,
             "pid": int,
-            "journal_path": None
+            "journal_path": None,
         }
     )
     schema.validate(output)

--- a/tests/output/test_json.py
+++ b/tests/output/test_json.py
@@ -90,6 +90,7 @@ def test_print_server_record(hq_env: HqEnv):
             "server_uid": str,
             "start_date": str,
             "pid": int,
+            "journal_path": None
         }
     )
     schema.validate(output)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,7 +3,6 @@ import time
 import subprocess
 from typing import List, Callable, Any
 
-from executing.executing import assert_
 from schema import Schema
 
 from .conftest import HqEnv, get_hq_binary

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -81,7 +81,7 @@ def test_server_info(hq_env: HqEnv):
     server_uid = table.get_row_value("Server UID")
     assert len(server_uid) == 6
     assert server_uid.isalnum()
-    assert len(table) == 8
+    assert len(table) == 9
 
 
 def test_server_stop(hq_env: HqEnv):


### PR DESCRIPTION
I wanted to work on https://github.com/It4innovations/hyperqueue/issues/864, but as usually, I got sidetracked.. When I opened the dashboard, I realized that it does not show past events if the server doesn't use a journal. This PR improves that.