### PR TITLE
Update outdated docs warning

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
 {% block outdated %}
-You're not viewing the latest version.
+You're not viewing the current stable version.
 <a href="{{ '../' ~ base_url }}">
-  <b>Click here to go to the latest version.</b>
+  <b>Click here to go to the stable version.</b>
 </a>
 {% endblock %}


### PR DESCRIPTION
It would show "you're not viewing the latest version" when you clicked on the "latest" version selector :laughing: Which was confusing.