### PR TITLE
Fix task cancellation on max fails

### DIFF
--- a/crates/hyperqueue/src/server/state.rs
+++ b/crates/hyperqueue/src/server/state.rs
@@ -122,10 +122,12 @@ impl State {
 
         let job_id = task_id.job_id();
         let job = self.get_job_mut(job_id).unwrap();
-        log::debug!(
-            "Tasks id={:?} canceled because of task dependency fails",
-            &cancelled_tasks
-        );
+        if !cancelled_tasks.is_empty() {
+            log::debug!(
+                "Tasks {:?} canceled because of task dependency fails",
+                &cancelled_tasks
+            );
+        }
 
         job.set_cancel_state(cancelled_tasks, senders);
         job.set_failed_state(task_id.job_task_id(), info.message, senders);
@@ -136,7 +138,6 @@ impl State {
                 let task_ids = job.non_finished_task_ids();
                 job.set_cancel_state(task_ids.clone(), senders);
                 return task_ids;
-                // return job.non_finished_task_ids();
             }
         }
         Vec::new()

--- a/crates/tako/src/internal/server/reactor.rs
+++ b/crates/tako/src/internal/server/reactor.rs
@@ -517,6 +517,7 @@ fn fail_task_helper(
     }
     drop(state);
     objs_to_remove.send(comm);
+    comm.ask_for_scheduling();
     let cancel_ids = comm.client().on_task_error(task_id, consumers, error_info);
     if !cancel_ids.is_empty() {
         on_cancel_tasks(core, comm, &cancel_ids);

--- a/crates/tako/src/internal/server/reactor.rs
+++ b/crates/tako/src/internal/server/reactor.rs
@@ -518,7 +518,7 @@ fn fail_task_helper(
     drop(state);
     objs_to_remove.send(comm);
     let cancel_ids = comm.client().on_task_error(task_id, consumers, error_info);
-    if cancel_ids.is_empty() {
+    if !cancel_ids.is_empty() {
         on_cancel_tasks(core, comm, &cancel_ids);
     }
 }


### PR DESCRIPTION
Found this while investigating https://github.com/It4innovations/hyperqueue/issues/919. I can't reproduce that locally, so I'm not sure if this solves the issue, but the `is_empty()` check was quite suspicious.

An alternative would be to handle `Canceled` state in `set_failed_state`, but I guess that would just hide potential bugs?