### PR TITLE
Disable worker overview by default and make it temporarily overridable when streaming events

### DIFF
--- a/crates/hyperqueue/src/client/commands/journal/mod.rs
+++ b/crates/hyperqueue/src/client/commands/journal/mod.rs
@@ -64,6 +64,7 @@ async fn stream_json(gsettings: &GlobalSettings, live_events: bool) -> anyhow::R
         .connection()
         .send(FromClientMessage::StreamEvents(StreamEvents {
             live_events,
+            enable_worker_overviews: false,
         }))
         .await?;
     let stdout = std::io::stdout();

--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -294,10 +294,10 @@ fn gather_configuration(opts: WorkerStartOpts) -> anyhow::Result<WorkerConfigura
             Some(duration)
         }
     });
-    let overview_configuration = send_overview_interval.map(|interval| OverviewConfiguration {
-        send_interval: interval,
+    let overview_configuration = OverviewConfiguration {
+        send_interval: send_overview_interval,
         gpu_families,
-    });
+    };
 
     Ok(WorkerConfiguration {
         resources,

--- a/crates/hyperqueue/src/dashboard/mod.rs
+++ b/crates/hyperqueue/src/dashboard/mod.rs
@@ -47,6 +47,7 @@ pub async fn preload_dashboard_events(
             connection
                 .send(FromClientMessage::StreamEvents(StreamEvents {
                     live_events: true,
+                    enable_worker_overviews: true,
                 }))
                 .await?;
 

--- a/crates/hyperqueue/src/dashboard/ui/screens/cluster/worker/worker_config_table.rs
+++ b/crates/hyperqueue/src/dashboard/ui/screens/cluster/worker/worker_config_table.rs
@@ -64,10 +64,9 @@ fn create_rows(worker_info: &WorkerConfiguration) -> Vec<WorkerConfigDataRow> {
             label: "Send Overview Interval:",
             data: worker_info
                 .overview_configuration
+                .send_interval
                 .as_ref()
-                .map(|configuration| {
-                    humantime::format_duration(configuration.send_interval).to_string()
-                })
+                .map(|send_interval| humantime::format_duration(*send_interval).to_string())
                 .unwrap_or_else(|| missing_data_str.clone()),
         },
         WorkerConfigDataRow {

--- a/crates/hyperqueue/src/server/client/mod.rs
+++ b/crates/hyperqueue/src/server/client/mod.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use orion::kdf::SecretKey;
-use tako::gateway::{CancelTasks, FromGatewayMessage, StopWorkerRequest, ToGatewayMessage};
+use tako::gateway::{
+    CancelTasks, FromGatewayMessage, StopWorkerRequest, ToGatewayMessage, WorkerOverviewListenerOp,
+};
 use tako::{Set, TaskGroup};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc::UnboundedSender;

--- a/crates/hyperqueue/src/server/event/journal/read.rs
+++ b/crates/hyperqueue/src/server/event/journal/read.rs
@@ -239,48 +239,4 @@ mod tests {
             EventPayload::AllocationFinished(0, _)
         ));
     }
-
-    #[test]
-    fn test_read_bad_data() -> anyhow::Result<()> {
-        // This test simulates the situation from https://github.com/It4innovations/hyperqueue/pull/858,
-        // where a corrupted journal file was causing HQ to allocate enormous amounts of memory.
-        // This test reconstructs a part of that problematic file and checks that HQ correctly
-        // reports a size error rather than going OOM.
-        let tempdir = tempfile::tempdir()?;
-        let journal = tempdir.path().join("journal.bin");
-
-        // Create a new journal start
-        let mut writer = JournalWriter::create_or_append(&journal, None)?;
-        writer.flush()?;
-        // Do not finish the file
-        std::mem::forget(writer);
-
-        // Write known bad data into it
-        let bad_data = [
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 1, 0, 200, 66, 253, 0, 48, 210, 204, 62, 0, 0, 0, 253, 0, 144, 73, 241, 55, 0, 0, 0,
-            253, 95, 251, 247, 59, 186, 0, 0, 0, 253, 140, 194, 17, 205, 108, 0, 0, 0, 252, 53,
-            213, 191, 40, 252, 66, 130, 166, 21, 0, 0, 0, 0, 252, 146, 46, 212, 103, 253, 156, 218,
-            171, 41, 43, 3, 0, 0, 2, 251, 104, 1, 4, 253, 0, 0, 0, 0, 254, 4, 0, 0, 1, 4, 99, 112,
-            117, 115, 32, 127, 0, 126, 0, 125, 0, 124, 0, 123,
-        ];
-        {
-            let mut file = OpenOptions::new().append(true).open(&journal)?;
-            file.write_all(&bad_data)?;
-            file.flush()?;
-        }
-
-        let mut reader = JournalReader::open(&journal)?;
-        let mut reader = &mut reader;
-        reader.next().unwrap()?;
-        reader.next().unwrap()?;
-
-        let error: bincode::Error = reader
-            .next()
-            .unwrap()
-            .expect_err("third read should be an error");
-        assert!(matches!(error.deref(), ErrorKind::SizeLimit));
-
-        Ok(())
-    }
 }

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -88,7 +88,11 @@ pub struct TaskKindProgram {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StreamEvents {
+    /// If false, only replay historical events.
+    /// If true, replay historical events and then start streaming live events.
     pub live_events: bool,
+    /// Enable worker overviews during the event streaming.
+    pub enable_worker_overviews: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/pyhq/src/cluster/worker.rs
+++ b/crates/pyhq/src/cluster/worker.rs
@@ -6,6 +6,7 @@ use hyperqueue::common::utils::network::get_hostname;
 use tokio::task::LocalSet;
 
 use hyperqueue::worker::bootstrap::{finalize_configuration, initialize_worker};
+use tako::internal::worker::configuration::OverviewConfiguration;
 use tako::resources::{
     CPU_RESOURCE_NAME, ResourceDescriptor, ResourceDescriptorItem, ResourceDescriptorKind,
     ResourceIndex,
@@ -44,7 +45,7 @@ impl RunningWorker {
                 group: "default".to_string(),
                 work_dir,
                 heartbeat_interval: Duration::from_secs(10),
-                overview_configuration: None,
+                overview_configuration: OverviewConfiguration::disabled(),
                 idle_timeout: None,
                 time_limit: None,
                 on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/benches/utils/mod.rs
+++ b/crates/tako/benches/utils/mod.rs
@@ -3,6 +3,7 @@ use tako::ItemId;
 use tako::internal::server::core::Core;
 use tako::internal::server::task::{Task, TaskConfiguration};
 use tako::internal::server::worker::Worker;
+use tako::internal::worker::configuration::OverviewConfiguration;
 use tako::resources::{
     CPU_RESOURCE_NAME, ResourceDescriptor, ResourceDescriptorItem, ResourceDescriptorKind,
 };
@@ -33,7 +34,7 @@ pub fn create_worker(id: u64) -> Worker {
             group: "default".to_string(),
             work_dir: Default::default(),
             heartbeat_interval: Default::default(),
-            overview_configuration: None,
+            overview_configuration: OverviewConfiguration::default(),
             idle_timeout: None,
             time_limit: None,
             on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/gateway.rs
+++ b/crates/tako/src/gateway.rs
@@ -178,6 +178,12 @@ pub struct NewWorkerQuery {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+pub enum WorkerOverviewListenerOp {
+    Add,
+    Remove,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(tag = "op")]
 pub enum FromGatewayMessage {
     NewTasks(NewTasksMessage),
@@ -188,6 +194,7 @@ pub enum FromGatewayMessage {
     StopWorker(StopWorkerRequest),
     NewWorkerQuery(NewWorkerQuery),
     TryReleaseMemory,
+    ModifyWorkerOverviewListeners(WorkerOverviewListenerOp),
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/tako/src/internal/messages/worker.rs
+++ b/crates/tako/src/internal/messages/worker.rs
@@ -16,6 +16,8 @@ pub struct WorkerRegistrationResponse {
     pub other_workers: Vec<NewWorkerMsg>,
     pub server_idle_timeout: Option<Duration>,
     pub server_uid: String,
+    /// Override worker overview interval, if the worker does not have it configured
+    pub worker_overview_interval_override: Option<Duration>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/tako/src/internal/messages/worker.rs
+++ b/crates/tako/src/internal/messages/worker.rs
@@ -69,6 +69,10 @@ pub enum ToWorkerMessage {
     NewWorker(NewWorkerMsg),
     LostWorker(WorkerId),
     SetReservation(bool),
+    /// Override the internally set overview interval with a new duration
+    /// if it is **disabled** on the worker.
+    /// If the worker has already enabled overview interval, then this does nothing.
+    SetOverviewIntervalOverride(Option<Duration>),
     Stop,
 }
 

--- a/crates/tako/src/internal/server/core.rs
+++ b/crates/tako/src/internal/server/core.rs
@@ -45,6 +45,9 @@ pub struct Core {
     secret_key: Option<Arc<SecretKey>>,
     server_uid: String,
     custom_conn_handler: Option<CustomConnectionHandler>,
+
+    // How many streaming clients currently want to receive worker overviews
+    worker_overview_listeners: u64,
 }
 
 pub(crate) type CoreRef = WrappedRcRefCell<Core>;
@@ -101,6 +104,13 @@ impl Core {
 
     pub fn server_uid(&self) -> &str {
         &self.server_uid
+    }
+
+    pub fn worker_overview_listeners(&self) -> u64 {
+        self.worker_overview_listeners
+    }
+    pub fn worker_overview_listeners_mut(&mut self) -> &mut u64 {
+        &mut self.worker_overview_listeners
     }
 
     pub(crate) fn multi_node_queue_split_mut(

--- a/crates/tako/src/internal/server/rpc.rs
+++ b/crates/tako/src/internal/server/rpc.rs
@@ -23,7 +23,7 @@ use crate::internal::server::reactor::{
     on_new_worker, on_remove_worker, on_steal_response, on_task_error, on_task_finished,
     on_task_running,
 };
-use crate::internal::server::worker::Worker;
+use crate::internal::server::worker::{DEFAULT_WORKER_OVERVIEW_INTERVAL, Worker};
 use crate::internal::transfer::auth::{
     do_authentication, forward_queue_to_sealed_sink, open_message, serialize,
 };
@@ -173,7 +173,11 @@ async fn worker_rpc_loop(
                 .collect(),
             server_idle_timeout: *core.idle_timeout(),
             server_uid: core.server_uid().to_string(),
-            worker_overview_interval_override: None,
+            worker_overview_interval_override: if core.worker_overview_listeners() > 0 {
+                Some(DEFAULT_WORKER_OVERVIEW_INTERVAL)
+            } else {
+                None
+            },
         }
     };
     queue_sender

--- a/crates/tako/src/internal/server/worker.rs
+++ b/crates/tako/src/internal/server/worker.rs
@@ -43,6 +43,8 @@ pub struct MultiNodeTaskAssignment {
     pub reservation_only: bool,
 }
 
+pub const DEFAULT_WORKER_OVERVIEW_INTERVAL: Duration = Duration::from_secs(2);
+
 pub struct Worker {
     pub(crate) id: WorkerId,
 

--- a/crates/tako/src/internal/tests/integration/utils/worker.rs
+++ b/crates/tako/src/internal/tests/integration/utils/worker.rs
@@ -73,12 +73,10 @@ pub(super) fn create_worker_configuration(
             group: "".to_string(),
             work_dir: Default::default(),
             heartbeat_interval,
-            overview_configuration: send_overview_interval.map(|send_interval| {
-                OverviewConfiguration {
-                    send_interval,
-                    gpu_families: Default::default(),
-                }
-            }),
+            overview_configuration: OverviewConfiguration {
+                send_interval: send_overview_interval,
+                gpu_families: Default::default(),
+            },
             idle_timeout,
             on_server_lost: ServerLostPolicy::Stop,
             time_limit: None,

--- a/crates/tako/src/internal/tests/test_reactor.rs
+++ b/crates/tako/src/internal/tests/test_reactor.rs
@@ -46,10 +46,10 @@ fn test_worker_add() {
         hostname: "test1".to_string(),
         work_dir: Default::default(),
         heartbeat_interval: Duration::from_millis(1000),
-        overview_configuration: Some(OverviewConfiguration {
-            send_interval: Duration::from_millis(1000),
+        overview_configuration: OverviewConfiguration {
+            send_interval: Some(Duration::from_millis(1000)),
             gpu_families: Default::default(),
-        }),
+        },
         idle_timeout: None,
         time_limit: None,
         on_server_lost: ServerLostPolicy::Stop,
@@ -99,10 +99,10 @@ fn test_worker_add() {
         group: "default".to_string(),
         work_dir: Default::default(),
         heartbeat_interval: Duration::from_millis(1000),
-        overview_configuration: Some(OverviewConfiguration {
-            send_interval: Duration::from_millis(1000),
+        overview_configuration: OverviewConfiguration {
+            send_interval: Some(Duration::from_millis(1000)),
             gpu_families: Default::default(),
-        }),
+        },
         idle_timeout: None,
         time_limit: None,
         on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/internal/tests/test_worker.rs
+++ b/crates/tako/src/internal/tests/test_worker.rs
@@ -39,10 +39,10 @@ fn create_test_worker_config() -> WorkerConfiguration {
         group: "default".to_string(),
         work_dir: Default::default(),
         heartbeat_interval: Duration::from_millis(1000),
-        overview_configuration: Some(OverviewConfiguration {
-            send_interval: Duration::from_millis(1000),
+        overview_configuration: OverviewConfiguration {
+            send_interval: Some(Duration::from_millis(1000)),
             gpu_families: Default::default(),
-        }),
+        },
         idle_timeout: None,
         time_limit: None,
         on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/internal/tests/utils/env.rs
+++ b/crates/tako/src/internal/tests/utils/env.rs
@@ -113,10 +113,10 @@ impl TestEnv {
                 group: "default".to_string(),
                 work_dir: Default::default(),
                 heartbeat_interval: Duration::from_millis(1000),
-                overview_configuration: Some(OverviewConfiguration {
-                    send_interval: Duration::from_millis(1000),
+                overview_configuration: OverviewConfiguration {
+                    send_interval: Some(Duration::from_millis(1000)),
                     gpu_families: Default::default(),
-                }),
+                },
                 idle_timeout: None,
                 time_limit: *time_limit,
                 on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/internal/tests/utils/schedule.rs
+++ b/crates/tako/src/internal/tests/utils/schedule.rs
@@ -26,10 +26,10 @@ pub fn create_test_worker_config(
         group: "default".to_string(),
         work_dir: Default::default(),
         heartbeat_interval: Duration::from_millis(1000),
-        overview_configuration: Some(OverviewConfiguration {
-            send_interval: Duration::from_millis(1000),
+        overview_configuration: OverviewConfiguration {
+            send_interval: Some(Duration::from_millis(1000)),
             gpu_families: Default::default(),
-        }),
+        },
         idle_timeout: None,
         time_limit: None,
         on_server_lost: ServerLostPolicy::Stop,

--- a/crates/tako/src/internal/worker/configuration.rs
+++ b/crates/tako/src/internal/worker/configuration.rs
@@ -12,12 +12,22 @@ pub enum ServerLostPolicy {
     FinishRunning,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct OverviewConfiguration {
-    /// How often should overview be gathered
-    pub send_interval: Duration,
+    /// How often should overview be gathered.
+    /// If `None`, worker overview is currently disabled.
+    pub send_interval: Option<Duration>,
     /// GPU families to monitor
     pub gpu_families: Set<GpuFamily>,
+}
+
+impl OverviewConfiguration {
+    pub fn disabled() -> Self {
+        Self {
+            send_interval: None,
+            gpu_families: Default::default(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -29,7 +39,7 @@ pub struct WorkerConfiguration {
     pub group: String,
     pub work_dir: PathBuf,
     pub heartbeat_interval: Duration,
-    pub overview_configuration: Option<OverviewConfiguration>,
+    pub overview_configuration: OverviewConfiguration,
     pub idle_timeout: Option<Duration>,
     pub time_limit: Option<Duration>,
     pub on_server_lost: ServerLostPolicy,

--- a/crates/tako/src/internal/worker/configuration.rs
+++ b/crates/tako/src/internal/worker/configuration.rs
@@ -28,6 +28,11 @@ impl OverviewConfiguration {
             gpu_families: Default::default(),
         }
     }
+
+    /// Returns true if the user explicitly enabled overview for this worker.
+    pub fn is_overview_enabled(&self) -> bool {
+        self.send_interval.is_some()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/tako/src/internal/worker/rpc.rs
+++ b/crates/tako/src/internal/worker/rpc.rs
@@ -430,6 +430,9 @@ pub(crate) fn process_worker_message(state: &mut WorkerState, message: ToWorkerM
             log::info!("Received stop command");
             return true;
         }
+        ToWorkerMessage::SetOverviewIntervalOverride(r#override) => {
+            state.worker_overview_interval_override = r#override;
+        }
     }
     false
 }
@@ -509,8 +512,10 @@ async fn send_overview_loop(state_ref: WorkerStateRef) -> crate::Result<()> {
         let current_overview_duration = {
             let state = state_ref.get();
             state
-                .worker_overview_interval_override
-                .or(state.configuration.overview_configuration.send_interval)
+                .configuration
+                .overview_configuration
+                .send_interval
+                .or(state.worker_overview_interval_override)
         };
         if let Some(current_duration) = current_overview_duration {
             let _ = trigger_tx.send(()).await;

--- a/crates/tako/src/internal/worker/state.rs
+++ b/crates/tako/src/internal/worker/state.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use orion::aead::SecretKey;
 use rand::SeedableRng;
@@ -43,6 +43,8 @@ pub struct WorkerState {
     pub(crate) random: SmallRng,
 
     pub(crate) configuration: WorkerConfiguration,
+    /// If `Some`, forcefully overrides `configuration.overview_configuration.send_interval`.
+    pub(crate) worker_overview_interval_override: Option<Duration>,
     pub(crate) task_launcher: Box<dyn TaskLauncher>,
     //pub(crate) secret_key: Option<Arc<SecretKey>>,
     pub(crate) start_time: Instant,
@@ -307,6 +309,7 @@ impl WorkerStateRef {
             comm,
             worker_id,
             configuration,
+            worker_overview_interval_override: None,
             task_launcher,
             tasks: Default::default(),
             ready_task_queue,


### PR DESCRIPTION
Fixes: https://github.com/It4innovations/hyperqueue/issues/864