### PR TITLE
Improve logging in autoalloc and add fast path

### DIFF
--- a/crates/hyperqueue/src/common/arraydef.rs
+++ b/crates/hyperqueue/src/common/arraydef.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
 
 use serde::Deserialize;
@@ -6,7 +7,7 @@ use serde::Serialize;
 
 use crate::common::arrayparser::parse_array;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Clone, Copy)]
 pub struct IntRange {
     pub start: u32,
     pub count: u32,
@@ -25,6 +26,13 @@ impl IntRange {
     pub fn contains(&self, value: u32) -> bool {
         let end = self.start + self.count;
         self.start <= value && value < end && ((value - self.start) % self.step == 0)
+    }
+}
+
+impl Debug for IntRange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let Self { start, count, step } = self;
+        write!(f, "({start}-{};{step})", start + count)
     }
 }
 

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -87,14 +87,14 @@ pub async fn autoalloc_process(
     loop {
         tokio::select! {
             _ = periodic_update_interval.tick() => {
-                if autoalloc.has_queues() {
+                if autoalloc.has_active_queues() {
                     log::debug!("Performing periodic update");
                     do_periodic_update(&senders, &mut autoalloc).await;
                 }
             }
             _ = scheduling_interval.tick() => {
                 if should_schedule || last_schedule.elapsed() >= max_scheduling_delay {
-                    if autoalloc.has_queues() {
+                    if autoalloc.has_active_queues() {
                         log::debug!("Performing submits");
                         if let Err(error) = perform_submits(&mut autoalloc, &senders).await {
                             log::error!("Autoalloc scheduling failed: {error:?}");

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -252,6 +252,26 @@ impl AllocationQueue {
     pub fn get_worker_config(&self) -> Option<&WorkerConfiguration> {
         self.worker_config.as_ref()
     }
+
+    /// How many workers are currently queued or running?
+    pub fn active_worker_count(&self) -> u32 {
+        self.active_allocations()
+            .map(|allocation| allocation.target_worker_count as u32)
+            .sum::<u32>()
+    }
+
+    /// Returns true only if at least a single allocation could be added to this queue.
+    pub fn has_space_for_submit(&self) -> bool {
+        if self.queued_allocations().count() >= self.info.backlog() as usize {
+            return false;
+        }
+        if let Some(max_worker_count) = self.info.max_worker_count() {
+            if self.active_worker_count() >= max_worker_count {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 // Allocation

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -103,8 +103,8 @@ impl AutoAllocState {
         to_remove
     }
 
-    pub fn has_queues(&self) -> bool {
-        !self.queues.is_empty()
+    pub fn has_active_queues(&self) -> bool {
+        self.queues.values().any(|q| q.state().is_active())
     }
 
     #[cfg(test)]

--- a/crates/tako/src/internal/server/core.rs
+++ b/crates/tako/src/internal/server/core.rs
@@ -547,7 +547,7 @@ mod tests {
             self.worker_groups.get(group_name)
         }
 
-        pub fn get_read_to_assign(&self) -> &[TaskId] {
+        pub fn get_ready_to_assign(&self) -> &[TaskId] {
             &self.single_node_ready_to_assign
         }
 

--- a/crates/tako/src/internal/tests/test_reactor.rs
+++ b/crates/tako/src/internal/tests/test_reactor.rs
@@ -1100,7 +1100,7 @@ fn test_task_deps() {
     let mut core = Core::default();
     //create_test_workers(&mut core, &[1, 1, 1]);
     submit_example_3(&mut core);
-    assert_eq!(core.get_read_to_assign().len(), 2);
+    assert_eq!(core.get_ready_to_assign().len(), 2);
     create_test_workers(&mut core, &[1]);
     start_and_finish_on_worker(&mut core, 2, 100);
     core.assert_waiting(&[3, 4, 6]);


### PR DESCRIPTION
Logging `stdin` as a bytearray didn't really look nice in logs.