### PR TITLE
Expose tako integration test utilities to HyperQueue

### DIFF
--- a/crates/tako/Cargo.toml
+++ b/crates/tako/Cargo.toml
@@ -8,6 +8,8 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = { workspace = true }
+derive_builder = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["codec"] }
@@ -27,6 +29,7 @@ bstr = { workspace = true }
 psutil = { workspace = true }
 thin-vec = { workspace = true }
 bitflags = { workspace = true }
+tempfile = { workspace = true }
 
 hashbrown = { version = "0.15", features = ["serde", "inline-more"], default-features = false }
 priority-queue = "2"
@@ -34,10 +37,7 @@ fxhash = "0.2"
 derive_more = { version = "2", features = ["add", "add_assign", "sum"] }
 
 [dev-dependencies]
-anyhow = { workspace = true }
 env_logger = { workspace = true }
-tempfile = { workspace = true }
-derive_builder = { workspace = true }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/tako/src/internal/common/resources/amount.rs
+++ b/crates/tako/src/internal/common/resources/amount.rs
@@ -71,6 +71,12 @@ impl ResourceAmount {
     }
 }
 
+impl From<u32> for ResourceAmount {
+    fn from(val: u32) -> Self {
+        ResourceAmount::new_units(val)
+    }
+}
+
 impl std::fmt::Display for ResourceAmount {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let fractions = self.fractions();

--- a/crates/tako/src/internal/common/resources/descriptor.rs
+++ b/crates/tako/src/internal/common/resources/descriptor.rs
@@ -184,6 +184,27 @@ pub struct ResourceDescriptorItem {
     pub kind: ResourceDescriptorKind,
 }
 
+impl ResourceDescriptorItem {
+    pub fn range(name: &str, start: u32, end: u32) -> Self {
+        ResourceDescriptorItem {
+            name: name.to_string(),
+            kind: ResourceDescriptorKind::Range {
+                start: start.into(),
+                end: end.into(),
+            },
+        }
+    }
+
+    pub fn sum(name: &str, size: u32) -> Self {
+        ResourceDescriptorItem {
+            name: name.to_string(),
+            kind: ResourceDescriptorKind::Sum {
+                size: ResourceAmount::new_units(size),
+            },
+        }
+    }
+}
+
 /// Most precise description of request provided by a worker (without time resource)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ResourceDescriptor {
@@ -227,27 +248,6 @@ impl ResourceDescriptor {
 mod tests {
     use super::*;
     use crate::resources::CPU_RESOURCE_NAME;
-
-    impl ResourceDescriptorItem {
-        pub fn range(name: &str, start: u32, end: u32) -> Self {
-            ResourceDescriptorItem {
-                name: name.to_string(),
-                kind: ResourceDescriptorKind::Range {
-                    start: start.into(),
-                    end: end.into(),
-                },
-            }
-        }
-
-        pub fn sum(name: &str, size: u32) -> Self {
-            ResourceDescriptorItem {
-                name: name.to_string(),
-                kind: ResourceDescriptorKind::Sum {
-                    size: ResourceAmount::new_units(size),
-                },
-            }
-        }
-    }
 
     impl ResourceDescriptor {
         pub fn simple(n_cpus: ResourceUnits) -> Self {

--- a/crates/tako/src/internal/tests/integration/mod.rs
+++ b/crates/tako/src/internal/tests/integration/mod.rs
@@ -1,5 +1,10 @@
+#[cfg(test)]
 mod test_basic;
+#[cfg(test)]
 mod test_resources;
+#[cfg(test)]
 mod test_secret;
+#[cfg(test)]
 mod test_worker;
-mod utils;
+
+pub mod utils;

--- a/crates/tako/src/internal/tests/integration/test_basic.rs
+++ b/crates/tako/src/internal/tests/integration/test_basic.rs
@@ -1,6 +1,6 @@
 use crate::control::{NewWorkerAllocationResponse, WorkerTypeQuery};
 use crate::internal::tests::integration::utils::check_file_contents;
-use crate::internal::tests::integration::utils::server::{ServerHandle, run_test};
+use crate::internal::tests::integration::utils::server::{ServerHandle, run_server_test};
 use crate::internal::tests::integration::utils::task::ResourceRequestConfigBuilder;
 use crate::internal::tests::integration::utils::task::{
     GraphBuilder, TaskConfigBuilder, simple_args, simple_task,
@@ -12,7 +12,7 @@ use tokio::time::sleep;
 
 #[tokio::test]
 async fn test_submit_simple_task_ok() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let worker = handler.start_worker(Default::default()).await.unwrap();
 
         let stdout = worker.workdir.join("test.out");
@@ -48,7 +48,7 @@ async fn test_submit_simple_task_ok() {
 
 #[tokio::test]
 async fn test_submit_simple_task_fail() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         handler.start_worker(Default::default()).await.unwrap();
 
         let ids = handler
@@ -77,7 +77,7 @@ async fn test_submit_simple_task_fail() {
 
 #[tokio::test]
 async fn test_task_time_limit_fail() {
-    run_test(Default::default(), |mut handle| async move {
+    run_server_test(Default::default(), |mut handle| async move {
         handle.start_worker(Default::default()).await.unwrap();
 
         handle
@@ -98,7 +98,7 @@ async fn test_task_time_limit_fail() {
 
 #[tokio::test]
 async fn test_task_time_limit_pass() {
-    run_test(Default::default(), |mut handle| async move {
+    run_server_test(Default::default(), |mut handle| async move {
         handle.start_worker(Default::default()).await.unwrap();
 
         handle
@@ -122,7 +122,7 @@ fn query_helper(
 
 #[tokio::test]
 async fn test_query_no_output_immediate_call() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         handler.start_worker(Default::default()).await.unwrap();
         let ids = handler
             .submit(GraphBuilder::singleton(simple_task(&["sleep", "1"], 1)))
@@ -146,7 +146,7 @@ async fn test_query_no_output_immediate_call() {
 
 #[tokio::test]
 async fn test_query_no_output_delayed_call() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         handler.start_worker(Default::default()).await.unwrap();
         let ids = handler
             .submit(GraphBuilder::singleton(simple_task(&["sleep", "1"], 1)))
@@ -171,7 +171,7 @@ async fn test_query_no_output_delayed_call() {
 
 #[tokio::test]
 async fn test_query_new_workers_delayed_call() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         handler.start_worker(Default::default()).await.unwrap();
         let _ = handler
             .submit(GraphBuilder::singleton(
@@ -198,7 +198,7 @@ async fn test_query_new_workers_delayed_call() {
 
 #[tokio::test]
 async fn test_query_new_workers_immediate() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         handler.start_worker(Default::default()).await.unwrap();
         let _ = handler
             .submit(GraphBuilder::singleton(

--- a/crates/tako/src/internal/tests/integration/test_resources.rs
+++ b/crates/tako/src/internal/tests/integration/test_resources.rs
@@ -6,7 +6,7 @@ use crate::WorkerId;
 use crate::internal::tests::integration::utils::api::{
     wait_for_task_start, wait_for_worker_overview, wait_for_workers_overview,
 };
-use crate::internal::tests::integration::utils::server::run_test;
+use crate::internal::tests::integration::utils::server::run_server_test;
 use crate::internal::tests::integration::utils::task::ResourceRequestConfigBuilder as RR;
 use crate::internal::tests::integration::utils::task::{
     GraphBuilder as GB, GraphBuilder, TaskConfigBuilder as TC, simple_args, simple_task,
@@ -16,7 +16,7 @@ use crate::resources::ResourceDescriptor;
 
 #[tokio::test]
 async fn test_submit_2_sleeps_on_1() {
-    run_test(Default::default(), |mut handle| async move {
+    run_server_test(Default::default(), |mut handle| async move {
         handle
             .submit(
                 GraphBuilder::default()
@@ -50,7 +50,7 @@ async fn test_submit_2_sleeps_on_1() {
 
 #[tokio::test]
 async fn test_submit_2_sleeps_on_2() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         handler
             .submit(
                 GraphBuilder::default()
@@ -82,7 +82,7 @@ async fn test_submit_2_sleeps_on_2() {
 
 #[tokio::test]
 async fn test_submit_2_sleeps_on_separated_2() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         handler
             .submit(
                 GraphBuilder::default()
@@ -119,7 +119,7 @@ async fn test_submit_2_sleeps_on_separated_2() {
 
 #[tokio::test]
 async fn test_submit_sleeps_more_cpus1() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let rq1 = RR::default().cpus(3);
         let rq2 = RR::default().cpus(2);
         handler
@@ -167,7 +167,7 @@ async fn test_submit_sleeps_more_cpus1() {
 
 #[tokio::test]
 async fn test_submit_sleeps_more_cpus2() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let rq1 = RR::default().cpus(3);
         let rq2 = RR::default().cpus(2);
         let t = |rq: &RR| {
@@ -202,7 +202,7 @@ async fn test_submit_sleeps_more_cpus2() {
 
 #[tokio::test]
 async fn test_submit_sleeps_more_cpus3() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let rq1 = RR::default().cpus(3);
         let rq2 = RR::default().cpus(2);
         let t = |rq: &RR| {
@@ -238,7 +238,7 @@ async fn test_submit_sleeps_more_cpus3() {
 
 #[tokio::test]
 async fn test_force_compact() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let rq = RR::default().add_force_compact("cpus", 4);
 
         handler

--- a/crates/tako/src/internal/tests/integration/test_secret.rs
+++ b/crates/tako/src/internal/tests/integration/test_secret.rs
@@ -1,5 +1,5 @@
 use crate::internal::tests::integration::utils::server::ServerConfigBuilder;
-use crate::internal::tests::integration::utils::server::{ServerSecretKey, run_test};
+use crate::internal::tests::integration::utils::server::{ServerSecretKey, run_server_test};
 use crate::internal::tests::integration::utils::worker::{WorkerConfigBuilder, WorkerSecretKey};
 use crate::internal::tests::utils::expect_error_message;
 use orion::auth::SecretKey;
@@ -7,7 +7,7 @@ use orion::auth::SecretKey;
 #[tokio::test]
 async fn test_no_auth() {
     let config = ServerConfigBuilder::default().secret_key(ServerSecretKey::Custom(None));
-    run_test(config, |mut handler| async move {
+    run_server_test(config, |mut handler| async move {
         let config = WorkerConfigBuilder::default().secret_key(WorkerSecretKey::Custom(None));
         handler.start_worker(config).await.unwrap();
     })
@@ -17,7 +17,7 @@ async fn test_no_auth() {
 #[tokio::test]
 async fn test_server_auth_worker_no_auth() {
     let config = ServerConfigBuilder::default().secret_key(ServerSecretKey::AutoGenerate);
-    run_test(config, |mut handler| async move {
+    run_server_test(config, |mut handler| async move {
         let config = WorkerConfigBuilder::default().secret_key(WorkerSecretKey::Custom(None));
         expect_error_message(
             handler.start_worker(config).await,
@@ -30,7 +30,7 @@ async fn test_server_auth_worker_no_auth() {
 #[tokio::test]
 async fn test_server_no_auth_worker_auth() {
     let config = ServerConfigBuilder::default().secret_key(ServerSecretKey::Custom(None));
-    run_test(config, |mut handler| async move {
+    run_server_test(config, |mut handler| async move {
         let config = WorkerConfigBuilder::default()
             .secret_key(WorkerSecretKey::Custom(Some(Default::default())));
         expect_error_message(
@@ -47,7 +47,7 @@ async fn test_auth_same_key() {
     let config = ServerConfigBuilder::default().secret_key(ServerSecretKey::Custom(Some(
         SecretKey::from_slice(&key_bytes).unwrap(),
     )));
-    run_test(config, |mut handler| async move {
+    run_server_test(config, |mut handler| async move {
         let config = WorkerConfigBuilder::default().secret_key(WorkerSecretKey::Custom(Some(
             SecretKey::from_slice(&key_bytes).unwrap(),
         )));
@@ -65,7 +65,7 @@ async fn test_auth_different_key() {
 
     key_bytes[0] = 100;
 
-    run_test(config, |mut handler| async move {
+    run_server_test(config, |mut handler| async move {
         let config = WorkerConfigBuilder::default().secret_key(WorkerSecretKey::Custom(Some(
             SecretKey::from_slice(&key_bytes).unwrap(),
         )));

--- a/crates/tako/src/internal/tests/integration/test_worker.rs
+++ b/crates/tako/src/internal/tests/integration/test_worker.rs
@@ -6,7 +6,7 @@ use crate::gateway::LostWorkerReason;
 use crate::internal::tests::integration::utils::api::{
     wait_for_task_start, wait_for_worker_connected, wait_for_worker_lost, wait_for_worker_overview,
 };
-use crate::internal::tests::integration::utils::server::run_test;
+use crate::internal::tests::integration::utils::server::run_server_test;
 use crate::internal::tests::integration::utils::task::{GraphBuilder, simple_task};
 
 use super::utils::server::ServerConfigBuilder;
@@ -14,7 +14,7 @@ use super::utils::worker::WorkerConfigBuilder;
 
 #[tokio::test]
 async fn test_hw_monitoring() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let config =
             WorkerConfigBuilder::default().send_overview_interval(Some(Duration::from_millis(10)));
         let worker = handler.start_worker(config).await.unwrap();
@@ -41,7 +41,7 @@ async fn test_hw_monitoring() {
 
 #[tokio::test]
 async fn test_worker_connected_event() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         for _ in 0..3 {
             let worker = handler
                 .start_worker(WorkerConfigBuilder::default())
@@ -56,7 +56,7 @@ async fn test_worker_connected_event() {
 
 #[tokio::test]
 async fn test_worker_lost_killed() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let worker = handler
             .start_worker(WorkerConfigBuilder::default())
             .await
@@ -70,7 +70,7 @@ async fn test_worker_lost_killed() {
 
 #[tokio::test]
 async fn test_worker_lost_stopped() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let worker = handler
             .start_worker(WorkerConfigBuilder::default())
             .await
@@ -85,7 +85,7 @@ async fn test_worker_lost_stopped() {
 
 #[tokio::test]
 async fn test_worker_lost_heartbeat_expired() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let config = WorkerConfigBuilder::default().heartbeat_interval(Duration::from_millis(200));
         let worker = handler.start_worker(config).await.unwrap();
         let _token = worker.pause().await;
@@ -98,7 +98,7 @@ async fn test_worker_lost_heartbeat_expired() {
 
 #[tokio::test]
 async fn test_worker_lost_idle_timeout() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let builder = WorkerConfigBuilder::default().idle_timeout(Some(Duration::from_millis(200)));
         let worker = handler.start_worker(builder).await.unwrap();
 
@@ -110,7 +110,7 @@ async fn test_worker_lost_idle_timeout() {
 
 #[tokio::test]
 async fn test_worker_idle_timeout_stays_alive_with_tasks() {
-    run_test(Default::default(), |mut handle| async move {
+    run_server_test(Default::default(), |mut handle| async move {
         handle
             .submit(
                 GraphBuilder::default()
@@ -140,7 +140,7 @@ async fn test_worker_idle_timeout_stays_alive_with_tasks() {
 #[should_panic]
 async fn test_panic_on_worker_lost() {
     let config = ServerConfigBuilder::default().panic_on_worker_lost(true);
-    let completion = run_test(config, |mut handle| async move {
+    let completion = run_server_test(config, |mut handle| async move {
         let worker = handle.start_worker(Default::default()).await.unwrap();
         handle.kill_worker(worker.id).await;
     })
@@ -150,7 +150,7 @@ async fn test_panic_on_worker_lost() {
 
 #[tokio::test]
 async fn test_lost_worker_with_tasks_continue() {
-    run_test(Default::default(), |mut handler| async move {
+    run_server_test(Default::default(), |mut handler| async move {
         let _workers = handler.start_workers(Default::default, 2).await.unwrap();
 
         let task_ids = handler
@@ -166,7 +166,7 @@ async fn test_lost_worker_with_tasks_continue() {
 
 #[tokio::test]
 async fn test_lost_worker_with_tasks_restarts() {
-    run_test(Default::default(), |mut handle| async move {
+    run_server_test(Default::default(), |mut handle| async move {
         handle
             .submit(GraphBuilder::singleton(simple_task(&["sleep", "1"], 1)))
             .await;

--- a/crates/tako/src/internal/tests/integration/utils/api.rs
+++ b/crates/tako/src/internal/tests/integration/utils/api.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use crate::gateway::LostWorkerReason;
 use crate::internal::common::Map;
 use crate::internal::messages::worker::WorkerOverview;
@@ -5,7 +7,7 @@ use crate::internal::tests::integration::utils::server::{ServerHandle, TestTaskS
 use crate::worker::WorkerConfiguration;
 use crate::{TaskId, WorkerId};
 
-pub(crate) struct WaitResult {
+pub struct WaitResult {
     tasks: Map<TaskId, TestTaskState>,
 }
 

--- a/crates/tako/src/internal/tests/integration/utils/mod.rs
+++ b/crates/tako/src/internal/tests/integration/utils/mod.rs
@@ -1,10 +1,9 @@
 use std::path::Path;
 
-mod api;
+pub mod api;
 pub mod server;
-#[cfg(test)]
-mod task;
-mod worker;
+pub mod task;
+pub mod worker;
 
 pub fn check_file_contents(path: &Path, expected: &[u8]) {
     assert_eq!(std::fs::read(path).unwrap(), expected.to_vec());

--- a/crates/tako/src/internal/tests/integration/utils/mod.rs
+++ b/crates/tako/src/internal/tests/integration/utils/mod.rs
@@ -1,9 +1,10 @@
 use std::path::Path;
 
-pub mod api;
+mod api;
 pub mod server;
-pub mod task;
-pub mod worker;
+#[cfg(test)]
+mod task;
+mod worker;
 
 pub fn check_file_contents(path: &Path, expected: &[u8]) {
     assert_eq!(std::fs::read(path).unwrap(), expected.to_vec());

--- a/crates/tako/src/internal/tests/integration/utils/server.rs
+++ b/crates/tako/src/internal/tests/integration/utils/server.rs
@@ -303,7 +303,7 @@ impl ServerCompletion {
     }
 }
 
-pub async fn run_test<
+pub async fn run_server_test<
     CreateTestFut: FnOnce(ServerHandle) -> TestFut,
     TestFut: Future<Output = ()>,
 >(

--- a/crates/tako/src/internal/tests/integration/utils/server.rs
+++ b/crates/tako/src/internal/tests/integration/utils/server.rs
@@ -119,7 +119,7 @@ impl ServerHandle {
 }
 
 #[derive(Clone)]
-pub(crate) enum TestTaskState {
+pub enum TestTaskState {
     Running(WorkerId),
     Finished(Option<WorkerId>),
     Failed(Option<WorkerId>, TaskFailInfo),
@@ -146,19 +146,19 @@ impl TestTaskState {
 }
 
 #[derive(Debug)]
-pub(crate) struct TestWorkerState {
+pub struct TestWorkerState {
     pub configuration: WorkerConfiguration,
     pub lost_reason: Option<LostWorkerReason>,
 }
 
-pub(crate) struct AsyncTestClientProcessor {
+pub struct AsyncTestClientProcessor {
     pub notify: Rc<Notify>,
     pub task_state: Map<TaskId, TestTaskState>,
     pub overviews: Map<WorkerId, Box<WorkerOverview>>,
     pub worker_state: Map<WorkerId, TestWorkerState>,
 }
 
-pub(crate) type AsyncTestClientProcessorRef = WrappedRcRefCell<AsyncTestClientProcessor>;
+pub type AsyncTestClientProcessorRef = WrappedRcRefCell<AsyncTestClientProcessor>;
 
 impl AsyncTestClientProcessorRef {
     fn update_state(&self, task_id: TaskId, state: TestTaskState) {

--- a/crates/tako/src/internal/tests/mod.rs
+++ b/crates/tako/src/internal/tests/mod.rs
@@ -1,6 +1,4 @@
 #[cfg(test)]
-mod integration;
-#[cfg(test)]
 mod test_query;
 #[cfg(test)]
 mod test_reactor;
@@ -11,4 +9,5 @@ mod test_scheduler_sn;
 #[cfg(test)]
 mod test_worker;
 
+pub mod integration;
 pub mod utils;

--- a/crates/tako/src/internal/tests/utils/resources.rs
+++ b/crates/tako/src/internal/tests/utils/resources.rs
@@ -5,12 +5,6 @@ use crate::internal::common::resources::{ResourceId, ResourceRequestVariants, Re
 use crate::resources::{AllocationRequest, NumOfNodes, ResourceAmount, ResourceUnits};
 pub use ResourceRequestBuilder as ResBuilder;
 
-impl From<u32> for ResourceAmount {
-    fn from(val: u32) -> Self {
-        ResourceAmount::new_units(val)
-    }
-}
-
 #[derive(Default, Clone)]
 pub struct ResourceRequestBuilder {
     n_nodes: NumOfNodes,

--- a/crates/tako/src/lib.rs
+++ b/crates/tako/src/lib.rs
@@ -71,3 +71,7 @@ pub mod datasrv {
     pub use crate::internal::datasrv::dataobj::{DataInputId, DataObjectId, OutputId};
     pub use crate::internal::datasrv::local_client::LocalDataClient;
 }
+
+pub mod tests {
+    pub use crate::internal::tests::*;
+}


### PR DESCRIPTION
So that we can write HyperQueue integration tests (e.g. for the automatic allocator).