### PR TITLE
Stable task compactation in the main scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   This is useful for deployment scripts that need to wait for server availability.
 * New `hq alloc add` parameter called `--wrap-worker-cmd`. It can be used to start
   workers on allocated nodes using some wrapping mechanism (e.g. Podman).
+* The scheduler has better compacting behavior when there are small number of tasks
+  and workers appearing/disappering
 
 ### Fixes
 

--- a/crates/tako/src/internal/scheduler/state.rs
+++ b/crates/tako/src/internal/scheduler/state.rs
@@ -22,6 +22,11 @@ use crate::{TaskId, WorkerId};
 const LONG_DURATION: std::time::Duration = std::time::Duration::from_secs(365 * 24 * 60 * 60);
 
 // Knobs
+/// If there is at most `MAX_TASKS_FOR_IMMEDIATE_RUN_CHECK` fresh incoming tasks,
+/// then try compat task on workers (it tests that task may immediately run)
+/// If there are more tasks, skip this test and assumes that we are
+/// going to overload workers anyway.
+/// Ideally, it should depend on the number of workers and their resources.
 const MAX_TASKS_FOR_IMMEDIATE_RUN_CHECK: usize = 600;
 
 pub struct SchedulerState {

--- a/crates/tako/src/internal/server/core.rs
+++ b/crates/tako/src/internal/server/core.rs
@@ -164,6 +164,14 @@ impl Core {
         self.sleeping_sn_tasks.push(task_id);
     }
 
+    pub fn add_sleeping_sn_tasks(&mut self, task_ids: Vec<TaskId>) {
+        if self.sleeping_sn_tasks.is_empty() {
+            self.sleeping_sn_tasks = task_ids;
+        } else {
+            self.sleeping_sn_tasks.extend(task_ids);
+        }
+    }
+
     pub fn sleeping_sn_tasks(&self) -> &[TaskId] {
         &self.sleeping_sn_tasks
     }

--- a/crates/tako/src/internal/server/worker.rs
+++ b/crates/tako/src/internal/server/worker.rs
@@ -193,6 +193,17 @@ impl Worker {
             .have_immediate_resources_for_rqv(rqv, &self.resources)
     }
 
+    pub fn have_immediate_resources_for_rqv_now(
+        &self,
+        rqv: &ResourceRequestVariants,
+        now: Instant,
+    ) -> bool {
+        self.has_time_to_run_for_rqv(rqv, now)
+            && self
+                .sn_load
+                .have_immediate_resources_for_rqv(rqv, &self.resources)
+    }
+
     pub fn have_immediate_resources_for_lb(&self, rrb: &ResourceRequestLowerBound) -> bool {
         self.sn_load
             .have_immediate_resources_for_lb(rrb, &self.resources)

--- a/crates/tako/src/internal/tests/test_scheduler_sn.rs
+++ b/crates/tako/src/internal/tests/test_scheduler_sn.rs
@@ -491,6 +491,7 @@ fn test_generic_resource_assign2() {
         rt.new_task(TaskBuilder::new(i).add_resource(2, 2));
     }
     rt.schedule();
+
     assert_eq!(
         rt.core()
             .get_worker_by_id(101.into())


### PR DESCRIPTION
The PR improves compacting behavior of the main scheduler. 

The original scheduler was also compacting but it could change target of compaction when a new worker appears/disappears. This is fixed by this PR. 

The new version should lead to the following scenario (even when running workers are changed): when there are just few incoming tasks, it should spread tasks across the minimal number of workers and this should lead to termination of others by idle timeout.

This should help with the situation described in #937.