### PR TITLE
Run typo check in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,9 @@ jobs:
           cargo install --git https://github.com/spirali/cli_doc
           mkdocs build
 
+
+      - name: Spellcheck
+        uses: crate-ci/typos@v1.34.0
   compatibility_mode:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 *.so
 *snap
+/venv

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,8 @@
+[default.extend-words]
+ratatui = "ratatui"
+HPE = "HPE"
+
+[files]
+# typos doesn't have an include list, so this is an alternative,
+# so that we don't have to spell out the correct filenames both in scripts and on CI
+extend-exclude = ["*", "!crates", "!tests", "!docs", "!README.md", "!CHANGELOG.md"]

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,4 +1,0 @@
-[default.extend-words]
-ratatui = "ratatui"
-HPE="HPE"
-

--- a/scripts/fix-typos.sh
+++ b/scripts/fix-typos.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+cd `dirname $0`/..
+
+cargo install --locked typos-cli@1.34.0
+typos -w

--- a/scripts/typos.sh
+++ b/scripts/typos.sh
@@ -1,2 +1,0 @@
-cd `dirname $0`/..
-typos crates README.md CHANGELOG.md tests docs


### PR DESCRIPTION
Had to do some gymnastics to use the same set of paths to check on CI and locally (https://github.com/crate-ci/typos/issues/1340).