### PR TITLE
Implement granular detection of worker resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           override: true
 
       - uses: Swatinem/rust-cache@v2
@@ -94,7 +94,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           override: true
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           override: true
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           override: true
           components: clippy, rustfmt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## Unreleased
 
-### Changes
+### Breaking changes
 
-* Allocation policy `compact` is update.
-  It still tries to find the minimal number of the resource groups,
-  but when they are found, resources are evenly taken from the minimal groups.
-  For old behavior, use new policy `tight`.
+* The `--no-detect-resources` flag of the `hq worker start` command has been removed.
+  You can now configure automatically detected resources in a granular way using the new
+  `--detect-resources` flag (see below). `--no-detect-resources` corresponds to `--detect-resources=none`.
 
 ### New features
 
@@ -24,6 +23,16 @@
   This is useful for deployment scripts that need to wait for server availability.
 * New `hq alloc add` parameter called `--wrap-worker-cmd`. It can be used to start
   workers on allocated nodes using some wrapping mechanism (e.g. Podman).
+* New flag `--detect-resources` for `hq worker start`. It can be used to configure which worker resources
+  will be automatically detected. You can e.g. say `--detect-resources=cpus,gpus/nvidia`.
+  See [documentation](https://it4innovations.github.io/hyperqueue/latest/jobs/resources) for more information.
+
+### Changes
+
+* Allocation policy `compact` was updated.
+  It still tries to find the minimal number of the resource groups,
+  but when they are found, resources are evenly taken from the minimal groups.
+  For old behavior, use new policy `tight`.
 * The scheduler has better compacting behavior when there are small number of tasks
   and workers appearing/disappering
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 edition = "2024"
 authors = ["Ada Böhm <ada@kreatrix.org>", "Jakub Beránek <berykubik@gmail.com>"]
 

--- a/crates/hyperqueue/src/bin/hq.rs
+++ b/crates/hyperqueue/src/bin/hq.rs
@@ -20,8 +20,9 @@ use hyperqueue::client::commands::submit::{
 };
 use hyperqueue::client::commands::wait::{wait_for_jobs, wait_for_jobs_with_progress};
 use hyperqueue::client::commands::worker::{
-    ManagerOpts, WorkerFilter, WorkerStartOpts, deploy_ssh_workers, gather_manager_info,
-    get_worker_info, get_worker_list, start_hq_worker, stop_worker, wait_for_workers,
+    ManagerOpts, ResourceDetectComponents, WorkerFilter, WorkerStartOpts, deploy_ssh_workers,
+    gather_manager_info, get_worker_info, get_worker_list, start_hq_worker, stop_worker,
+    wait_for_workers,
 };
 use hyperqueue::client::default_server_directory_path;
 use hyperqueue::client::globalsettings::GlobalSettings;
@@ -279,6 +280,7 @@ fn command_worker_hwdetect(gsettings: &GlobalSettings, opts: HwDetectOpts) -> an
     }];
     detect_additional_resources(
         &mut resources,
+        &ResourceDetectComponents::All,
         gather_manager_info(ManagerOpts::Detect)?.as_ref(),
     )?;
     gsettings

--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -342,7 +342,7 @@ wasted allocation duration."
         resource,
         coupling,
         group,
-        no_detect_resources,
+        detect_resources,
         no_hyper_threading,
         idle_timeout,
         overview_interval,
@@ -380,8 +380,11 @@ wasted allocation duration."
     if no_hyper_threading {
         worker_args.push("--no-hyper-threading".to_string());
     }
-    if no_detect_resources {
-        worker_args.push("--no-detect-resources".to_string());
+    if let Some(detect_resources) = detect_resources {
+        worker_args.extend([
+            "--detect-resources".to_string(),
+            detect_resources.into_original_input(),
+        ]);
     }
     if let Some(overview_interval) = overview_interval {
         worker_args.extend([

--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -369,14 +369,12 @@ fn gather_configuration(opts: WorkerStartOpts) -> anyhow::Result<WorkerConfigura
         None => {
             let kind = if let Some(cpus) = cpus {
                 cpus.into_parsed_arg()
+            } else if detect_resources.has(ResourceDetectComponent::Cpus) {
+                detect_cpus()?
             } else {
-                if detect_resources.has(ResourceDetectComponent::Cpus) {
-                    detect_cpus()?
-                } else {
-                    return Err(anyhow::anyhow!(
-                        "You have to specify --cpus explicitly when opting out of CPU automatic detection"
-                    ));
-                }
+                return Err(anyhow::anyhow!(
+                    "You have to specify --cpus explicitly when opting out of CPU automatic detection"
+                ));
             };
             resources.push(ResourceDescriptorItem {
                 name: CPU_RESOURCE_NAME.to_string(),

--- a/crates/hyperqueue/src/client/utils.rs
+++ b/crates/hyperqueue/src/client/utils.rs
@@ -39,7 +39,7 @@ impl<Arg> PassThroughArgument<Arg> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PassthroughParser<Parser>(Parser);
 
 /// Creates a new parser that passed the original value through, while checking that `Arg`

--- a/docs/jobs/cresources.md
+++ b/docs/jobs/cresources.md
@@ -188,6 +188,7 @@ detect the partitioning into sockets (NUMA configuration). In most cases, it sho
 If you want to see how will a HQ worker see your CPU configuration without actually starting the worker,
 you can use the [`hq worker hwdetect`](cli:hq.worker.hwdetect) command, which will print the detected CPU configuration.
 
+You can find out how to modify or disable automatic detection of resources [here](resources.md#configuring-automatic-detection).
 
 ### Manual specification of CPU configuration
 

--- a/docs/jobs/resources.md
+++ b/docs/jobs/resources.md
@@ -113,25 +113,31 @@ The following resources are detected automatically if a resource of a given name
     - AMD GPUs are stored under the resource name `gpus/amd`. These GPUs are detected from the environment
       variable `ROCR_VISIBLE_DEVICES`.
 
-  You can set these environment variables when starting a worker to override the list of available GPUs:
+    You can set these environment variables when starting a worker to override the list of available GPUs:
 
     ```bash
     $ CUDA_VISIBLE_DEVICES=2,3 hq worker start
     # The worker will have resource gpus/nvidia=[2,3]
     ```
 
-* RAM of the node is detected as resource "mem" in megabytes; i.e. `--resource mem=100` asks for 100 MiBs of the memory.
+* RAM of the node is detected as resource "mem" in megabytes.
 
-If you want to see how your system is seen by a worker without actually starting it,
-you can start:
+If you want to see which specific resource values would be detected by a worker (without actually starting it),
+you can use the [`hq worker hwdetect`](cli:hq.worker.hwdetect) command:
 
 ```bash
 $ hq worker hwdetect
 ```
 
-The automatic detection of resources can be disabled by argument ``--no-detect-resources`` in ``hq worker start ...``.
-It disables detection of resources other than "cpus";
-if resource "cpus" are not explicitly defined, it will always be detected.
+#### Configuring automatic detection
+
+You can affect which kinds of resources are automatically detected using the `--detect-resources` argument of [`hq worker start`](cli:hq.worker.start):
+
+- The default value is `all`, which will detect all default resources known to HyperQueue (CPUs, memory and NVIDIA/AMD GPUs).
+- You can opt out of automatic detection by passing `none`: `--detect-resources=none`.
+    - Note that if you opt out of detecting CPU cores, you will need to specify CPUs explicitly using `--cpus` or `--resource cpus`.
+- You can specify a comma-separated list of things that should be detected, e.g. `--detect-resources=cpus,mem,gpus/nvidia`.
+    - This can be useful to opt out of detection of invalid resources e.g. on clusters that set environment variables even for hardware that is not present (e.g. they set `ROCM_VISIBLE_DEVICES` even if no AMD GPUs are present).
 
 ## Resource request
 

--- a/tests/autoalloc/test_autoalloc.py
+++ b/tests/autoalloc/test_autoalloc.py
@@ -475,7 +475,7 @@ def test_pass_cpu_and_resources_to_worker(hq_env: HqEnv, flavor: ManagerFlavor):
                 "--resource",
                 "z=[1,2,4]",
                 "--no-hyper-threading",
-                "--no-detect-resources",
+                "--detect-resources=cpus,mem",
             ],
         )
 
@@ -484,7 +484,7 @@ def test_pass_cpu_and_resources_to_worker(hq_env: HqEnv, flavor: ManagerFlavor):
         assert normalize_output(hq_env, flavor.manager_type(), line.cmd) == snapshot(
             '<hq-binary> worker start --idle-timeout "5m" --manager "<manager>" --server-dir "<server-dir>/001" --cpus'
             ' "2x8" --resource "x=sum(100)" --resource "y=range(1-4)" --resource "z=[1,2,4]" --no-hyper-threading'
-            ' --no-detect-resources --on-server-lost "finish-running" --time-limit "1h"'
+            ' --detect-resources cpus,mem --on-server-lost "finish-running" --time-limit "1h"'
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,7 @@ class HqEnv(Env):
         final_check: bool = True,
         hostname=None,
         expect_fail=None,
+        detect_resources: Optional[str] = None,
     ) -> Optional[subprocess.Popen]:
         self.id_counter += 1
         worker_id = self.id_counter
@@ -197,8 +198,14 @@ class HqEnv(Env):
             "start",
             f"--work-dir={work_dir}",
             f"--on-server-lost={on_server_lost}",
-            "--no-detect-resources",  # Ignore resources on testing machine
         ]
+
+        if detect_resources is None:
+            worker_args.append("--detect-resources=none")
+        else:
+            # Ignore resources on testing machine by default
+            worker_args.append(f"--detect-resources={detect_resources}")
+
         if hostname is None:
             hostname = f"worker{worker_id}"
         if set_hostname:


### PR DESCRIPTION
`--no-detect-resources` has been removed, it was replaced by `--detect-resources=all | none | cpus,mem,...`.

Closes: https://github.com/It4innovations/hyperqueue/issues/729