### PR TITLE
Leftovers update

### DIFF
--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -377,7 +377,7 @@ async fn perform_submits(
         .iter()
         .map(|(_, queue)| create_queue_worker_query(queue))
         .collect();
-    let response = senders.server.new_worker_query(queries)?;
+    let response = senders.server.new_worker_query(queries, false)?;
     log::debug!("Scheduler query response: {response:?}");
 
     // Merge responses back into a single array

--- a/crates/tako/src/control.rs
+++ b/crates/tako/src/control.rs
@@ -21,7 +21,7 @@ use crate::internal::server::explain::{
 };
 use crate::internal::server::reactor::on_cancel_tasks;
 use crate::internal::server::worker::DEFAULT_WORKER_OVERVIEW_INTERVAL;
-use crate::resources::ResourceDescriptor;
+use crate::resources::{NumOfNodes, ResourceDescriptor};
 use crate::{TaskId, WorkerId};
 
 #[derive(Debug)]
@@ -40,13 +40,25 @@ pub struct WorkerTypeQuery {
 }
 
 #[derive(Debug)]
+pub struct SingleNodeLeftOvers {
+    pub min_time: Duration,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct MultiNodeLeftOvers {
+    pub n_nodes: NumOfNodes,
+    pub min_time: Duration,
+}
+
+#[derive(Debug)]
 pub struct NewWorkerAllocationResponse {
     /// Array of the same size as the number of queries, it returns the number of workers that should
     /// be spawned for the given query
     pub single_node_workers_per_query: Vec<usize>,
     /// True iff not all tasks could be executed on resources provided in the query
-    pub single_node_leftovers: bool,
+    pub single_node_leftovers: Option<SingleNodeLeftOvers>,
     pub multi_node_allocations: Vec<MultiNodeAllocationResponse>,
+    pub multi_node_leftovers: crate::Set<MultiNodeLeftOvers>,
 }
 
 #[derive(Clone)]

--- a/crates/tako/src/internal/common/resources/request.rs
+++ b/crates/tako/src/internal/common/resources/request.rs
@@ -244,6 +244,10 @@ impl ResourceRequestVariants {
         assert!(!variants.is_empty()); // Valid variants are non empty
         ResourceRequestVariants { variants }
     }
+
+    pub fn min_time(&self) -> TimeRequest {
+        self.variants.iter().map(|v| v.min_time).min().unwrap()
+    }
 }
 
 #[cfg(test)]

--- a/crates/tako/src/internal/common/resources/request.rs
+++ b/crates/tako/src/internal/common/resources/request.rs
@@ -6,6 +6,7 @@ use crate::internal::common::resources::{NumOfNodes, ResourceAmount, ResourceId}
 
 use crate::internal::server::workerload::WorkerResources;
 use crate::internal::worker::resources::allocator::ResourceAllocator;
+use crate::resources::ResourceMap;
 use smallvec::SmallVec;
 use std::time::Duration;
 
@@ -147,6 +148,21 @@ impl ResourceRequest {
             }
         }
         Ok(())
+    }
+
+    pub fn to_gateway(&self, resource_map: &ResourceMap) -> crate::gateway::ResourceRequest {
+        crate::gateway::ResourceRequest {
+            n_nodes: self.n_nodes,
+            resources: self
+                .resources
+                .iter()
+                .map(|r| crate::gateway::ResourceRequestEntry {
+                    resource: resource_map.get_name(r.resource_id).unwrap().to_string(),
+                    policy: r.request.clone(),
+                })
+                .collect(),
+            min_time: self.min_time,
+        }
     }
 }
 

--- a/crates/tako/src/internal/scheduler/query.rs
+++ b/crates/tako/src/internal/scheduler/query.rs
@@ -1,4 +1,6 @@
-use crate::control::{NewWorkerAllocationResponse, WorkerTypeQuery};
+use crate::control::{
+    MultiNodeLeftOvers, NewWorkerAllocationResponse, SingleNodeLeftOvers, WorkerTypeQuery,
+};
 use crate::gateway::MultiNodeAllocationResponse;
 use crate::internal::server::core::Core;
 use crate::internal::server::task::Task;
@@ -22,7 +24,9 @@ pub(crate) fn compute_new_worker_query(
     // Scheduler has to be performed before the query, so there should be no ready_to_assign tasks
     assert!(core.sn_ready_to_assign().is_empty() || !core.has_workers());
 
-    let add_task = |new_loads: &mut [WorkerTypeState], task: &Task| -> bool {
+    let add_task = |new_loads: &mut [WorkerTypeState],
+                    task: &Task,
+                    leftover: &mut Option<SingleNodeLeftOvers>| {
         let request = &task.configuration.resources;
         for ws in new_loads.iter_mut() {
             if let Some(time_limit) = ws.time_limit {
@@ -38,17 +42,23 @@ pub(crate) fn compute_new_worker_query(
             for load in ws.loads.iter_mut() {
                 if load.have_immediate_resources_for_rqv(request, &ws.w_resources) {
                     load.add_request(task.id, request, &ws.w_resources);
-                    return false;
+                    return;
                 }
             }
             if ws.loads.len() < ws.max as usize {
                 let mut load = WorkerLoad::new(&ws.w_resources);
                 load.add_request(task.id, request, &ws.w_resources);
                 ws.loads.push(load);
-                return false;
+                return;
             }
         }
-        true
+        if let Some(lo) = leftover {
+            lo.min_time = lo.min_time.min(request.min_time());
+        } else {
+            *leftover = Some(SingleNodeLeftOvers {
+                min_time: request.min_time(),
+            });
+        }
     };
 
     /* Make sure that all named resources provided has an Id */
@@ -69,7 +79,7 @@ pub(crate) fn compute_new_worker_query(
         })
         .collect();
 
-    let mut leftover = false;
+    let mut sn_leftovers = None;
     for worker in core.get_workers() {
         let mut load = WorkerLoad::new(&worker.resources);
         for task_id in worker.sn_tasks() {
@@ -81,12 +91,12 @@ pub(crate) fn compute_new_worker_query(
                 load.add_request(task.id, request, &worker.resources);
                 continue;
             }
-            leftover |= add_task(&mut new_loads, task);
+            add_task(&mut new_loads, task, &mut sn_leftovers);
         }
     }
     for task_id in core.sleeping_sn_tasks() {
         let task = core.get_task(*task_id);
-        leftover |= add_task(&mut new_loads, task);
+        add_task(&mut new_loads, task, &mut sn_leftovers);
     }
 
     // `compute_new_worker_query` should be called immediately after scheduling was performed,
@@ -95,7 +105,7 @@ pub(crate) fn compute_new_worker_query(
     // postponing ready_to_assign. So we have to look also into this array
     for task_id in core.sn_ready_to_assign() {
         let task = core.get_task(*task_id);
-        leftover |= add_task(&mut new_loads, task);
+        add_task(&mut new_loads, task, &mut sn_leftovers);
     }
 
     let single_node_allocations = new_loads
@@ -115,12 +125,13 @@ pub(crate) fn compute_new_worker_query(
         })
         .collect();
 
+    let mut mn_leftovers = crate::Set::new();
     let (queue, _map, _ws) = core.multi_node_queue_split();
     let mut multi_node_allocations: Vec<_> = queue
         .get_profiles()
         .filter_map(|(rq, count)| {
             let n_nodes = rq.n_nodes();
-            queries.iter().enumerate().find_map(|(i, worker_type)| {
+            let result = queries.iter().enumerate().find_map(|(i, worker_type)| {
                 if let Some(time_limit) = worker_type.time_limit {
                     if rq.min_time() > time_limit {
                         return None;
@@ -135,14 +146,22 @@ pub(crate) fn compute_new_worker_query(
                 } else {
                     None
                 }
-            })
+            });
+            if result.is_none() {
+                mn_leftovers.insert(MultiNodeLeftOvers {
+                    n_nodes,
+                    min_time: rq.min_time(),
+                });
+            }
+            result
         })
         .collect();
     multi_node_allocations.sort_unstable_by_key(|x| (x.worker_type, x.worker_per_allocation));
 
     NewWorkerAllocationResponse {
         single_node_workers_per_query: single_node_allocations,
-        single_node_leftovers: leftover,
+        single_node_leftovers: sn_leftovers,
         multi_node_allocations,
+        multi_node_leftovers: mn_leftovers,
     }
 }

--- a/crates/tako/src/internal/scheduler/query.rs
+++ b/crates/tako/src/internal/scheduler/query.rs
@@ -1,10 +1,10 @@
-use crate::control::{
-    MultiNodeLeftOvers, NewWorkerAllocationResponse, SingleNodeLeftOvers, WorkerTypeQuery,
-};
+use crate::Set;
+use crate::control::{NewWorkerAllocationResponse, WorkerTypeQuery};
 use crate::gateway::MultiNodeAllocationResponse;
 use crate::internal::server::core::Core;
 use crate::internal::server::task::Task;
 use crate::internal::server::workerload::{WorkerLoad, WorkerResources};
+use crate::resources::ResourceRequest;
 use std::time::Duration;
 
 struct WorkerTypeState {
@@ -18,48 +18,48 @@ struct WorkerTypeState {
 pub(crate) fn compute_new_worker_query(
     core: &mut Core,
     queries: &[WorkerTypeQuery],
+    collect_leftovers: bool,
 ) -> NewWorkerAllocationResponse {
     log::debug!("Compute new worker query: query = {:?}", queries);
 
     // Scheduler has to be performed before the query, so there should be no ready_to_assign tasks
     assert!(core.sn_ready_to_assign().is_empty() || !core.has_workers());
 
-    let add_task = |new_loads: &mut [WorkerTypeState],
-                    task: &Task,
-                    leftover: &mut Option<SingleNodeLeftOvers>| {
-        let request = &task.configuration.resources;
-        for ws in new_loads.iter_mut() {
-            if let Some(time_limit) = ws.time_limit {
-                if !ws
-                    .w_resources
-                    .is_capable_to_run_with(request, |rq| rq.min_time() <= time_limit)
-                {
+    let add_task =
+        |new_loads: &mut [WorkerTypeState], task: &Task, leftovers: &mut Set<ResourceRequest>| {
+            let request = &task.configuration.resources;
+            for ws in new_loads.iter_mut() {
+                if let Some(time_limit) = ws.time_limit {
+                    if !ws
+                        .w_resources
+                        .is_capable_to_run_with(request, |rq| rq.min_time() <= time_limit)
+                    {
+                        continue;
+                    }
+                } else if !ws.w_resources.is_capable_to_run(request) {
                     continue;
                 }
-            } else if !ws.w_resources.is_capable_to_run(request) {
-                continue;
-            }
-            for load in ws.loads.iter_mut() {
-                if load.have_immediate_resources_for_rqv(request, &ws.w_resources) {
+                for load in ws.loads.iter_mut() {
+                    if load.have_immediate_resources_for_rqv(request, &ws.w_resources) {
+                        load.add_request(task.id, request, &ws.w_resources);
+                        return;
+                    }
+                }
+                if ws.loads.len() < ws.max as usize {
+                    let mut load = WorkerLoad::new(&ws.w_resources);
                     load.add_request(task.id, request, &ws.w_resources);
+                    ws.loads.push(load);
                     return;
                 }
             }
-            if ws.loads.len() < ws.max as usize {
-                let mut load = WorkerLoad::new(&ws.w_resources);
-                load.add_request(task.id, request, &ws.w_resources);
-                ws.loads.push(load);
-                return;
+            if collect_leftovers {
+                for rq in request.requests() {
+                    if !leftovers.contains(rq) {
+                        leftovers.insert(rq.clone());
+                    }
+                }
             }
-        }
-        if let Some(lo) = leftover {
-            lo.min_time = lo.min_time.min(request.min_time());
-        } else {
-            *leftover = Some(SingleNodeLeftOvers {
-                min_time: request.min_time(),
-            });
-        }
-    };
+        };
 
     /* Make sure that all named resources provided has an Id */
     for query in queries {
@@ -79,7 +79,7 @@ pub(crate) fn compute_new_worker_query(
         })
         .collect();
 
-    let mut sn_leftovers = None;
+    let mut leftovers = Set::new();
     for worker in core.get_workers() {
         let mut load = WorkerLoad::new(&worker.resources);
         for task_id in worker.sn_tasks() {
@@ -91,12 +91,12 @@ pub(crate) fn compute_new_worker_query(
                 load.add_request(task.id, request, &worker.resources);
                 continue;
             }
-            add_task(&mut new_loads, task, &mut sn_leftovers);
+            add_task(&mut new_loads, task, &mut leftovers);
         }
     }
     for task_id in core.sleeping_sn_tasks() {
         let task = core.get_task(*task_id);
-        add_task(&mut new_loads, task, &mut sn_leftovers);
+        add_task(&mut new_loads, task, &mut leftovers);
     }
 
     // `compute_new_worker_query` should be called immediately after scheduling was performed,
@@ -105,7 +105,7 @@ pub(crate) fn compute_new_worker_query(
     // postponing ready_to_assign. So we have to look also into this array
     for task_id in core.sn_ready_to_assign() {
         let task = core.get_task(*task_id);
-        add_task(&mut new_loads, task, &mut sn_leftovers);
+        add_task(&mut new_loads, task, &mut leftovers);
     }
 
     let single_node_allocations = new_loads
@@ -125,7 +125,6 @@ pub(crate) fn compute_new_worker_query(
         })
         .collect();
 
-    let mut mn_leftovers = crate::Set::new();
     let (queue, _map, _ws) = core.multi_node_queue_split();
     let mut multi_node_allocations: Vec<_> = queue
         .get_profiles()
@@ -147,21 +146,27 @@ pub(crate) fn compute_new_worker_query(
                     None
                 }
             });
-            if result.is_none() {
-                mn_leftovers.insert(MultiNodeLeftOvers {
-                    n_nodes,
-                    min_time: rq.min_time(),
-                });
+            if collect_leftovers && result.is_none() && !leftovers.contains(rq) {
+                leftovers.insert(rq.clone());
             }
             result
         })
         .collect();
     multi_node_allocations.sort_unstable_by_key(|x| (x.worker_type, x.worker_per_allocation));
 
+    let leftovers = if collect_leftovers {
+        let resource_map = core.create_resource_map();
+        leftovers
+            .iter()
+            .map(|v| v.to_gateway(&resource_map))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     NewWorkerAllocationResponse {
         single_node_workers_per_query: single_node_allocations,
-        single_node_leftovers: sn_leftovers,
+        leftovers,
         multi_node_allocations,
-        multi_node_leftovers: mn_leftovers,
     }
 }

--- a/crates/tako/src/internal/tests/integration/test_basic.rs
+++ b/crates/tako/src/internal/tests/integration/test_basic.rs
@@ -117,7 +117,10 @@ fn query_helper(
     handler: &mut ServerHandle,
     worker_queries: Vec<WorkerTypeQuery>,
 ) -> NewWorkerAllocationResponse {
-    handler.server_ref.new_worker_query(worker_queries).unwrap()
+    handler
+        .server_ref
+        .new_worker_query(worker_queries, true)
+        .unwrap()
 }
 
 #[tokio::test]
@@ -139,7 +142,7 @@ async fn test_query_no_output_immediate_call() {
         );
         assert_eq!(msg.single_node_workers_per_query, vec![0]);
         assert!(msg.multi_node_allocations.is_empty());
-        assert!(msg.single_node_leftovers.is_none());
+        assert!(msg.leftovers.is_empty());
         handler.wait(&ids).await;
     })
     .await;
@@ -165,7 +168,7 @@ async fn test_query_no_output_delayed_call() {
         );
         assert_eq!(msg.single_node_workers_per_query, vec![0]);
         assert!(msg.multi_node_allocations.is_empty());
-        assert!(msg.single_node_leftovers.is_none());
+        assert!(msg.leftovers.is_empty());
         handler.wait(&ids).await;
     })
     .await;
@@ -194,7 +197,6 @@ async fn test_query_new_workers_delayed_call() {
         );
         assert_eq!(msg.single_node_workers_per_query, vec![1]);
         assert!(msg.multi_node_allocations.is_empty());
-        assert!(msg.single_node_leftovers.is_none());
     })
     .await;
 }
@@ -221,7 +223,6 @@ async fn test_query_new_workers_immediate() {
         );
         assert_eq!(msg.single_node_workers_per_query, vec![1]);
         assert!(msg.multi_node_allocations.is_empty());
-        assert!(msg.single_node_leftovers.is_none());
     })
     .await;
 }

--- a/crates/tako/src/internal/tests/integration/test_basic.rs
+++ b/crates/tako/src/internal/tests/integration/test_basic.rs
@@ -139,7 +139,7 @@ async fn test_query_no_output_immediate_call() {
         );
         assert_eq!(msg.single_node_workers_per_query, vec![0]);
         assert!(msg.multi_node_allocations.is_empty());
-        assert!(!msg.single_node_leftovers);
+        assert!(msg.single_node_leftovers.is_none());
         handler.wait(&ids).await;
     })
     .await;
@@ -165,7 +165,7 @@ async fn test_query_no_output_delayed_call() {
         );
         assert_eq!(msg.single_node_workers_per_query, vec![0]);
         assert!(msg.multi_node_allocations.is_empty());
-        assert!(!msg.single_node_leftovers);
+        assert!(msg.single_node_leftovers.is_none());
         handler.wait(&ids).await;
     })
     .await;
@@ -194,7 +194,7 @@ async fn test_query_new_workers_delayed_call() {
         );
         assert_eq!(msg.single_node_workers_per_query, vec![1]);
         assert!(msg.multi_node_allocations.is_empty());
-        assert!(!msg.single_node_leftovers);
+        assert!(msg.single_node_leftovers.is_none());
     })
     .await;
 }
@@ -221,7 +221,7 @@ async fn test_query_new_workers_immediate() {
         );
         assert_eq!(msg.single_node_workers_per_query, vec![1]);
         assert!(msg.multi_node_allocations.is_empty());
-        assert!(!msg.single_node_leftovers);
+        assert!(msg.single_node_leftovers.is_none());
     })
     .await;
 }

--- a/crates/tako/src/internal/tests/test_query.rs
+++ b/crates/tako/src/internal/tests/test_query.rs
@@ -21,10 +21,11 @@ fn test_query_no_tasks() {
             max_workers_per_allocation: 1,
             min_utilization: 0.0,
         }],
+        true,
     );
     assert_eq!(r.single_node_workers_per_query, vec![0]);
     assert!(r.multi_node_allocations.is_empty());
-    assert!(r.single_node_leftovers.is_none());
+    assert!(r.leftovers.is_empty());
 }
 
 #[test]
@@ -51,10 +52,11 @@ fn test_query_enough_workers() {
             max_workers_per_allocation: 1,
             min_utilization: 0.0,
         }],
+        false,
     );
     assert_eq!(r.single_node_workers_per_query, vec![0]);
     assert!(r.multi_node_allocations.is_empty());
-    assert!(r.single_node_leftovers.is_none());
+    assert!(r.leftovers.is_empty());
 }
 
 #[test]
@@ -90,10 +92,11 @@ fn test_query_no_enough_workers1() {
                 min_utilization: 0.0,
             },
         ],
+        true,
     );
     assert_eq!(r.single_node_workers_per_query, vec![0, 1]);
     assert!(r.multi_node_allocations.is_empty());
-    assert!(r.single_node_leftovers.is_some());
+    assert!(r.leftovers.is_empty());
 }
 
 #[test]
@@ -124,10 +127,10 @@ fn test_query_enough_workers2() {
                 min_utilization: 0.0,
             },
         ],
+        false,
     );
     assert_eq!(r.single_node_workers_per_query, vec![0, 0]);
     assert!(r.multi_node_allocations.is_empty());
-    assert!(r.single_node_leftovers.is_none());
 }
 
 #[test]
@@ -159,10 +162,10 @@ fn test_query_not_enough_workers3() {
                 min_utilization: 0.0,
             },
         ],
+        false,
     );
     assert_eq!(r.single_node_workers_per_query, vec![1, 0]);
     assert!(r.multi_node_allocations.is_empty());
-    assert!(r.single_node_leftovers.is_some());
 }
 
 #[test]
@@ -201,10 +204,10 @@ fn test_query_many_workers_needed() {
                 min_utilization: 0.0,
             },
         ],
+        false,
     );
     assert_eq!(r.single_node_workers_per_query, vec![5, 1, 26]);
     assert!(r.multi_node_allocations.is_empty());
-    assert!(r.single_node_leftovers.is_none());
 }
 
 #[test]
@@ -247,6 +250,7 @@ fn test_query_multi_node_tasks() {
                 min_utilization: 0.0,
             },
         ],
+        false,
     );
     assert_eq!(r.single_node_workers_per_query, vec![0, 0]);
     assert_eq!(r.multi_node_allocations.len(), 3);
@@ -261,7 +265,6 @@ fn test_query_multi_node_tasks() {
     assert_eq!(r.multi_node_allocations[2].worker_type, 1);
     assert_eq!(r.multi_node_allocations[2].worker_per_allocation, 6);
     assert_eq!(r.multi_node_allocations[2].max_allocations, 10);
-    assert!(r.single_node_leftovers.is_none());
 }
 
 #[test]
@@ -281,9 +284,9 @@ fn test_query_multi_node_time_limit() {
                 max_workers_per_allocation: 4,
                 min_utilization: 0.0,
             }],
+            false,
         );
         assert_eq!(r.multi_node_allocations.len(), allocs);
-        assert!(r.single_node_leftovers.is_none());
     }
 }
 
@@ -317,6 +320,7 @@ fn test_query_min_utilization1() {
                 max_workers_per_allocation: 1,
                 min_utilization: *min_utilization,
             }],
+            false,
         );
         assert_eq!(r.single_node_workers_per_query, vec![*alloc_value]);
         assert!(r.multi_node_allocations.is_empty());
@@ -366,6 +370,7 @@ fn test_query_min_utilization2() {
                 max_workers_per_allocation: 1,
                 min_utilization: *min_utilization,
             }],
+            true,
         );
         assert_eq!(r.single_node_workers_per_query, vec![*alloc_value]);
         assert!(r.multi_node_allocations.is_empty());
@@ -403,6 +408,7 @@ fn test_query_min_time2() {
                 max_workers_per_allocation: 1,
                 min_utilization: 0.0f32,
             }],
+            false,
         );
         assert_eq!(r.single_node_workers_per_query, vec![alloc]);
         assert!(r.multi_node_allocations.is_empty());
@@ -440,6 +446,7 @@ fn test_query_min_time1() {
             max_workers_per_allocation: 1,
             min_utilization: 0.0f32,
         }],
+        false,
     );
     assert_eq!(r.single_node_workers_per_query, vec![0]);
     assert!(r.multi_node_allocations.is_empty());
@@ -453,6 +460,7 @@ fn test_query_min_time1() {
             max_workers_per_allocation: 1,
             min_utilization: 0.0f32,
         }],
+        false,
     );
     assert_eq!(r.single_node_workers_per_query, vec![2]);
     assert!(r.multi_node_allocations.is_empty());
@@ -470,6 +478,7 @@ fn test_query_min_time1() {
             max_workers_per_allocation: 1,
             min_utilization: 0.0f32,
         }],
+        false,
     );
     assert_eq!(r.single_node_workers_per_query, vec![1]);
     assert!(r.multi_node_allocations.is_empty());
@@ -495,11 +504,13 @@ fn test_query_sn_leftovers1() {
                 max_workers_per_allocation: 1,
                 min_utilization: 0.0,
             }],
+            true,
         );
         if leftovers {
-            assert_eq!(r.single_node_leftovers.unwrap().min_time.as_secs(), 5_000);
+            assert_eq!(r.leftovers.len(), 1);
+            assert_eq!(r.leftovers[0].min_time.as_secs(), 5_000);
         } else {
-            assert!(r.single_node_leftovers.is_none());
+            assert!(r.leftovers.is_empty());
         }
     }
 }
@@ -526,8 +537,9 @@ fn test_query_sn_leftovers2() {
             max_workers_per_allocation: 1,
             min_utilization: 0.0,
         }],
+        true,
     );
-    assert_eq!(r.single_node_leftovers.unwrap().min_time.as_secs(), 10_000);
+    assert_eq!(r.leftovers.len(), 2);
 }
 
 #[test]
@@ -547,10 +559,10 @@ fn test_query_mn_leftovers() {
             max_workers_per_allocation: 3,
             min_utilization: 0.0,
         }],
+        true,
     );
-    assert!(r.single_node_leftovers.is_none());
-    assert_eq!(r.multi_node_leftovers.len(), 1);
-    let lo = r.multi_node_leftovers.into_iter().next().unwrap();
+    assert_eq!(r.leftovers.len(), 1);
+    let lo = &r.leftovers[0];
     assert_eq!(lo.min_time, Duration::from_secs(750));
     assert_eq!(lo.n_nodes, 4);
 }


### PR DESCRIPTION
* Leftovers is now array of ResourceRequests. You can decide if it makes sense to make a probe for a queue for these requests (e.g. min_time > time_limit so probe is unnecessary, or n_nodes > max_worker_per_alloc, or if we already know the number of cpus, etc).

* Leftovers is optional (because it is not free to compute now), so if there is no "unknown queues", you can skip computing leftovers in query.