### PR TITLE
pyhq: release version constraint on cloudpickle

### DIFF
--- a/crates/pyhq/pyproject.toml
+++ b/crates/pyhq/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
 requires-python = ">=3.9"
 description = "HyperQueue Python API"
 dependencies = [
-    "cloudpickle>=2.0,<3",
+    "cloudpickle>=2.0,<4",
     "tqdm>=4.60,<5"
 ]
 dynamic = ["version"]


### PR DESCRIPTION
There is cloudpickle 3.1.1 now and hyperqueue seems to work just fine with this version.