### PR TITLE
Sync scheduler query + scheduler refactor

### DIFF
--- a/crates/tako/src/internal/scheduler/query.rs
+++ b/crates/tako/src/internal/scheduler/query.rs
@@ -12,12 +12,15 @@ struct WorkerTypeState {
     max: u32,
 }
 
-/* Read the documentation of `new_worker_query`` in control.rs */
+/// Read the documentation of `new_worker_query`` in control.rs
 pub(crate) fn compute_new_worker_query(
     core: &mut Core,
     queries: &[WorkerTypeQuery],
 ) -> NewWorkerAllocationResponse {
     log::debug!("Compute new worker query: query = {:?}", queries);
+
+    // Scheduler has to be performed before the query, so there should be no ready_to_assign tasks
+    assert!(core.sn_ready_to_assign().is_empty() || !core.has_workers());
 
     let add_task = |new_loads: &mut [WorkerTypeState], task: &Task| {
         let request = &task.configuration.resources;

--- a/crates/tako/src/internal/scheduler/state.rs
+++ b/crates/tako/src/internal/scheduler/state.rs
@@ -340,16 +340,6 @@ impl SchedulerState {
 
     /// Returns true if balancing is needed.
     fn schedule_available_tasks(&mut self, core: &mut Core) -> bool {
-        let multi_node_ready_tasks = core.take_multi_node_ready_to_assign();
-        if !multi_node_ready_tasks.is_empty() {
-            let (multi_node_queue, task_map, _, _) = core.multi_node_queue_split_mut();
-            for task_id in multi_node_ready_tasks {
-                if let Some(task) = task_map.find_task(task_id) {
-                    multi_node_queue.add_task(task)
-                }
-            }
-        }
-
         if !core.has_workers() {
             return false;
         }

--- a/crates/tako/src/internal/tests/integration/test_basic.rs
+++ b/crates/tako/src/internal/tests/integration/test_basic.rs
@@ -113,12 +113,11 @@ async fn test_task_time_limit_pass() {
     .await;
 }
 
-async fn query_helper(
+fn query_helper(
     handler: &mut ServerHandle,
     worker_queries: Vec<WorkerTypeQuery>,
 ) -> NewWorkerAllocationResponse {
-    let result = handler.server_ref.new_worker_query(worker_queries).unwrap();
-    result.await.unwrap()
+    handler.server_ref.new_worker_query(worker_queries).unwrap()
 }
 
 #[tokio::test]
@@ -137,8 +136,7 @@ async fn test_query_no_output_immediate_call() {
                 max_worker_per_allocation: 2,
                 min_utilization: 0.0,
             }],
-        )
-        .await;
+        );
         assert_eq!(msg.single_node_allocations, vec![0]);
         assert!(msg.multi_node_allocations.is_empty());
         handler.wait(&ids).await;
@@ -163,8 +161,7 @@ async fn test_query_no_output_delayed_call() {
                 max_worker_per_allocation: 2,
                 min_utilization: 0.0,
             }],
-        )
-        .await;
+        );
         assert_eq!(msg.single_node_allocations, vec![0]);
         assert!(msg.multi_node_allocations.is_empty());
         handler.wait(&ids).await;
@@ -192,8 +189,7 @@ async fn test_query_new_workers_delayed_call() {
                 max_worker_per_allocation: 2,
                 min_utilization: 0.0,
             }],
-        )
-        .await;
+        );
         assert_eq!(msg.single_node_allocations, vec![1]);
         assert!(msg.multi_node_allocations.is_empty());
     })
@@ -219,8 +215,7 @@ async fn test_query_new_workers_immediate() {
                 max_worker_per_allocation: 2,
                 min_utilization: 0.0,
             }],
-        )
-        .await;
+        );
         assert_eq!(msg.single_node_allocations, vec![1]);
         assert!(msg.multi_node_allocations.is_empty());
     })


### PR DESCRIPTION
This PR brings some simplification into the scheduler (removes `multinode_ready_tasks`) and makes the scheduler query synchronous, so it solves some potential races between autoalloc and query.