### PR TITLE
Restore known worker resources for allocation queues

### DIFF
--- a/crates/hyperqueue/src/common/manager/info.rs
+++ b/crates/hyperqueue/src/common/manager/info.rs
@@ -5,7 +5,7 @@ use tako::worker::WorkerConfiguration;
 
 pub const WORKER_EXTRA_MANAGER_KEY: &str = "JobManager";
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub enum ManagerType {
     Pbs,
     Slurm,

--- a/crates/hyperqueue/src/server/autoalloc/process.rs
+++ b/crates/hyperqueue/src/server/autoalloc/process.rs
@@ -192,7 +192,7 @@ async fn handle_message(
             if let Some((queue, queue_id, allocation_id)) =
                 get_data_from_worker(autoalloc, &manager_info)
             {
-                queue.register_worker_config(config);
+                queue.register_worker_resources(config);
                 log::info!(
                     "Worker {id} connected from allocation {}",
                     manager_info.allocation_id
@@ -264,10 +264,18 @@ async fn handle_message(
             server_directory,
             params,
             queue_id,
+            worker_resources,
             response,
         } => {
             log::debug!("Creating queue, params={params:?}");
-            let result = create_queue(autoalloc, events, server_directory, params, queue_id);
+            let result = create_queue(
+                autoalloc,
+                events,
+                server_directory,
+                params,
+                queue_id,
+                worker_resources,
+            );
             response.respond(result);
             true
         }
@@ -389,9 +397,9 @@ async fn perform_submits(
 /// Create a worker query that corresponds to the provided resources of the given `queue`.
 fn create_queue_worker_query(queue: &AllocationQueue) -> WorkerTypeQuery {
     let (descriptor, partial) = {
-        if let Some(worker_config) = queue.get_worker_config() {
-            // If we have a known worker config, we estimate exact resources based on it
-            (worker_config.resources.clone(), false)
+        if let Some(worker_resources) = queue.get_worker_resources() {
+            // If we have known worker resources, we estimate exact resources based on it
+            (worker_resources.clone(), false)
         } else if let Some(resources) = queue.info().cli_resource_descriptor() {
             // If not, try to at least estimate partial resources based from the CLI arguments
             (resources.clone(), true)
@@ -656,6 +664,7 @@ fn create_queue(
     server_directory: PathBuf,
     params: QueueParameters,
     queue_id: Option<QueueId>,
+    worker_resources: Option<ResourceDescriptor>,
 ) -> anyhow::Result<QueueId> {
     let name = params.name.clone();
     let handler = create_allocation_handler(&params.manager, name.clone(), server_directory);
@@ -663,7 +672,13 @@ fn create_queue(
 
     match handler {
         Ok(handler) => {
-            let queue = AllocationQueue::new(queue_info, name, handler, create_rate_limiter());
+            let queue = AllocationQueue::new(
+                queue_info,
+                name,
+                handler,
+                create_rate_limiter(),
+                worker_resources,
+            );
             let id = {
                 let id = autoalloc.add_queue(queue, queue_id);
                 if queue_id.is_none() {
@@ -2135,6 +2150,7 @@ mod tests {
                     server_directory: PathBuf::from("test"),
                     params,
                     queue_id: None,
+                    worker_resources: None,
                     response: token,
                 },
             )
@@ -2174,7 +2190,7 @@ mod tests {
             self.state
                 .get_queue_mut(queue)
                 .expect("queue not found")
-                .register_worker_config(config);
+                .register_worker_resources(config);
         }
 
         async fn start_worker<Info: Into<ManagerInfo>>(
@@ -2347,6 +2363,7 @@ mod tests {
                 None,
                 always_queued_handler(),
                 limiter,
+                None,
             )
         }
     }

--- a/crates/hyperqueue/src/server/autoalloc/service.rs
+++ b/crates/hyperqueue/src/server/autoalloc/service.rs
@@ -16,6 +16,7 @@ use crate::server::autoalloc::{Allocation, QueueId, QueueParameters};
 use crate::server::event::streamer::EventStreamer;
 use crate::transfer::messages::QueueData;
 use tako::JobId;
+use tako::resources::ResourceDescriptor;
 
 #[derive(Debug)]
 pub enum AutoAllocMessage {
@@ -34,6 +35,7 @@ pub enum AutoAllocMessage {
         server_directory: PathBuf,
         params: QueueParameters,
         queue_id: Option<QueueId>,
+        worker_resources: Option<ResourceDescriptor>,
         response: ResponseToken<anyhow::Result<QueueId>>,
     },
     RemoveQueue {
@@ -103,12 +105,14 @@ impl AutoAllocService {
         server_dir: &Path,
         params: QueueParameters,
         queue_id: Option<QueueId>,
+        worker_resources: Option<ResourceDescriptor>,
     ) -> anyhow::Result<QueueId> {
         let fut = initiate_request(|token| {
             self.sender.send(AutoAllocMessage::AddQueue {
                 server_directory: server_dir.to_path_buf(),
                 params,
                 queue_id,
+                worker_resources,
                 response: token,
             })
         });

--- a/crates/hyperqueue/src/server/autoalloc/state.rs
+++ b/crates/hyperqueue/src/server/autoalloc/state.rs
@@ -15,6 +15,7 @@ use crate::server::autoalloc::config::MAX_KEPT_DIRECTORIES;
 use crate::server::autoalloc::queue::QueueHandler;
 use crate::server::autoalloc::{LostWorkerDetails, QueueInfo};
 use tako::Map;
+use tako::resources::ResourceDescriptor;
 use tako::worker::WorkerConfiguration;
 
 // Main state holder
@@ -146,9 +147,9 @@ pub struct AllocationQueue {
     name: Option<String>,
     handler: Box<dyn QueueHandler>,
     rate_limiter: RateLimiter,
-    /// A worker configuration from a worker that connected from an allocation
+    /// Worker resources from a worker that connected from an allocation
     /// attached to this queue.
-    worker_config: Option<WorkerConfiguration>,
+    worker_resources: Option<ResourceDescriptor>,
 }
 
 impl AllocationQueue {
@@ -157,6 +158,7 @@ impl AllocationQueue {
         name: Option<String>,
         handler: Box<dyn QueueHandler>,
         rate_limiter: RateLimiter,
+        worker_resources: Option<ResourceDescriptor>,
     ) -> Self {
         Self {
             state: AllocationQueueState::Active,
@@ -165,7 +167,7 @@ impl AllocationQueue {
             handler,
             allocations: Default::default(),
             rate_limiter,
-            worker_config: None,
+            worker_resources,
         }
     }
 
@@ -244,13 +246,13 @@ impl AllocationQueue {
             .filter(|alloc| alloc.is_active())
     }
 
-    pub fn register_worker_config(&mut self, config: WorkerConfiguration) {
+    pub fn register_worker_resources(&mut self, config: WorkerConfiguration) {
         // Always overwrite the config with the latest one that we have seen
-        self.worker_config = Some(config);
+        self.worker_resources = Some(config.resources);
     }
 
-    pub fn get_worker_config(&self) -> Option<&WorkerConfiguration> {
-        self.worker_config.as_ref()
+    pub fn get_worker_resources(&self) -> Option<&ResourceDescriptor> {
+        self.worker_resources.as_ref()
     }
 
     /// How many workers are currently queued or running?
@@ -560,6 +562,7 @@ mod tests {
                 None,
                 Box::new(NullHandler),
                 RateLimiter::new(vec![Duration::from_secs(1)], 1, 1),
+                None,
             ),
             None,
         );

--- a/crates/hyperqueue/src/server/bootstrap.rs
+++ b/crates/hyperqueue/src/server/bootstrap.rs
@@ -379,7 +379,12 @@ async fn start_server(
             for queue in new_queues {
                 senders
                     .autoalloc
-                    .add_queue(&server_dir, *queue.params, Some(queue.queue_id))
+                    .add_queue(
+                        &server_dir,
+                        *queue.params,
+                        Some(queue.queue_id),
+                        queue.worker_resources,
+                    )
                     .await
                     .unwrap();
             }

--- a/crates/hyperqueue/src/server/client/autoalloc.rs
+++ b/crates/hyperqueue/src/server/client/autoalloc.rs
@@ -34,9 +34,10 @@ pub async fn handle_autoalloc_message(
                 }
             }
 
-            let result = senders
-                .autoalloc
-                .add_queue(server_dir.directory(), parameters, None);
+            let result =
+                senders
+                    .autoalloc
+                    .add_queue(server_dir.directory(), parameters, None, None);
             match result.await {
                 Ok(queue_id) => {
                     ToClientMessage::AutoAllocResponse(AutoAllocResponse::QueueCreated(queue_id))


### PR DESCRIPTION
So that they are not forgotten when the server restarts.

Closes: https://github.com/It4innovations/hyperqueue/issues/958