### PR TITLE
Update CI action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           toolchain: 1.85.0
           override: true
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2
         with:
           key: x64
 
@@ -97,7 +97,7 @@ jobs:
           toolchain: 1.85.0
           override: true
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.arch }}
 
@@ -128,7 +128,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2
         with:
           key: pyhq
       - uses: messense/maturin-action@v1

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'It4innovations'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Download all git history to enable git revision history display in docs pages
           fetch-depth: 0

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -22,7 +22,7 @@ jobs:
       tag: ${{ env.TAG }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set env on push
         if: github.event_name == 'push'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check package versions
         run: python scripts/check_package_versions.py
   set-env:
@@ -29,7 +29,7 @@ jobs:
       prerelease: ${{ env.PRERELEASE }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set env on push
         if: github.event_name == 'push'
         run: |
@@ -59,7 +59,7 @@ jobs:
     needs: [ set-env, build-artifacts ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.set-env.outputs.sha }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -23,7 +23,7 @@ jobs:
           override: true
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check package versions
         run: python scripts/check_package_versions.py
@@ -99,7 +99,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}
 
@@ -138,7 +138,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build HyperQueue with the zero worker mode
         run: RUSTFLAGS="--cfg zero_worker" cargo build --workspace


### PR DESCRIPTION
`rust-cache` 2.7.0 couldn't deal with Cargo v4 lockfiles.