### PR TITLE
Allow using the `all` selector in `hq job info`

### DIFF
--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -43,9 +43,7 @@ use hyperqueue::common::cli::{
 use hyperqueue::common::setup::setup_logging;
 use hyperqueue::common::utils::fs::absolute_path;
 use hyperqueue::server::bootstrap::get_client_session;
-use hyperqueue::transfer::messages::{
-    FromClientMessage, IdSelector, JobInfoRequest, ToClientMessage,
-};
+use hyperqueue::transfer::messages::{FromClientMessage, JobInfoRequest, ToClientMessage};
 use hyperqueue::worker::hwdetect::{
     detect_additional_resources, detect_cpus, prune_hyper_threading,
 };
@@ -106,13 +104,6 @@ async fn command_job_summary(gsettings: &GlobalSettings) -> anyhow::Result<()> {
 }
 
 async fn command_job_detail(gsettings: &GlobalSettings, opts: JobInfoOpts) -> anyhow::Result<()> {
-    if matches!(opts.selector, IdSelector::All) {
-        log::warn!(
-            "Job detail doesn't support the `all` selector, did you mean to use `hq job list --all`?"
-        );
-        return Ok(());
-    }
-
     let mut session = get_client_session(gsettings.server_directory()).await?;
     output_job_detail(gsettings, &mut session, opts.selector).await
 }

--- a/docs/cli/shortcuts.md
+++ b/docs/cli/shortcuts.md
@@ -38,7 +38,6 @@ would stop workers with IDs `1`, `3`, `5`, `6`, `7` and `8`.
 - `hq submit --array=<selector>`
 - `hq worker stop <selector>`
 - `hq job info <selector>`
-    - does not support `all` (use `hq job list` instead)
 - `hq job cancel <selector>`
 - `hq job wait <selector>`
 - `hq job progress <selector>`


### PR DESCRIPTION
Fixes: https://github.com/It4innovations/hyperqueue/issues/843
