### PR TITLE
Task array data sharing

### DIFF
--- a/crates/hyperqueue/src/client/commands/submit/command.rs
+++ b/crates/hyperqueue/src/client/commands/submit/command.rs
@@ -36,7 +36,8 @@ use chumsky::text::TextParser;
 use clap::{ArgMatches, Parser};
 use smallvec::smallvec;
 use tako::gateway::{
-    ResourceRequest, ResourceRequestEntries, ResourceRequestEntry, ResourceRequestVariants,
+    EntryType, ResourceRequest, ResourceRequestEntries, ResourceRequestEntry,
+    ResourceRequestVariants,
 };
 use tako::program::{FileOnCloseBehavior, ProgramDefinition, StdioDef};
 use tako::resources::{AllocationRequest, CPU_RESOURCE_NAME, NumOfNodes, ResourceAmount};
@@ -759,7 +760,7 @@ pub(crate) async fn send_submit_request(
     Ok(())
 }
 
-fn get_ids_and_entries(opts: &JobSubmitOpts) -> anyhow::Result<(IntArray, Option<Vec<BString>>)> {
+fn get_ids_and_entries(opts: &JobSubmitOpts) -> anyhow::Result<(IntArray, Option<Vec<EntryType>>)> {
     let mut entries = if let Some(ref filename) = opts.conf.each_line {
         Some(read_lines(filename)?)
     } else if let Some(ref filename) = opts.conf.from_json {
@@ -928,20 +929,20 @@ fn validate_name(name: String) -> anyhow::Result<String> {
 }
 
 // We need to read it as bytes, because not all our users use UTF-8
-fn read_lines(filename: &Path) -> anyhow::Result<Vec<BString>> {
+fn read_lines(filename: &Path) -> anyhow::Result<Vec<EntryType>> {
     log::info!("Reading file: {}", filename.display());
     if fs::metadata(filename)?.len() > 100 << 20 {
         log::warn!("Reading file bigger than 100MB");
     };
     let file = std::fs::File::open(filename)?;
-    let results: Result<Vec<BString>, std::io::Error> = io::BufReader::new(file)
+    let results: Result<Vec<EntryType>, std::io::Error> = io::BufReader::new(file)
         .split(b'\n')
-        .map(|x| x.map(BString::from))
+        .map(|x| x.map(EntryType::from))
         .collect();
     Ok(results?)
 }
 
-fn make_entries_from_json(filename: &Path) -> anyhow::Result<Vec<BString>> {
+fn make_entries_from_json(filename: &Path) -> anyhow::Result<Vec<EntryType>> {
     log::info!("Reading json file: {}", filename.display());
     if fs::metadata(filename)?.len() > 100 << 20 {
         log::warn!("Reading file bigger then 100MB");
@@ -954,7 +955,7 @@ fn make_entries_from_json(filename: &Path) -> anyhow::Result<Vec<BString>> {
             .iter()
             .map(|element| {
                 serde_json::to_string(element)
-                    .map(BString::from)
+                    .map(|x| EntryType::from(x.as_bytes()))
                     .map_err(|e| e.into())
             })
             .collect()

--- a/crates/hyperqueue/src/client/commands/submit/jobfile.rs
+++ b/crates/hyperqueue/src/client/commands/submit/jobfile.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 use smallvec::smallvec;
 use std::path::PathBuf;
 use tako::Map;
-use tako::gateway::{ResourceRequest, ResourceRequestVariants, TaskDataFlags};
+use tako::gateway::{EntryType, ResourceRequest, ResourceRequestVariants, TaskDataFlags};
 use tako::program::{FileOnCloseBehavior, ProgramDefinition, StdioDef};
 use tako::{JobId, JobTaskCount, JobTaskId};
 
@@ -110,7 +110,13 @@ fn build_job_desc_array(array: ArrayDef) -> JobTaskDescription {
     let entries = if array.entries.is_empty() {
         None
     } else {
-        Some(array.entries.into_iter().map(|s| s.into()).collect())
+        Some(
+            array
+                .entries
+                .into_iter()
+                .map(|s| EntryType::from(s.as_bytes()))
+                .collect(),
+        )
     };
     JobTaskDescription::Array {
         ids,

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -226,7 +226,6 @@ fn prepare_job(job_id: JobId, submit_desc: &mut JobSubmitDescription, state: &mu
 }
 
 fn serialize_task_body(
-    task_id: TaskId,
     entry: Option<BString>,
     task_desc: &TaskDescription,
     submit_dir: &PathBuf,
@@ -234,7 +233,6 @@ fn serialize_task_body(
 ) -> Box<[u8]> {
     let body_msg = TaskBuildDescription {
         task_kind: Cow::Borrowed(&task_desc.kind),
-        task_id,
         submit_dir: Cow::Borrowed(submit_dir),
         stream_path: stream_path.map(Cow::Borrowed),
         entry,
@@ -267,7 +265,7 @@ fn build_tasks_array(
             .map(|job_task_id| {
                 let task_id = TaskId::new(job_id, job_task_id.into());
                 build_task_conf(
-                    serialize_task_body(task_id, None, task_desc, submit_dir, stream_path),
+                    serialize_task_body(None, task_desc, submit_dir, stream_path),
                     task_id,
                 )
             })
@@ -278,7 +276,7 @@ fn build_tasks_array(
             .map(|(job_task_id, entry)| {
                 let task_id = TaskId::new(job_id, job_task_id.into());
                 build_task_conf(
-                    serialize_task_body(task_id, Some(entry), task_desc, submit_dir, stream_path),
+                    serialize_task_body(Some(entry), task_desc, submit_dir, stream_path),
                     task_id,
                 )
             })
@@ -338,13 +336,7 @@ fn build_tasks_graph(
 
     let mut task_configs = Vec::with_capacity(tasks.len());
     for task in tasks {
-        let body = serialize_task_body(
-            TaskId::new(job_id, task.id),
-            None,
-            &task.task_desc,
-            submit_dir,
-            stream_path,
-        );
+        let body = serialize_task_body(None, &task.task_desc, submit_dir, stream_path);
         let shared_data_index = allocate_shared_data(&task.task_desc, task.data_flags);
 
         let mut task_dep_ids: Set<JobTaskId> = task.task_deps.iter().copied().collect();

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -249,7 +249,7 @@ fn build_tasks_array(
     submit_dir: &PathBuf,
     stream_path: Option<&PathBuf>,
 ) -> TaskSubmit {
-    let build_task_conf = |tako_id: TaskId, entry: Option<ThinVec<u8>>| TaskConfiguration {
+    let build_task_conf = |tako_id: TaskId, entry: Option<EntryType>| TaskConfiguration {
         id: tako_id,
         shared_data_index: 0,
         task_deps: ThinVec::new(),

--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -2,11 +2,11 @@ use std::borrow::Cow;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use bstr::BString;
 use chrono::{DateTime, Utc};
 use tako::Set;
 use tako::gateway::{
-    ResourceRequestVariants, SharedTaskConfiguration, TaskConfiguration, TaskDataFlags, TaskSubmit,
+    EntryType, ResourceRequestVariants, SharedTaskConfiguration, TaskConfiguration, TaskDataFlags,
+    TaskSubmit,
 };
 use tako::{Map, TaskId};
 use thin_vec::ThinVec;
@@ -226,7 +226,6 @@ fn prepare_job(job_id: JobId, submit_desc: &mut JobSubmitDescription, state: &mu
 }
 
 fn serialize_task_body(
-    entry: Option<BString>,
     task_desc: &TaskDescription,
     submit_dir: &PathBuf,
     stream_path: Option<&PathBuf>,
@@ -235,7 +234,6 @@ fn serialize_task_body(
         task_kind: Cow::Borrowed(&task_desc.kind),
         submit_dir: Cow::Borrowed(submit_dir),
         stream_path: stream_path.map(Cow::Borrowed),
-        entry,
     };
     let body = tako::comm::serialize(&body_msg).expect("Could not serialize task body");
     // Make sure that `into_boxed_slice` is a no-op.
@@ -246,17 +244,17 @@ fn serialize_task_body(
 fn build_tasks_array(
     job_id: JobId,
     ids: &IntArray,
-    entries: Option<Vec<BString>>,
+    entries: Option<Vec<EntryType>>,
     task_desc: &TaskDescription,
     submit_dir: &PathBuf,
     stream_path: Option<&PathBuf>,
 ) -> TaskSubmit {
-    let build_task_conf = |body: Box<[u8]>, tako_id: TaskId| TaskConfiguration {
+    let build_task_conf = |tako_id: TaskId, entry: Option<ThinVec<u8>>| TaskConfiguration {
         id: tako_id,
         shared_data_index: 0,
         task_deps: ThinVec::new(),
         dataobj_deps: ThinVec::new(),
-        body,
+        entry,
     };
 
     let tasks = match entries {
@@ -264,10 +262,7 @@ fn build_tasks_array(
             .iter()
             .map(|job_task_id| {
                 let task_id = TaskId::new(job_id, job_task_id.into());
-                build_task_conf(
-                    serialize_task_body(None, task_desc, submit_dir, stream_path),
-                    task_id,
-                )
+                build_task_conf(task_id, None)
             })
             .collect(),
         Some(entries) => ids
@@ -275,10 +270,7 @@ fn build_tasks_array(
             .zip(entries)
             .map(|(job_task_id, entry)| {
                 let task_id = TaskId::new(job_id, job_task_id.into());
-                build_task_conf(
-                    serialize_task_body(Some(entry), task_desc, submit_dir, stream_path),
-                    task_id,
-                )
+                build_task_conf(task_id, Some(entry))
             })
             .collect(),
     };
@@ -291,6 +283,7 @@ fn build_tasks_array(
             priority: task_desc.priority,
             crash_limit: task_desc.crash_limit,
             data_flags: TaskDataFlags::empty(),
+            body: serialize_task_body(task_desc, submit_dir, stream_path),
         }],
         adjust_instance_id_and_crash_counters: Default::default(),
     }
@@ -329,6 +322,7 @@ fn build_tasks_graph(
                     priority: task.priority,
                     crash_limit: task.crash_limit,
                     data_flags,
+                    body: serialize_task_body(task, submit_dir, stream_path),
                 });
                 index
             }) as u32
@@ -336,7 +330,6 @@ fn build_tasks_graph(
 
     let mut task_configs = Vec::with_capacity(tasks.len());
     for task in tasks {
-        let body = serialize_task_body(None, &task.task_desc, submit_dir, stream_path);
         let shared_data_index = allocate_shared_data(&task.task_desc, task.data_flags);
 
         let mut task_dep_ids: Set<JobTaskId> = task.task_deps.iter().copied().collect();
@@ -361,7 +354,7 @@ fn build_tasks_graph(
             shared_data_index,
             task_deps,
             dataobj_deps,
-            body,
+            entry: None,
         });
     }
 

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -12,11 +12,12 @@ use crate::server::event::Event;
 use crate::server::job::{JobTaskCounters, JobTaskInfo, SubmittedJobDescription};
 use std::path::PathBuf;
 use std::time::Duration;
-use tako::gateway::{LostWorkerReason, ResourceRequestVariants, TaskDataFlags, WorkerRuntimeInfo};
+use tako::gateway::{
+    EntryType, LostWorkerReason, ResourceRequestVariants, TaskDataFlags, WorkerRuntimeInfo,
+};
 use tako::program::ProgramDefinition;
 use tako::worker::WorkerConfiguration;
 use tako::{JobId, JobTaskCount, JobTaskId, Map, TaskId, WorkerId};
-use thin_vec::ThinVec;
 
 // Messages client -> server
 #[allow(clippy::large_enum_variant)]
@@ -137,7 +138,7 @@ pub enum JobTaskDescription {
     /// Either a single-task job or a task array usually submitted through the CLI.
     Array {
         ids: IntArray,
-        entries: Option<Vec<ThinVec<u8>>>,
+        entries: Option<Vec<EntryType>>,
         task_desc: TaskDescription,
     },
     /// Generic DAG of tasks usually submitted through the Python binding.

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -10,13 +10,13 @@ use crate::common::manager::info::ManagerType;
 use crate::server::autoalloc::{Allocation, QueueId, QueueInfo};
 use crate::server::event::Event;
 use crate::server::job::{JobTaskCounters, JobTaskInfo, SubmittedJobDescription};
-use bstr::BString;
 use std::path::PathBuf;
 use std::time::Duration;
 use tako::gateway::{LostWorkerReason, ResourceRequestVariants, TaskDataFlags, WorkerRuntimeInfo};
 use tako::program::ProgramDefinition;
 use tako::worker::WorkerConfiguration;
 use tako::{JobId, JobTaskCount, JobTaskId, Map, TaskId, WorkerId};
+use thin_vec::ThinVec;
 
 // Messages client -> server
 #[allow(clippy::large_enum_variant)]
@@ -74,7 +74,6 @@ pub struct TaskBuildDescription<'a> {
     pub task_kind: Cow<'a, TaskKind>,
     pub submit_dir: Cow<'a, PathBuf>,
     pub stream_path: Option<Cow<'a, PathBuf>>,
-    pub entry: Option<BString>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -138,7 +137,7 @@ pub enum JobTaskDescription {
     /// Either a single-task job or a task array usually submitted through the CLI.
     Array {
         ids: IntArray,
-        entries: Option<Vec<BString>>,
+        entries: Option<Vec<ThinVec<u8>>>,
         task_desc: TaskDescription,
     },
     /// Generic DAG of tasks usually submitted through the Python binding.

--- a/crates/hyperqueue/src/transfer/messages.rs
+++ b/crates/hyperqueue/src/transfer/messages.rs
@@ -72,7 +72,6 @@ impl PinMode {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TaskBuildDescription<'a> {
     pub task_kind: Cow<'a, TaskKind>,
-    pub task_id: TaskId,
     pub submit_dir: Cow<'a, PathBuf>,
     pub stream_path: Option<Cow<'a, PathBuf>>,
     pub entry: Option<BString>,

--- a/crates/hyperqueue/src/worker/start/mod.rs
+++ b/crates/hyperqueue/src/worker/start/mod.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use tokio::sync::oneshot::Receiver;
 
 use crate::transfer::messages::{TaskBuildDescription, TaskKind};
+use tako::InstanceId;
 use tako::launcher::{StopReason, TaskBuildContext, TaskLaunchData, TaskLauncher};
-use tako::{InstanceId, TaskId};
 
 use crate::worker::start::program::build_program_task;
 use crate::worker::streamer::StreamerRef;
@@ -47,7 +47,6 @@ impl TaskLauncher for HqTaskLauncher {
 
         let desc: TaskBuildDescription = tako::comm::deserialize(build_ctx.body())?;
         let shared = SharedTaskDescription {
-            task_id: desc.task_id,
             submit_dir: desc.submit_dir.into_owned(),
             stream_path: desc.stream_path.map(|x| x.into_owned()),
             entry: desc.entry,
@@ -65,7 +64,6 @@ impl TaskLauncher for HqTaskLauncher {
 }
 
 struct SharedTaskDescription {
-    task_id: TaskId,
     submit_dir: PathBuf,
     stream_path: Option<PathBuf>,
     entry: Option<BString>,

--- a/crates/hyperqueue/src/worker/start/mod.rs
+++ b/crates/hyperqueue/src/worker/start/mod.rs
@@ -1,4 +1,3 @@
-use bstr::BString;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tokio::sync::oneshot::Receiver;
@@ -49,7 +48,6 @@ impl TaskLauncher for HqTaskLauncher {
         let shared = SharedTaskDescription {
             submit_dir: desc.submit_dir.into_owned(),
             stream_path: desc.stream_path.map(|x| x.into_owned()),
-            entry: desc.entry,
         };
         match desc.task_kind.into_owned() {
             TaskKind::ExternalProgram(program) => build_program_task(
@@ -66,5 +64,4 @@ impl TaskLauncher for HqTaskLauncher {
 struct SharedTaskDescription {
     submit_dir: PathBuf,
     stream_path: Option<PathBuf>,
-    entry: Option<BString>,
 }

--- a/crates/hyperqueue/src/worker/start/program.rs
+++ b/crates/hyperqueue/src/worker/start/program.rs
@@ -58,7 +58,6 @@ pub(super) fn build_program_task(
     let SharedTaskDescription {
         submit_dir,
         stream_path,
-        entry,
     } = shared;
 
     let task_id = build_ctx.task_id();
@@ -79,8 +78,10 @@ pub(super) fn build_program_task(
             HQ_SUBMIT_DIR.into(),
             BString::from(submit_dir.to_string_lossy().as_bytes()),
         );
-        if let Some(entry) = entry {
-            program.env.insert(HQ_ENTRY.into(), entry);
+        if let Some(entry) = build_ctx.entry() {
+            program
+                .env
+                .insert(HQ_ENTRY.into(), BString::from(entry.as_ref()));
         }
 
         pin_program(&mut program, build_ctx.allocation(), pin_mode, &build_ctx)?;

--- a/crates/hyperqueue/src/worker/start/program.rs
+++ b/crates/hyperqueue/src/worker/start/program.rs
@@ -56,11 +56,12 @@ pub(super) fn build_program_task(
         task_dir,
     } = program;
     let SharedTaskDescription {
-        task_id,
         submit_dir,
         stream_path,
         entry,
     } = shared;
+
+    let task_id = build_ctx.task_id();
 
     let (program, task_id, instance_id, task_dir): (
         ProgramDefinition,

--- a/crates/tako/Cargo.toml
+++ b/crates/tako/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["codec"] }
 bytes = { workspace = true }
 smallvec = { workspace = true, features = ["serde"] }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/tako/src/gateway.rs
+++ b/crates/tako/src/gateway.rs
@@ -1,11 +1,10 @@
-use serde::{Deserialize, Serialize};
-use std::fmt::Display;
-
 use crate::internal::common::error::DsError;
 use crate::internal::datasrv::dataobj::DataObjectId;
 use crate::resources::{AllocationRequest, CPU_RESOURCE_NAME, NumOfNodes, ResourceAmount};
 use crate::{InstanceId, Map, Priority, TaskId};
+use serde::{Deserialize, Serialize};
 use smallvec::{SmallVec, smallvec};
+use std::fmt::Display;
 use std::time::Duration;
 use thin_vec::ThinVec;
 
@@ -99,7 +98,7 @@ bitflags::bitflags! {
 
 /// Task data that is often shared by multiple tasks.
 /// It is sent out-of-band in NewTasksMessage to save bandwidth and allocations.
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug)]
 pub struct SharedTaskConfiguration {
     pub resources: ResourceRequestVariants,
 
@@ -110,7 +109,11 @@ pub struct SharedTaskConfiguration {
     pub crash_limit: u32,
 
     pub data_flags: TaskDataFlags,
+
+    pub body: Box<[u8]>,
 }
+
+pub type EntryType = ThinVec<u8>;
 
 /// Task data that is unique for each task.
 #[derive(Deserialize, Serialize, Debug)]
@@ -126,9 +129,7 @@ pub struct TaskConfiguration {
     /// to maintain the invariant.
     pub dataobj_deps: ThinVec<DataObjectId>,
 
-    /// Opaque data that is passed by the gateway user to task launchers.
-    #[serde(with = "serde_bytes")]
-    pub body: Box<[u8]>,
+    pub entry: Option<EntryType>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]

--- a/crates/tako/src/internal/messages/worker.rs
+++ b/crates/tako/src/internal/messages/worker.rs
@@ -1,5 +1,5 @@
 use crate::datasrv::{DataObjectId, OutputId};
-use crate::gateway::TaskDataFlags;
+use crate::gateway::{EntryType, TaskDataFlags};
 use crate::hwstats::WorkerHwStateMessage;
 use crate::internal::common::resources::{ResourceAmount, ResourceIndex};
 use crate::internal::messages::common::TaskFailInfo;
@@ -40,6 +40,8 @@ pub struct ComputeTaskMsg {
 
     #[serde(with = "serde_bytes")]
     pub body: Box<[u8]>,
+
+    pub entry: Option<EntryType>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/tako/src/internal/server/client.rs
+++ b/crates/tako/src/internal/server/client.rs
@@ -42,6 +42,7 @@ fn create_task_configuration(
         user_priority: msg.priority,
         crash_limit: msg.crash_limit,
         data_flags: msg.data_flags,
+        body: msg.body,
     }
 }
 
@@ -81,8 +82,8 @@ pub(crate) fn handle_new_tasks(
             task.id,
             task.task_deps,
             task.dataobj_deps,
+            task.entry,
             conf.clone(),
-            task.body,
         );
         task.scheduler_priority = -(task.id.job_id().as_num() as i32);
         tasks.push(task);

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -75,10 +75,10 @@ pub struct Task {
     pub data_deps: ThinVec<DataObjectId>,
     pub flags: TaskFlags,
     pub configuration: Rc<TaskConfiguration>,
-    pub entry: Option<ThinVec<u8>>,
     pub scheduler_priority: Priority,
     pub instance_id: InstanceId,
     pub crash_counter: u32,
+    pub entry: Option<EntryType>,
 }
 
 // Task is a critical data structure, so we should keep its size in check

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -7,7 +7,7 @@ use crate::WorkerId;
 use crate::internal::common::Set;
 use crate::internal::common::stablemap::ExtractKey;
 
-use crate::gateway::TaskDataFlags;
+use crate::gateway::{EntryType, TaskDataFlags};
 use crate::internal::datasrv::dataobj::DataObjectId;
 
 use crate::internal::messages::worker::{ComputeTaskMsg, ToWorkerMessage};
@@ -63,6 +63,7 @@ pub struct TaskConfiguration {
     pub time_limit: Option<Duration>,
     pub crash_limit: u32,
     pub data_flags: TaskDataFlags,
+    pub body: Box<[u8]>,
 }
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
@@ -74,14 +75,14 @@ pub struct Task {
     pub data_deps: ThinVec<DataObjectId>,
     pub flags: TaskFlags,
     pub configuration: Rc<TaskConfiguration>,
+    pub entry: Option<ThinVec<u8>>,
     pub scheduler_priority: Priority,
     pub instance_id: InstanceId,
     pub crash_counter: u32,
-    pub body: Box<[u8]>,
 }
 
 // Task is a critical data structure, so we should keep its size in check
-static_assert_size!(Task, 120);
+static_assert_size!(Task, 112);
 
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -95,8 +96,8 @@ impl Task {
         id: TaskId,
         task_deps: ThinVec<TaskId>,
         dataobj_deps: ThinVec<DataObjectId>,
+        entry: Option<EntryType>,
         configuration: Rc<TaskConfiguration>,
-        body: Box<[u8]>,
     ) -> Self {
         log::debug!(
             "New task {} {:?} {:?} {:?}",
@@ -115,7 +116,7 @@ impl Task {
             data_deps: dataobj_deps,
             flags,
             configuration,
-            body,
+            entry,
             scheduler_priority: Default::default(),
             state: TaskRuntimeState::Waiting(WaitingInfo { unfinished_deps: 0 }),
             consumers: Default::default(),
@@ -232,7 +233,8 @@ impl Task {
             node_list,
             data_deps: self.data_deps.iter().copied().collect(),
             data_flags: self.configuration.data_flags,
-            body: self.body.clone(),
+            body: self.configuration.body.clone(),
+            entry: self.entry.clone(),
         })
     }
 

--- a/crates/tako/src/internal/tests/integration/utils/task.rs
+++ b/crates/tako/src/internal/tests/integration/utils/task.rs
@@ -107,6 +107,7 @@ pub fn build_task_def_from_config(
         priority: 0,
         crash_limit: 5,
         data_flags: TaskDataFlags::empty(),
+        body: body.into_boxed_slice(),
     };
     (
         TaskConfiguration {
@@ -114,7 +115,7 @@ pub fn build_task_def_from_config(
             shared_data_index: 0,
             task_deps: ThinVec::new(),
             dataobj_deps: ThinVec::new(),
-            body: body.into_boxed_slice(),
+            entry: None,
         },
         conf,
     )

--- a/crates/tako/src/internal/tests/test_worker.rs
+++ b/crates/tako/src/internal/tests/test_worker.rs
@@ -89,6 +89,7 @@ fn create_dummy_compute_msg(task_id: TaskId) -> ComputeTaskMsg {
         data_deps: vec![],
         data_flags: TaskDataFlags::empty(),
         body: Default::default(),
+        entry: None,
     }
 }
 

--- a/crates/tako/src/internal/tests/utils/task.rs
+++ b/crates/tako/src/internal/tests/utils/task.rs
@@ -108,8 +108,8 @@ impl TaskBuilder {
                 user_priority: self.user_priority,
                 crash_limit: self.crash_limit,
                 data_flags: self.data_flags,
+                body: Default::default(),
             }),
-            Default::default(),
         )
     }
 }

--- a/crates/tako/src/internal/tests/utils/task.rs
+++ b/crates/tako/src/internal/tests/utils/task.rs
@@ -102,13 +102,14 @@ impl TaskBuilder {
             self.id,
             self.task_deps.into_iter().collect(),
             self.data_deps,
+            None,
             Rc::new(TaskConfiguration {
                 resources,
                 time_limit: None,
                 user_priority: self.user_priority,
                 crash_limit: self.crash_limit,
                 data_flags: self.data_flags,
-                body: Default::default(),
+                body: Box::new([]),
             }),
         )
     }

--- a/crates/tako/src/internal/worker/task.rs
+++ b/crates/tako/src/internal/worker/task.rs
@@ -1,5 +1,5 @@
 use crate::datasrv::DataObjectId;
-use crate::gateway::TaskDataFlags;
+use crate::gateway::{EntryType, TaskDataFlags};
 use crate::internal::common::resources::Allocation;
 use crate::internal::common::stablemap::ExtractKey;
 use crate::internal::messages::worker::{ComputeTaskMsg, TaskOutput};
@@ -28,6 +28,7 @@ pub struct Task {
     pub resources: crate::internal::common::resources::ResourceRequestVariants,
     pub time_limit: Option<Duration>,
     pub body: Box<[u8]>,
+    pub entry: Option<EntryType>,
     pub node_list: Vec<WorkerId>, // Filled in multi-node tasks; otherwise empty
 
     pub data_deps: Option<Rc<Vec<DataObjectId>>>,
@@ -44,6 +45,7 @@ impl Task {
             resources: message.resources,
             time_limit: message.time_limit,
             body: message.body,
+            entry: message.entry,
             node_list: message.node_list,
             data_deps: (!message.data_deps.is_empty()).then(|| Rc::new(message.data_deps)),
             data_flags: message.data_flags,

--- a/crates/tako/src/internal/worker/test_util.rs
+++ b/crates/tako/src/internal/worker/test_util.rs
@@ -71,6 +71,7 @@ impl WorkerTaskBuilder {
                 data_deps: self.data_deps,
                 data_flags: self.data_flags,
                 body: Default::default(),
+                entry: None,
             },
             self.task_state,
         )

--- a/crates/tako/src/launcher.rs
+++ b/crates/tako/src/launcher.rs
@@ -10,7 +10,7 @@ use bstr::{BString, ByteSlice};
 use nix::libc;
 use tokio::process::Command;
 
-use crate::gateway::TaskDataFlags;
+use crate::gateway::{EntryType, TaskDataFlags};
 use crate::internal::common::resources::map::ResourceMap;
 use crate::internal::worker::configuration::WorkerConfiguration;
 use crate::internal::worker::localcomm::Token;
@@ -80,6 +80,10 @@ pub struct TaskBuildContext<'a> {
 impl<'a> TaskBuildContext<'a> {
     pub fn task_id(&self) -> TaskId {
         self.task.id
+    }
+
+    pub fn entry(&self) -> Option<&EntryType> {
+        self.task.entry.as_ref()
     }
 
     pub fn resources(&self) -> &'a ResourceRequest {


### PR DESCRIPTION
Each task in Tako contains serialized payload of task data.
Previously, each task had its own payload even they came from the task array.

This PR changes it. Payload no longer contains task id and entry, so they can be shared across the task array.
It is first step of larger scheduler changes, but if @Kobzol has time, I would be curious if it has measurable performance implications.