### PR TITLE
Fix jobfile docs: array is not a TOML sequence

### DIFF
--- a/docs/jobs/jobfile.md
+++ b/docs/jobs/jobfile.md
@@ -101,7 +101,7 @@ command = ["sleep", "3"]
 If you want to create uniform tasks you can define task array (similar to `--array`):
 
 ```toml
-[[array]]
+[array]
 ids = "1,2,50-100"
 command = ["sleep", "1"]
 ```
@@ -109,7 +109,7 @@ command = ["sleep", "1"]
 You can also specify array with content of `HQ_ENTRIES`:
 
 ```toml
-[[array]]
+[array]
 entries = ["One", "Two", "Three"]
 command = ["sleep", "1"]
 ```


### PR DESCRIPTION
I was trying to define task arrays in a job definition file and was stuck with this error wondering why it was not working:
```
Deserialization error: TOML parse error at line 4, column 1
  |
4 | [[array]]
  | ^^^^^^^^^
invalid type: sequence, expected struct ArrayDef
```
After looking at the [code](https://github.com/It4innovations/hyperqueue/blob/33ff4e55ff4eaed147662cbee2277b58e2b6e568/crates/hyperqueue/src/client/commands/submit/defs.rs#L258), I guess that the docs were wrong. Just wanted to PR this so anyone who's not very familiar with TOML does not get stuck like me.