### PR TITLE
Turn some debug logs into trace logs

### DIFF
--- a/crates/tako/src/internal/server/rpc.rs
+++ b/crates/tako/src/internal/server/rpc.rs
@@ -122,7 +122,7 @@ async fn worker_rpc_loop(
     );
 
     let heartbeat_interval = msg.configuration.heartbeat_interval;
-    log::debug!("Worker heartbeat: {heartbeat_interval:?}");
+    log::debug!("Worker heartbeat interval: {heartbeat_interval:?}");
     // Sanity that interval is not too small
     assert!(heartbeat_interval.as_millis() > 150);
 
@@ -318,7 +318,7 @@ pub(crate) async fn worker_receive_loop<
             }
             FromWorkerMessage::Heartbeat => {
                 if let Some(worker) = core.get_worker_mut(worker_id) {
-                    log::debug!("Heartbeat received, worker={worker_id}");
+                    log::trace!("Heartbeat received, worker={worker_id}");
                     worker.last_heartbeat = Instant::now();
                 };
             }

--- a/crates/tako/src/internal/transfer/auth.rs
+++ b/crates/tako/src/internal/transfer/auth.rs
@@ -97,7 +97,7 @@ impl Authenticator {
         match &mut (message.mode, &self.secret_key) {
             (AuthenticationMode::NoAuth, None) => Ok(AuthenticationResponse::NoAuth),
             (AuthenticationMode::Encryption(msg), Some(key)) => {
-                log::debug!("Worker authorization started");
+                log::trace!("Peer authorization started");
                 if msg.challenge.len() != CHALLENGE_LENGTH {
                     return self._make_error(format!(
                         "Invalid length of challenge ({})",
@@ -144,11 +144,11 @@ impl Authenticator {
                 return Err(format!("Received authentication error: {}", error.message).into());
             }
             (AuthenticationResponse::NoAuth, None) => {
-                log::debug!("Empty authentication finished");
+                log::trace!("Empty authentication finished");
                 None
             }
             (AuthenticationResponse::Encryption(response), Some(key)) => {
-                log::debug!("Challenge verification started");
+                log::trace!("Challenge verification started");
                 let remote_nonce =
                     &Nonce::from_slice(&response.nonce).map_err(|_| "Invalid nonce")?;
                 let mut opener =
@@ -164,7 +164,7 @@ impl Authenticator {
                 if tag != StreamTag::Message || opened_challenge != expected_response {
                     return Err("Received challenge does not match.".into());
                 }
-                log::debug!("Challenge verification finished");
+                log::trace!("Challenge verification finished");
                 Some(opener)
             }
             (_, _) => {


### PR DESCRIPTION
These messages are very verbose and I don't think they bring a lot of utility.

The "worker challenge" log was misleading, because it was also printed for client connections.