### PR TITLE
Improve deployment documentation

### DIFF
--- a/docs/deployment/allocation.md
+++ b/docs/deployment/allocation.md
@@ -1,20 +1,19 @@
 **Automatic allocation** is one of the core features of HyperQueue. When you run HyperQueue on an HPC cluster, it allows
-you to autonomously ask the job manager (PBS/Slurm) for computing resources and spawn HyperQueue [workers](worker.md)
+you to autonomously ask the allocation manager (PBS/Slurm) for computing resources and spawn HyperQueue [workers](worker.md)
 on the provided nodes.
 
 Using this mechanism, you can submit computations into HyperQueue without caring about the underlying PBS/Slurm allocations.
 
-!!! Note "Job terminology"
+!!! Note "Job vs allocation terminology"
 
-    It is common to use the term "job" for allocations created by an HPC job manager, such as PBS or Slurm, which are used to
-    perform computations on HPC clusters. However, HyperQueue also uses the term "job" for [ensembles of tasks](../jobs/jobs.md).
+    It is common to use the term "job" for allocations created by an HPC allocation manager, such as PBS or Slurm, which are used to
+    perform computations on HPC clusters. However, HyperQueue also uses the term "job" for [task graphs](../jobs/jobs.md).
 
     To differentiate between these two, we will refer to jobs created by PBS or Slurm as `allocations`. We will also refer
-    to PBS/Slurm as a `job manager`.
+    to PBS/Slurm as an `allocation manager`.
 
 ## Allocation queue
-To enable automatic allocation, you have to create an `Allocation queue`. It describes a specific configuration that
-will be used by HyperQueue to request computing resources from the job manager on your behalf.
+To enable automatic allocation, you have to create at least one `Allocation queue`. The queue describes a specific configuration that will be used by HyperQueue to request computing resources from the allocation manager on your behalf.
 
 Each allocation queue has a set of [parameters](#parameters). You can use them to modify the behavior of automatic
 allocation, but for start you can simply use the defaults. However, you will almost certainly need to specify some
@@ -39,7 +38,7 @@ To create a new allocation queue, you can use the following command. Any trailin
     Make sure that a HyperQueue server is running when you execute this command. Allocation queues are not persistent,
     so you have to set them up each time you (re)start the server (unless you use [journaling](server.md#resuming-stoppedcrashed-server)).
 
-The HyperQueue automatic allocator decides the number of nodes that will be requested and also the walltime of the allocation. Other parameters, such as project credentials, account ID, queue/partition name or the number of requested CPU or GPU cores per node have to be specified manually by the user using the trailing arguments.
+You have to specify the `--time-limit` parameter to tell HyperQueue the walltime of the requested allocations (the upper limit on their duration). The automatic allocator will automatically pass this walltime to PBS/Slurm, along with the number of nodes that should be spawned in each allocation. Other parameters, such as project credentials, account ID, queue/partition name or the number of requested CPU or GPU cores per node have to be specified manually by the user using the trailing arguments.
 
 !!! warning
 
@@ -64,7 +63,7 @@ In addition to arguments that are passed to `qsub`/`sbatch`, you can also use se
     We recommend you to specify the worker resources that will be available on workers spawned in the given allocation queue using the `--cpus` and `--resource` flags as precisely as possible. It will help the automatic allocator create the first allocation more accurately.
 
 #### Time limit
-Format[^1]: **`--time-limit <duration>`**
+- Format[^1]: **`--time-limit <duration>`**
 
 Sets the walltime of created allocations.
 
@@ -73,20 +72,21 @@ Make sure that you pass a time limit that does not exceed the limit of the PBS/S
 that you intend to use, otherwise the allocation submissions will fail. You can use the
 [`dry-run` command](#dry-run-command) to debug this.
 
-Workers in this allocation queue will be by default created with a time limit equal to the time limit of the queue
-(unless overridden with [Worker time limit](#worker-time-limit)).
+By default, workers will use a [time limit](./worker.md#time-limit) equal to the time limit of the queue (unless overridden).
 
 !!! Important
     If you specify a [time request](../jobs/jobs.md#time-management)
     for a task, you should be aware that the time limit for the allocation queue **should be larger than the time request**
     if you want to run this task on workers created by this allocations queue, because it will always take some time before
     a worker is fully initialized. For example, if you set `--time-request 1h` when submitting a task, and `--time-limit 1h`
-    when creating an allocation queue, this task will never get scheduled on workers from this queue.
+    when creating an allocation queue, this task will never get scheduled on workers from this queue, because the worker will
+    get started with an actual time limit of e.g. `59m 58s`.
 
 #### Backlog
-Format: `--backlog <count>`
+- Format: `--backlog <count>`
+- Default: `1`
 
-How many allocations should be queued (waiting to be started) in PBS/Slurm at any given time. Has to be a positive integer.
+Maximum number of allocations that should be queued (waiting to be started) in PBS/Slurm at any given time. Has to be a positive integer.
 
 !!! note
 
@@ -94,15 +94,16 @@ How many allocations should be queued (waiting to be started) in PBS/Slurm at an
 
 !!! warning
 
-    Do not set the `backlog` to a large number to avoid potentially overloading the job manager.
+    Do not set the `backlog` to a large number to avoid potentially overloading the allocation manager.
 
 #### Maximum number of workers per allocation
-Format: `--max-workers-per-alloc <count>`
+- Format: `--max-workers-per-alloc <count>`
+- Default: `1`
 
 The maximum number of workers that will be requested in each allocation. Note that if there is not enough computational demand,
 the automatic allocator can create allocations with a smaller number of workers.
 
-!!! notice
+!!! note
 
     If you use [multi-node](../jobs/multinode.md) tasks, you will probably want to use this parameter to set the maximum
     number of workers in a queue to the size of your [groups](../jobs/multinode.md#groups).
@@ -111,16 +112,16 @@ Note that the number of workers always corresponds to the number of requested no
 always creates a single worker per node in a single allocation request.
 
 #### Maximum worker count
-Format: `--max-worker-count <count>`
+- Format: `--max-worker-count <count>`
+- Default: unlimited
 
-Maximum number of workers that can be queued or running in the allocation queue. The total amount of workers will be usually
-limited by the manager (PBS/Slurm), but you can use this parameter to make the limit smaller, for example if you also want
-to manage allocations outside HyperQueue.
+Maximum number of workers that can be queued or running across all allocations managed by the allocation queue. The total amount of workers will be usually limited by the manager (PBS/Slurm), but you can use this parameter to make the limit smaller, for example if you also want to manage allocations outside HyperQueue.
 
 #### Minimal utilization
-Format: `--min-utilization <ratio>`
+- Format: `--min-utilization <ratio>`
+- Default: `0.0`
 
-Minimal utilization determines how could the scheduler utilize workers from submitted allocations. If the schedules thinks that it can make use of `N%` of worker resources in a single allocation of this queue, `min-utilization` has to be at least `N`, otherwise the allocation will not be created.
+Minimal utilization can be used to avoid creating allocations if there is not enough computational demand at the moment. If the scheduler thinks that it can currently make use of `N` of worker resources (on a range of `0.0 - 1.0`) in a single allocation of this queue, `min-utilization` has to be at least `N`, otherwise the allocation will not be created.
 
 It has to be a floating point number between 0.0 and 1.0.
 
@@ -146,20 +147,23 @@ allocation queue. The name and syntax of these parameters is the same as when yo
     If you do not pass any resources, they will be detected automatically (same as it works with
     `hq worker start`).
 
+As noted [above](#parameters), we recommend you to set these resources as precisely as possible, if you know them.
+
 #### Idle timeout
-Format[^1]: `--idle-timeout <duration>`
+- Format[^1]: `--idle-timeout <duration>`
+- Default: `5m`
 
 Sets the [idle timeout](worker.md#idle-timeout) for workers started by the allocation queue. We suggest that you do not
 use a long duration for this parameter, as it can result in wasting precious allocation time.
 
 #### Worker start command
-Format: `--worker-start-cmd <cmd>`
+- Format: `--worker-start-cmd <cmd>`
 
 Specifies a shell command that will be executed on each allocated node just before a worker is started
 on that node. You can use it e.g. to initialize some shared environment for the node, or to load software modules.
 
 #### Worker stop command
-Format: `--worker-stop-cmd <cmd>`
+- Format: `--worker-stop-cmd <cmd>`
 
 Specifies a shell command that will be executed on each allocated node just after the worker stops on
 that node. You can use it e.g. to clean up a previously initialized environment for the node.
@@ -170,7 +174,7 @@ that node. You can use it e.g. to clean up a previously initialized environment 
     PBS/Slurm can kill the allocation without giving HQ a chance to run the command.
 
 #### Worker time limit
-Format[^1]: `--worker-time-limit <duration>`
+- Format[^1]: `--worker-time-limit <duration>`
 
 Sets the time limit of workers spawned by the allocation queue. After the time limit expires, the worker will be stopped.
 By default, the worker time limit is set to the time limit of the allocation queue. But if you want, you can shorten it
@@ -183,20 +187,46 @@ to execute.
     provided by [idle timeout](#idle-timeout).
 
 #### Name
-Format: `--name <name>`
+- Format: `--name <name>`
 
-Name of the allocation queue. It will be used to name allocations submitted to the job manager. Serves for debug purposes
+Name of the allocation queue. It will be used to name allocations submitted to the allocation manager. Serves for debug purposes
 only.
 
 [^1]: You can use various [shortcuts](../cli/shortcuts.md#duration) for the duration value.
 
-## Behavior
-The automatic allocator coordinates with the scheduler to figure out how many workers are needed in order
-to compute currently submitted tasks that are waiting for resources.
+### Automatic dry-run submission
 
-When an allocation starts, a HyperQueue [worker](worker.md) will start and connect to the HyperQueue
-server that queued the allocation. The worker has the [idle timeout](worker.md#idle-timeout) set to
-five minutes, therefore it will terminate if it doesn't receive any new tasks for five minutes.
+Once you create an allocation queue, HyperQueue will first automatically create a test "dry run" allocation, to make sure that PBS/Slurm accepts the arguments that you have passed to the `hq alloc add` command. This allocation will be created in a suspended mode and it will be then immediately cancelled, so that it does not consume any resources.
+
+You can disable this behavior using the `--no-dry-run` flag when running `hq alloc add`.
+
+You can also create a dry-run submission [manually](#dry-run-command).
+
+## Behavior
+The (automatic) allocator submits allocations into PBS/Slurm based on current computational demand. When an allocation starts, a HyperQueue [worker](worker.md) will start and connect to the HyperQueue server that queued the allocation. The worker has the [idle timeout](worker.md#idle-timeout) set to five minutes, so it will terminate if it doesn't receive any new tasks for five minutes.
+
+The allocator coordinates with the HyperQueue scheduler to figure out how many workers (and allocations) are needed 
+to execute tasks that are currently waiting for computational resources. To determine that, the allocator needs to know the exact resources provided by workers that connect from allocations spawned by a given allocation queue. Because we cannot know these resources exactly until the first worker connects, the allocator can behave slightly differently before the first worker from a given allocation queue connects.
+
+For example, assume that you have specified that workers in a given queue will have `4` CPU cores (using `--cpus 4` when running `hq alloc add`). Here are a few scenarios for which we show how would the allocator behave:
+
+- If we have waiting tasks that require `8` cores, no allocation will be submitted, because workers from this queue definitely cannot compute these tasks.
+- If we have waiting tasks that require `2` cores, the allocator knows that workers from this queue will be able to compute them, so it will submit as many allocations are required to compute these tasks (based on [backlog](#backlog) and other limits). 
+- If we have waiting tasks that require `2` cores and `1` GPU, the allocator will first submit a single allocation, because it is possible that the spawned worker will have a GPU (which just wasn't explicitly specified by the user in `hq alloc add`). Then:
+    - If the connected worker has a GPU available, the allocator will submit further allocations for these waiting tasks.
+    - If the connected worker doesn't have a GPU available, the allocator will not submit further allocations to compute tasks that require a GPU.
+
+### Rate limits
+
+The allocator internally uses rate limiting to avoid overloading the PBS/Slurm allocation manager by spawning too many allocations too quickly.
+
+It also uses additional safety limits. If `10` allocations in a succession fail to be submitted or if `3` allocations that were submitted fail to start in a succession, the corresponding allocation queue will be automatically [paused](#pausing-automatic-allocation).
+
+## Pausing automatic allocation
+
+If you want to pause the submission of new allocations from a given allocation queue, without removing the queue completely, you can use the `hq alloc pause <queue-id>` command.
+
+If you later want to resume allocation submission, you can use the `hq alloc resume <queue-id>` command.
 
 ## Stopping automatic allocation
 If you want to remove an allocation queue, use the following command:
@@ -205,7 +235,7 @@ If you want to remove an allocation queue, use the following command:
 $ hq alloc remove <queue-id>
 ```
 
-When an allocation queue is removed, all its corresponding queued and running allocations will be
+When an allocation queue is removed, its queued and running allocations will be
 canceled immediately.
 
 By default, HQ will not allow you to remove an allocation queue that contains a running allocation.
@@ -215,19 +245,8 @@ When the HQ server stops, it will automatically remove all allocation queues and
 allocations.
 
 ## Debugging automatic allocation
-Since the automatic allocator is a "background" process that interacts with an external job manager, it can be challenging
-to debug its behavior. To aid with this process, HyperQueue provides a "dry-run" command that you can
-use to test allocation parameters. HyperQueue also provides various sources of information that can help you
-find out what is going on.
-
-To mitigate the case of incorrectly entered allocation parameters, HQ will also try to submit a test
-allocation (do a "dry run") into the target HPC job manager when you add a new allocation queue.
-If the test allocation fails, the queue will not be created. You can avoid this behaviour by passing
-the `--no-dry-run` flag to `hq alloc add`.
-
-There are also additional safety limits. If `10` allocations in a succession fail to be submitted,
-or if `3` allocations that were submitted fail during runtime in a succession, the corresponding
-allocation queue will be automatically removed.
+Since the automatic allocator is a "background" process that interacts with an external allocation manager, it can be challenging
+to debug its behavior. To aid with this process, HyperQueue provides a dry-run allocation test and also various sources of information that can help you figuring out what is going on.
 
 ### Dry-run command
 To test whether PBS/Slurm will accept the submit parameters that you provide to the auto allocator
@@ -253,7 +272,7 @@ If the allocation was submitted successfully, it will be canceled immediately to
 
     The log output of the server will then contain a detailed trace of allocator actions.
 
-- **Allocation files** Each time the allocator queues an allocation into the job manager, it will write the submitted
+- **Allocation files** Each time the allocator submits an allocation into the allocation manager, it will write the submitted
   bash script, allocation ID and `stdout` and `stderr` of the allocation to disk. You can find these files inside the
   server directory:
 

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -1,46 +1,54 @@
-# Starting HQ without shared file system
+# Starting HQ without a shared filesystem
 
-On system without shared file system, all what is needed is to distribute access file (`access.json`) to clients and workers.
-This file contains address and port where server is running and secret keys.
-By default, client and worker search for `access.json` in `$HOME/.hq-server`.
+By default, HyperQueue assumes the existence of a shared filesystem, which it uses to exchange metadata required to connect servers and workers and to run various HQ commands.
 
-## Generate access file in advance
+On systems without a shared filesystem, you will have to distribute an *access file* (`access.json`) to clients and workers.
+This file contains the address and port where the server is running, and also secret keys required for encrypted communication.
 
-In many cases you, we want to generate an access file in advance before any server is started;
-moreover, we do not want to regenerate secret keys in every start of server,
-because we do not want to redistribute access when server is restarted.
+## Sharing the access file
 
-To solve this, an access file can be generated in advance by command "generate-access", e.g.:
+After you start a server, you can find its `access.json` file in the `$HOME/.hq-server/hq-current` directory. You can then copy it to a different filesystem using a method of your choosing, and configure clients and workers to use that file.
 
-```commandline
+By default, clients and workers search for the `access.json` file in the `$HOME/.hq-server` directory, but you can override that using the `--server-dir` argument, which is available for all `hq` CLI commands. If you moved the `access.json` file into a directory called `/home/foo/hq-access` on the worker's node, you should start the worker like this:
+
+```bash
+$ hq --server-dir=/home/foo/hq-access worker start
+```
+
+!!! tip
+
+    You can also configure the server directory using an [environment variable](./server.md#server-directory).
+
+## Generate an access file in advance
+
+In some cases you might want to generate the access file in advance, before the server is started, and let the server, clients and workers use that access file. This can be useful so that you don't have to redistribute the access file to client/worker nodes everytime the server restarts, which could be cumbersome.
+
+To achieve this, an access file can be generated in advance by the `generate-access` command:
+
+```bash
 $ hq server generate-access myaccess.json --client-port=6789 --worker-port=1234
 ```
 
-This generates `myaccess.json` that contains generates keys and host information.
+This generates a `myaccess.json` file that contains generates keys and host information.
 
 The server can be later started with this configuration as follows:
 
-```commandline
+```bash
 $ hq server start --access-file=myaccess.json
 ```
 
-Note: That server still generates and manages "own" `access.json` in the server directory path.
-For connecting clients and workers you can use both, `myaccess.json` or newly generated `access.json`, they are same.
+Clients and workers should load the pre-generated access file in the same way as was described [above](#sharing-the-access-file). However, you will have to rename the generated file to `access.json`, because clients and workers look it up by its exact name in the provided server directory.
 
-Example of starting a worker from `myaccess.json`
+!!! note
 
-```commandline
-$ mv myaccess.json /mydirectory/access.json
-$ hq --server-dir=/mydirectory worker start
-```
+    The server will still generate and manages its "own" `access.json` in the server directory path, even if you provide your own access file. These files are the same, so you can use either when connectiong clients and workers.
+
 
 ## Splitting access for client and workers
 
-Access file contains two secret keys and two points to connect, for clients and for workers.
-This information can be divided into two separate files,
-containing only information needed only by clients or only by workers.
+The default access file contains two secret keys and two TCP/IP addresses, one for clients and one for workers. This metadata can be divided into two separate files, containing only information needed only by clients or only by workers.
 
-```commandline
+```bash
 $ hq server generate-access full.json --client-file=client.json --worker-file=worker.json --client-port=6789 --worker-port=1234
 ```
 
@@ -56,6 +64,6 @@ For starting server (`hq server start --access-file=...`) you have to use `full.
 
 You can use the following command to configure different hostnames under which the server is visible to workers and clients.
 
-```commandline
+```bash
 hq server generate-access full.json --worker-host=<WORKER_HOST> --client-host=<CLIENT_HOST> ...
 ```

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -16,3 +16,5 @@ not required. A common use-case is to start the server on a login of an HPC syst
 [comment]: <> (TODO: describe scheduler)
 
 Learn more about deploying [server](server.md) and the [workers](worker.md).
+
+There is also a third component that we call the **client**, which represents the users of HyperQueue invoking various `hq` commands to communicate with the server component.

--- a/docs/deployment/server.md
+++ b/docs/deployment/server.md
@@ -44,18 +44,15 @@ $ hq --server-dir=foo worker start
     $ hq worker start &
     ```
 
-!!! important
-
-    When you start the server, it will create a new subdirectory in the server directory, which will store the data of the current running instance. It will also create a symlink `hq-current` which will point to the currently active
-    subdirectory.
-    Using this approach, you can start a server using the same server directory multiple times without overwriting data
-    of the previous runs.
-
 !!! danger "Server directory access"
 
     Encryption keys are stored in the server directory. Whoever has access to the server directory may submit jobs,
     connect workers to the server and decrypt communication between HyperQueue components. By default, the directory is
     only accessible by the user who started the server.
+
+## Running multiple servers
+
+When you start the server, it will create a new subdirectory in the server directory, which will store the data of the current running instance. It will also create a symlink `hq-current` which will point to the currently active subdirectory. Using this approach, you can start a server using the same server directory multiple times without overwriting data of the previous runs.
 
 ## Keeping the server alive
 
@@ -98,7 +95,7 @@ have to be connected to the server after it restarts.
 
     If the server crashes, the last few seconds of progress may be lost. For example,
     when a task is finished and the server crashes before the journal is written, then
-    after resuming the server, the task will be not be computed after a server restart.
+    after resuming the server, the task will be recomputed.
 
 ### Exporting journal events
 
@@ -110,7 +107,7 @@ $ hq journal export <journal-path>
 ```
 
 The events will be read from the provided journal and printed to `stdout` encoded in JSON, one
-event per line (this corresponds to line-delimited JSON, i.e. [NDJSON](http://ndjson.org/)).
+event per line (this corresponds to line-delimited JSON, i.e. [JSON Lines](https://jsonlines.org/)).
 
 You can also directly stream events in real-time from the server using the following command:
 
@@ -123,17 +120,15 @@ $ hq journal stream
     The JSON format of the journal events and their definition is currently unstable and can change
     with a new HyperQueue version.
 
-### Pruning journal
+### Pruning the journal
 
-Command `hq journal prune` removes all completed jobs and disconnected workers from the journal file.
+The `hq journal prune` command removes all completed jobs and disconnected workers from the journal file, in order to reduce its size on disk.
 
-### Flushing journal
+### Flushing the journal
 
-Command `hq journal flush` will force the server to flush the journal.
-It is mainly for the testing purpose or if you are going to `hq journal export` on
-a live journal (however, it is usually better to use `hq journal stream`).
+Command `hq journal flush` will force the server to flush the journal, so that the latest state of affairs is persisted to disk. It is mainly useful for testing or if you are going to run `hq journal export` while a server is running (however, it is usually better to use `hq journal stream`).
 
-## Stopping server
+## Stopping the server
 
 You can stop a running server with the following command:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -54,7 +54,7 @@ about anything related to HyperQueue, feel free to ask on our [discussion forum]
     each with a single task.
 
     HQ also supports [streaming](jobs/streaming.md) of task outputs into a single file.
-    This avoids creating many small files for each task on a distributed file system, which improves
+    This avoids creating many small files for each task on a distributed filesystem, which improves
     scaling.
 
 ??? question "Does HQ support multi-CPU tasks?"

--- a/docs/jobs/arrays.md
+++ b/docs/jobs/arrays.md
@@ -110,7 +110,7 @@ If `--array` defines an ID that exceeds the number of lines in the file (or the 
 
 For example:
 
-```commandline
+```bash
 $ hq submit --each-line input.txt --array "2, 8-10"
 ```
 

--- a/docs/jobs/failure.md
+++ b/docs/jobs/failure.md
@@ -9,7 +9,7 @@ recompute only tasks with a specific status (e.g. failed tasks).
 By following combination of commands you may recompute only failed tasks. Let us assume that we want to recompute
 all failed tasks in job 5:
 
-```commandline
+```bash
 $ hq submit --array=`hq job task-ids 5 --filter=failed` ./my-computation
 ```
 It works as follows: Command `hq job task-ids 5 --filter=failed` returns IDs of failed jobs of job `5`, and we set
@@ -17,13 +17,13 @@ it to `--array` parameter that starts only tasks for given IDs.
 
 If we want to recompute all failed tasks and all canceled tasks we can do it as follows:
 
-```commandline
+```bash
 $ hq submit --array=`hq job task-ids 5 --filter=failed,canceled` ./my-computation
 ```
 
 Note that it also works with `--each-line` or `--from-json`, i.e.:
 
-```commandline
+```bash
 # Original computation
 $ hq submit --each-line=input.txt ./my-computation
 
@@ -56,7 +56,7 @@ You can change this behavior with the `--max-fails=<X>` option of the `submit` c
 If specified, once more tasks than `X` tasks fail, the rest of the job's tasks that were not completed yet will be canceled.
 
 For example:
-```commandline
+```bash
 $ hq submit --array 1-1000 --max-fails 5 ...
 ```
 This will create a task array with `1000` tasks. Once `5` or more tasks fail, the remaining uncompleted tasks of the job

--- a/docs/jobs/jobfile.md
+++ b/docs/jobs/jobfile.md
@@ -22,13 +22,13 @@ command = ["sleep", "1"]
 Let us assume that we have named this file as ``myfile.toml``,
 then we can run the following command to submit a job:
 
-```commandline
+```bash
 $ hq job submit-file myfile.toml
 ```
 
 The effect will be same as running:
 
-```commandline
+```bash
 $ hq submit sleep 1
 ```
 

--- a/docs/jobs/jobs.md
+++ b/docs/jobs/jobs.md
@@ -427,25 +427,25 @@ Here is a list of useful job commands:
 
 ### Display a summary table of all jobs
 
-```commandline
+```bash
 $ hq job summary
 ```
 
 ### Display information about a specific job
 
-```commandline
+```bash
 $ hq job info <job-selector>
 ```
 
 ### Display information about individual tasks (potentially across multiple jobs)
 
-```commandline
+```bash
 $ hq task list <job-selector> [--task-status <status>] [--tasks <task-selector>]
 ```
 
 ### Display job `stdout`/`stderr`
 
-```commandline
+```bash
 $ hq job cat <job-id> [--tasks <task-selector>] <stdout/stderr>
 ```
 
@@ -456,7 +456,7 @@ worker. HyperQueue server remembers how many times were a task running while a w
 If the count reaches the limit, then the task is set to the failed state.
 By default, this limit is `5` but it can be changed as follows:
 
-```commandline
+```bash
 $ hq submit --crash-limit=<NEWLIMIT> ...
 ```
 

--- a/docs/jobs/multinode.md
+++ b/docs/jobs/multinode.md
@@ -15,7 +15,7 @@ A job with multi-node task can be specified by ``--nodes=X`` option.
 
 An example of a job with multi-node task asking for 4 nodes:
 
-```commandline
+```bash
 $ hq submit --nodes 4 test.sh
 ```
 
@@ -46,7 +46,7 @@ are put in "default" group.
 
 A group of a worker can be specified at the start of the worker and it may be any string. Example:
 
-```commandline
+```bash
 $ hq worker start --group my_group
 ```
 

--- a/docs/jobs/openjobs.md
+++ b/docs/jobs/openjobs.md
@@ -9,7 +9,7 @@ long as it is open.
 
 A job can be opened by the following command:
 
-```commandline
+```bash
 $ hq job open
 ```
 
@@ -21,7 +21,7 @@ Job <ID> is open.
 
 If you want to get just ID without any additional text, you can open job as follows:
 
-```commandline
+```bash
 $ hq --output-mode=quiet job open
 ```
 
@@ -44,7 +44,7 @@ $ hq submit --job <JOB_ID> ... other submit args ...
 All tasks in one job share the task ID space. When you do not specify task ids, HQ automatically assigns a smallest ID
 that is bigger then any existing task id.
 
-```commandline
+```bash
 $ hq job open
 $ hq submit --job <JOB_ID> -- hostname # Task ID is 0 
 $ hq submit --job <JOB_ID> -- hostname # Task ID is 1
@@ -55,7 +55,7 @@ $ hq submit --job <JOB_ID> --each-line='test.txt' -- do-something
 
 If you are explicitly specifying task IDs, it is an error if task ID is reused:
 
-```commandline
+```bash
 $ hq submit --job <JOB_ID> -- hostname # Task ID is 0
 
 # This is Ok 
@@ -71,7 +71,7 @@ Job's name and configuration open `--max-fails` are the property of the job. The
 cannot be later changed. Submit options `--name` and `--max-fails` cannot be used if you are submitting into an open
 job.
 
-```commandline
+```bash
 # Configuring jobs's name and max fails
 $ hq job open --name=MyOpenJob --max-fails=10
 
@@ -84,7 +84,7 @@ $ hq submit --job <JOB_ID> --max-fails=5 ...
 Submitting job definition file into an open job works in the similar way as a normal submit, you just need to
 add `--job` parameter.
 
-```commandline
+```bash
 $ hq job submit-file --job <JOB_ID> job-definition.toml
 ```
 
@@ -92,7 +92,7 @@ $ hq job submit-file --job <JOB_ID> job-definition.toml
 
 You can close a job by calling:
 
-```commandline
+```bash
 $ hq job close <JOB_SELECTOR>
 ```
 

--- a/docs/jobs/streaming.md
+++ b/docs/jobs/streaming.md
@@ -27,7 +27,7 @@ $ hq submit --stream=<stream-dir> --array=1-10_000 ...
 
 !!! warning
 
-    It is the user's responsibility to ensure that the `<stream-dir>` path is accessible and writable by each worker that might execute tasks of the submitted job. See also [Working with a non-shared file system](#working-with-a-non-shared-file-system).
+    It is the user's responsibility to ensure that the `<stream-dir>` path is accessible and writable by each worker that might execute tasks of the submitted job. See also [Working with a non-shared filesystem](#working-with-a-non-shared-file-system).
 
 The command above will cause the `stdout` and `stderr` of all `10_000` tasks to be streamed in a compact way into a small number of files located in `<stream-dir>`. Note that the number of files created in the directory will be independent of the number of tasks of the job, thus alleviating the performance issue on networked filesystems. The created binary files will also contain additional metadata, which allows the resulting files to be filtered/sorted by tasks or channel.
 
@@ -111,7 +111,7 @@ If you want to see the output of a specific task, you can use the `--task=<task-
 If you want to inspect the contents of the stream directory along with its inner metadata that shows which task and which channel
 has produced which part of the data, you can use the `show` subcommand:
 
-```commandline
+```bash
 $ hq output-log <stream-directory> show
 ```
 
@@ -124,7 +124,7 @@ You can filter a specific channel with the `--channel=stdout/stderr` flag.
 
 The contents of the stream directory can be exported into JSON by the following command:
 
-```commandline
+```bash
 $ hq output-log <stream-dir> export
 ```
 
@@ -153,8 +153,8 @@ when working with such a streaming directory.
 
     When a server is restored from a journal file, it will maintain the same server UID. When a server is started "from a scratch" a new server UID is generated.
 
-## Working with a non-shared file system
+## Working with a non-shared filesystem
 
-You do not need to have a shared file system when working with streaming. You just have to collect all generated files from the streaming directories in the different file systems into a single directory before using the `hq output-log` commands.
+You do not need to have a shared filesystem when working with streaming. You just have to collect all generated files from the streaming directories in the different filesystems into a single directory before using the `hq output-log` commands.
 
 For example, you could use `/tmp/hq-stream` as a stream directory, which can be a local disk path on each worker, and then merge the contents of all such directories and use `hq output-log` on the resulting merged directory.

--- a/docs/python/dependencies.md
+++ b/docs/python/dependencies.md
@@ -6,7 +6,7 @@ If a task `B` **depends** on task `A`, then `B` will not be executed until `A` h
 finished. Using dependencies, you can describe arbitrarily complex DAG (directed acyclic graph)
 workflows.
 
-!!! notice
+!!! note
 
     HyperQueue jobs are independent of each other, so dependencies can only be specified between tasks
     within a single job.

--- a/docs/python/submit.md
+++ b/docs/python/submit.md
@@ -60,7 +60,7 @@ without the need to write an additional external script.
 Same as with the `program` method, `function` will return a [`Task`](hyperqueue.task.task.Task)
 that can used to define [dependencies](dependencies.md).
 
-!!! notice
+!!! note
 
     Currently, a new Python interpreter will be started for each Python task.
 


### PR DESCRIPTION
The autoalloc docs really needed an upgrade, but I did a full pass over the whole deployment docs.

Also unified `commandline` to `bash`. We can switch everything to `commandline` if you want, I just wanted to avoid having some examples use one and some the other.