### PR TITLE
Share task bodies and batch worker task compute messages

### DIFF
--- a/crates/hyperqueue/src/server/client/submit.rs
+++ b/crates/hyperqueue/src/server/client/submit.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
+use std::rc::Rc;
 use tako::gateway::{
     EntryType, SharedTaskConfiguration, TaskConfiguration, TaskDataFlags, TaskSubmit,
 };
@@ -332,16 +333,14 @@ fn serialize_task_body(
     task_desc: &TaskDescription,
     submit_dir: &PathBuf,
     stream_path: Option<&PathBuf>,
-) -> Box<[u8]> {
+) -> Rc<[u8]> {
     let body_msg = TaskBuildDescription {
         task_kind: Cow::Borrowed(&task_desc.kind),
         submit_dir: Cow::Borrowed(submit_dir),
         stream_path: stream_path.map(Cow::Borrowed),
     };
     let body = tako::comm::serialize(&body_msg).expect("Could not serialize task body");
-    // Make sure that `into_boxed_slice` is a no-op.
-    debug_assert_eq!(body.capacity(), body.len());
-    body.into_boxed_slice()
+    body.into()
 }
 
 fn build_tasks_array(

--- a/crates/tako/benches/benchmarks/worker.rs
+++ b/crates/tako/benches/benchmarks/worker.rs
@@ -6,7 +6,7 @@ use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion};
 use smallvec::smallvec;
 use tako::TaskId;
 use tako::gateway::TaskDataFlags;
-use tako::internal::messages::worker::ComputeTaskMsg;
+use tako::internal::messages::worker::{ComputeTaskSeparateData, ComputeTaskSharedData};
 use tako::internal::tests::utils::shared::res_allocator_from_descriptor;
 use tako::internal::worker::comm::WorkerComm;
 use tako::internal::worker::rqueue::ResourceWaitQueue;
@@ -58,18 +58,21 @@ fn create_worker_state() -> WorkerStateRef {
 
 fn create_worker_task(id: u32) -> Task {
     Task::new(
-        ComputeTaskMsg {
+        ComputeTaskSeparateData {
+            shared_index: 0,
             id: TaskId::new_test(id),
             instance_id: Default::default(),
-            user_priority: 0,
             scheduler_priority: 0,
-            resources: Default::default(),
-            time_limit: None,
             node_list: vec![],
             data_deps: vec![],
+            entry: None,
+        },
+        ComputeTaskSharedData {
+            user_priority: 0,
+            resources: Default::default(),
+            time_limit: None,
             data_flags: TaskDataFlags::empty(),
             body: Default::default(),
-            entry: None,
         },
         TaskState::Waiting(0),
     )

--- a/crates/tako/benches/utils/mod.rs
+++ b/crates/tako/benches/utils/mod.rs
@@ -19,7 +19,7 @@ pub fn create_task(id: TaskId) -> Task {
         time_limit: None,
         crash_limit: CrashLimit::default(),
         data_flags: TaskDataFlags::empty(),
-        body: Box::new([]),
+        body: Rc::new([]),
     };
     Task::new(
         id,

--- a/crates/tako/src/gateway.rs
+++ b/crates/tako/src/gateway.rs
@@ -88,15 +88,14 @@ impl ResourceRequestVariants {
 }
 
 bitflags::bitflags! {
-    #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-    #[cfg_attr(test, derive(Eq, PartialEq))]
+    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct TaskDataFlags: u32 {
         const ENABLE_DATA_LAYER = 0b00000001;
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum CrashLimit {
     NeverRestart,
     MaxCrashes(u16),

--- a/crates/tako/src/gateway.rs
+++ b/crates/tako/src/gateway.rs
@@ -5,6 +5,7 @@ use crate::{InstanceId, Map, Priority, TaskId};
 use serde::{Deserialize, Serialize};
 use smallvec::{SmallVec, smallvec};
 use std::fmt::{Display, Formatter};
+use std::rc::Rc;
 use std::time::Duration;
 use thin_vec::ThinVec;
 
@@ -132,7 +133,7 @@ pub struct SharedTaskConfiguration {
 
     pub data_flags: TaskDataFlags,
 
-    pub body: Box<[u8]>,
+    pub body: Rc<[u8]>,
 }
 
 pub type EntryType = ThinVec<u8>;

--- a/crates/tako/src/internal/messages/worker.rs
+++ b/crates/tako/src/internal/messages/worker.rs
@@ -7,7 +7,6 @@ use crate::resources::ResourceFractions;
 use crate::task::SerializedTaskContext;
 use crate::{InstanceId, Priority};
 use crate::{TaskId, WorkerId};
-use bstr::ByteSlice;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::rc::Rc;

--- a/crates/tako/src/internal/messages/worker.rs
+++ b/crates/tako/src/internal/messages/worker.rs
@@ -7,8 +7,10 @@ use crate::resources::ResourceFractions;
 use crate::task::SerializedTaskContext;
 use crate::{InstanceId, Priority};
 use crate::{TaskId, WorkerId};
+use bstr::ByteSlice;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
+use std::rc::Rc;
 use std::time::Duration;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -31,7 +33,6 @@ pub struct ComputeTaskSeparateData {
     pub scheduler_priority: Priority,
     pub node_list: Vec<WorkerId>,
     pub data_deps: Vec<DataObjectId>,
-    // TODO: do not take this as shared data
     pub entry: Option<EntryType>,
 }
 
@@ -41,8 +42,7 @@ pub struct ComputeTaskSharedData {
     pub resources: crate::internal::common::resources::ResourceRequestVariants,
     pub time_limit: Option<Duration>,
     pub data_flags: TaskDataFlags,
-    #[serde(with = "serde_bytes")]
-    pub body: Box<[u8]>,
+    pub body: Rc<[u8]>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/tako/src/internal/server/reactor.rs
+++ b/crates/tako/src/internal/server/reactor.rs
@@ -9,7 +9,7 @@ use crate::internal::messages::worker::{
 use crate::internal::server::comm::Comm;
 use crate::internal::server::core::Core;
 use crate::internal::server::dataobj::{DataObjectHandle, ObjsToRemoveFromWorkers, RefCount};
-use crate::internal::server::task::WaitingInfo;
+use crate::internal::server::task::{ComputeTasksBuilder, WaitingInfo};
 use crate::internal::server::task::{Task, TaskRuntimeState};
 use crate::internal::server::worker::Worker;
 use crate::internal::server::workermap::WorkerMap;
@@ -417,7 +417,10 @@ pub(crate) fn on_steal_response(
                     log::debug!("Task stealing was successful task={task_id}");
                     if let Some(w_id) = to_worker_id {
                         let task = core.get_task(task_id);
-                        comm.send_worker_message(w_id, &task.make_compute_message(Vec::new()));
+                        comm.send_worker_message(
+                            w_id,
+                            &ComputeTasksBuilder::single_task(task, Vec::new()),
+                        );
                         TaskRuntimeState::Assigned(w_id)
                     } else {
                         comm.ask_for_scheduling();

--- a/crates/tako/src/internal/server/task.rs
+++ b/crates/tako/src/internal/server/task.rs
@@ -96,7 +96,8 @@ pub struct TaskConfiguration {
     // In other words, task configuration fields that are the same between most tasks should be
     // ordered last.
     pub resources: crate::internal::common::resources::ResourceRequestVariants,
-    pub body: Box<[u8]>,
+    // Use Rc to avoid cloning the data when we serialize them
+    pub body: Rc<[u8]>,
     pub user_priority: Priority,
     pub time_limit: Option<Duration>,
     pub crash_limit: CrashLimit,
@@ -378,9 +379,9 @@ impl ExtractKey<TaskId> for Task {
 #[derive(Default)]
 pub struct ComputeTasksBuilder {
     tasks: Vec<ComputeTaskSeparateData>,
-    // TODO: if we ensured that we intern all known task configurations in memory, and they have
-    // a unique allocation, we could compare the configs here based on just pointer address, not
-    // the contents of `TaskConfiguration`.
+    // TODO: if we could ensure that we intern all known task configurations in memory, and they
+    // have a unique allocation, we could compare the configs here based on just pointer address,
+    // not the contents of `TaskConfiguration`.
     configuration_index: Map<Rc<TaskConfiguration>, usize>,
     shared_data: Vec<ComputeTaskSharedData>,
 }

--- a/crates/tako/src/internal/tests/integration/utils/task.rs
+++ b/crates/tako/src/internal/tests/integration/utils/task.rs
@@ -125,7 +125,7 @@ pub fn build_task_def_from_config(
         priority: 0,
         crash_limit: CrashLimit::default(),
         data_flags: TaskDataFlags::empty(),
-        body: body.into_boxed_slice(),
+        body: body.into(),
     };
     (
         TaskConfiguration {

--- a/crates/tako/src/internal/tests/test_scheduler_mn.rs
+++ b/crates/tako/src/internal/tests/test_scheduler_mn.rs
@@ -40,10 +40,10 @@ fn get_worker_status(ws: &[WorkerId], worker_id: WorkerId) -> WorkerStatus {
 fn check_worker_status_change(s1: WorkerStatus, s2: WorkerStatus, ms: &[ToWorkerMessage]) {
     match (s1, s2) {
         (WorkerStatus::Root, WorkerStatus::Root) | (WorkerStatus::None, WorkerStatus::Root) => {
-            assert!(matches!(ms, &[ToWorkerMessage::ComputeTask(_)]))
+            assert!(matches!(ms, &[ToWorkerMessage::ComputeTasks(_)]))
         }
         (WorkerStatus::NonRoot, WorkerStatus::Root) => {
-            assert!(matches!(ms, &[ToWorkerMessage::ComputeTask(_),]))
+            assert!(matches!(ms, &[ToWorkerMessage::ComputeTasks(_),]))
         }
         (WorkerStatus::NonRoot, WorkerStatus::None) => {
             assert!(matches!(ms, &[]))
@@ -83,8 +83,8 @@ fn test_schedule_mn_simple() {
     let test_mn_task = |task: &Task, comm: &mut TestComm| -> Vec<WorkerId> {
         let ws = task.mn_placement().unwrap().to_vec();
         assert_eq!(ws.len(), 2);
-        if let ToWorkerMessage::ComputeTask(m) = &comm.take_worker_msgs(ws[0], 1)[0] {
-            assert_eq!(&m.node_list, &ws);
+        if let ToWorkerMessage::ComputeTasks(m) = &comm.take_worker_msgs(ws[0], 1)[0] {
+            assert_eq!(&m.tasks[0].node_list, &ws);
         } else {
             unreachable!()
         }
@@ -140,7 +140,7 @@ fn test_schedule_mn_reserve() {
     let ws1 = core.get_task(1.into()).mn_placement().unwrap().to_vec();
     assert!(matches!(
         comm.take_worker_msgs(ws1[0], 1)[0],
-        ToWorkerMessage::ComputeTask(_)
+        ToWorkerMessage::ComputeTasks(_)
     ));
     assert!(!core.get_worker_by_id_or_panic(ws1[0]).is_reserved());
     assert!(core.get_worker_by_id_or_panic(ws1[1]).is_reserved());

--- a/crates/tako/src/internal/tests/test_scheduler_sn.rs
+++ b/crates/tako/src/internal/tests/test_scheduler_sn.rs
@@ -140,9 +140,10 @@ fn test_no_deps_distribute_with_balance() {
     let mut finish_all = |core: &mut Core, msgs, worker_id| {
         for m in msgs {
             match m {
-                ToWorkerMessage::ComputeTask(cm) => {
-                    assert!(active_ids.remove(&cm.id));
-                    finish_on_worker(core, cm.id, worker_id);
+                ToWorkerMessage::ComputeTasks(cm) => {
+                    assert_eq!(cm.tasks.len(), 0);
+                    assert!(active_ids.remove(&cm.tasks[0].id));
+                    finish_on_worker(core, cm.tasks[0].id, worker_id);
                 }
                 _ => unreachable!(),
             };

--- a/crates/tako/src/internal/tests/utils/task.rs
+++ b/crates/tako/src/internal/tests/utils/task.rs
@@ -109,7 +109,7 @@ impl TaskBuilder {
                 user_priority: self.user_priority,
                 crash_limit: self.crash_limit,
                 data_flags: self.data_flags,
-                body: Box::new([]),
+                body: Rc::new([]),
             }),
         )
     }

--- a/crates/tako/src/internal/worker/task.rs
+++ b/crates/tako/src/internal/worker/task.rs
@@ -29,7 +29,7 @@ pub struct Task {
 
     pub resources: crate::internal::common::resources::ResourceRequestVariants,
     pub time_limit: Option<Duration>,
-    pub body: Box<[u8]>,
+    pub body: Rc<[u8]>,
     pub entry: Option<EntryType>,
     pub node_list: Vec<WorkerId>, // Filled in multi-node tasks; otherwise empty
 

--- a/crates/tako/src/internal/worker/task.rs
+++ b/crates/tako/src/internal/worker/task.rs
@@ -2,7 +2,9 @@ use crate::datasrv::DataObjectId;
 use crate::gateway::{EntryType, TaskDataFlags};
 use crate::internal::common::resources::Allocation;
 use crate::internal::common::stablemap::ExtractKey;
-use crate::internal::messages::worker::{ComputeTaskMsg, TaskOutput};
+use crate::internal::messages::worker::{
+    ComputeTaskSeparateData, ComputeTaskSharedData, TaskOutput,
+};
 use crate::internal::worker::task_comm::RunningTaskComm;
 use crate::{InstanceId, Priority, TaskId, WorkerId};
 use std::rc::Rc;
@@ -36,19 +38,23 @@ pub struct Task {
 }
 
 impl Task {
-    pub fn new(message: ComputeTaskMsg, task_state: TaskState) -> Self {
+    pub fn new(
+        task: ComputeTaskSeparateData,
+        shared: ComputeTaskSharedData,
+        task_state: TaskState,
+    ) -> Self {
         Self {
             state: task_state,
-            id: message.id,
-            priority: (message.user_priority, message.scheduler_priority),
-            instance_id: message.instance_id,
-            resources: message.resources,
-            time_limit: message.time_limit,
-            body: message.body,
-            entry: message.entry,
-            node_list: message.node_list,
-            data_deps: (!message.data_deps.is_empty()).then(|| Rc::new(message.data_deps)),
-            data_flags: message.data_flags,
+            id: task.id,
+            priority: (shared.user_priority, task.scheduler_priority),
+            instance_id: task.instance_id,
+            resources: shared.resources,
+            time_limit: shared.time_limit,
+            body: shared.body,
+            entry: task.entry,
+            node_list: task.node_list,
+            data_deps: (!task.data_deps.is_empty()).then(|| Rc::new(task.data_deps)),
+            data_flags: shared.data_flags,
         }
     }
 

--- a/crates/tako/src/internal/worker/test_util.rs
+++ b/crates/tako/src/internal/worker/test_util.rs
@@ -2,7 +2,7 @@ use crate::datasrv::DataObjectId;
 use crate::gateway::TaskDataFlags;
 use crate::internal::common::Map;
 use crate::internal::common::resources::{Allocation, ResourceRequest, ResourceRequestVariants};
-use crate::internal::messages::worker::ComputeTaskMsg;
+use crate::internal::messages::worker::{ComputeTaskSeparateData, ComputeTaskSharedData};
 use crate::internal::server::workerload::WorkerResources;
 use crate::internal::tests::utils::resources::cpus_compact;
 use crate::internal::worker::rqueue::ResourceWaitQueue;
@@ -60,18 +60,21 @@ impl WorkerTaskBuilder {
         });
 
         Task::new(
-            ComputeTasksMsg {
+            ComputeTaskSeparateData {
+                shared_index: 0,
                 id: self.task_id,
                 instance_id: self.instance_id,
-                user_priority: self.user_priority,
                 scheduler_priority: self.server_priority,
-                resources,
-                time_limit: None,
                 node_list: vec![],
                 data_deps: self.data_deps,
+                entry: None,
+            },
+            ComputeTaskSharedData {
+                user_priority: self.user_priority,
+                resources,
+                time_limit: None,
                 data_flags: self.data_flags,
                 body: Default::default(),
-                entry: None,
             },
             self.task_state,
         )

--- a/crates/tako/src/internal/worker/test_util.rs
+++ b/crates/tako/src/internal/worker/test_util.rs
@@ -60,7 +60,7 @@ impl WorkerTaskBuilder {
         });
 
         Task::new(
-            ComputeTaskMsg {
+            ComputeTasksMsg {
                 id: self.task_id,
                 instance_id: self.instance_id,
                 user_priority: self.user_priority,


### PR DESCRIPTION
This reduces memory usage, bandwidth usage and also removes unnecessary cloning of bodies during serialization.

Some scheduler tests are failing.

Closes: https://github.com/It4innovations/hyperqueue/issues/999