### PR TITLE
Allow configuring job name in Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `hq worker info` contains more information
 * `hq job forget` tries to free more memory
+* You can now configure Job name in the Python API.
 
 ### Fixes
 

--- a/crates/pyhq/python/hyperqueue/ffi/protocol.py
+++ b/crates/pyhq/python/hyperqueue/ffi/protocol.py
@@ -47,5 +47,6 @@ class TaskDescription:
 
 @dataclasses.dataclass
 class JobDescription:
+    name: Optional[str]
     tasks: List[TaskDescription]
     max_fails: Optional[int]

--- a/crates/pyhq/python/hyperqueue/job.py
+++ b/crates/pyhq/python/hyperqueue/job.py
@@ -21,18 +21,21 @@ class Job:
         default_workdir: Optional[GenericPath] = None,
         max_fails: Optional[int] = 1,
         default_env: Optional[EnvType] = None,
+        name: Optional[str] = None,
     ):
         """
         :param default_workdir: Default working directory for tasks.
         :param max_fails: How many tasks can fail before the whole job will be cancelled.
         :param default_env: Environment variables that will be automatically set for each task in
         this job.
+        :param name: Name of the job.
         """
         self.tasks: List[Task] = []
         self.task_map: Dict[TaskId, Task] = {}
         self.max_fails = max_fails
         self.default_workdir = Path(default_workdir).resolve() if default_workdir is not None else default_workdir
         self.default_env = default_env or {}
+        self.name = name
 
     def task_by_id(self, id: TaskId) -> Optional[Task]:
         """
@@ -154,7 +157,7 @@ class Job:
         task_descriptions = []
         for task in self.tasks:
             task_descriptions.append(task._build(client))
-        return JobDescription(task_descriptions, self.max_fails)
+        return JobDescription(name=self.name, tasks=task_descriptions, max_fails=self.max_fails)
 
 
 @dataclasses.dataclass

--- a/crates/pyhq/src/client/job.rs
+++ b/crates/pyhq/src/client/job.rs
@@ -67,6 +67,7 @@ pub struct TaskDescription {
 
 #[derive(Debug, FromPyObject)]
 pub struct PyJobDescription {
+    name: Option<String>,
     tasks: Vec<TaskDescription>,
     max_fails: Option<JobTaskCount>,
 }
@@ -79,7 +80,7 @@ pub fn submit_job_impl(py: Python, ctx: ClientContextPtr, job: PyJobDescription)
 
         let message = FromClientMessage::Submit(SubmitRequest {
             job_desc: JobDescription {
-                name: "".to_string(),
+                name: job.name.unwrap_or_else(|| "PyAPI job".to_string()),
                 max_fails: job.max_fails,
             },
             submit_desc: JobSubmitDescription {

--- a/tests/pyapi/test_job.py
+++ b/tests/pyapi/test_job.py
@@ -328,3 +328,11 @@ def test_resource_min_time(hq_env: HqEnv):
 
     data = hq_env.command(["--output-mode=json", "job", "info", "last"], as_json=True)[0]
     assert data["submits"][0]["graph"][0]["resources"][0]["min_time"] == 42.0
+
+
+def test_job_name(hq_env: HqEnv):
+    (job, client) = prepare_job_client(hq_env, name="Foo")
+    job.program("ls")
+    client.submit(job)
+    data = hq_env.command(["job", "info", "last", "--output-mode", "json"], as_json=True)
+    assert data[0]["info"]["name"] == "Foo"


### PR DESCRIPTION
Fixes: https://github.com/It4innovations/hyperqueue/issues/862