### PR TITLE
Non-crash error handling in worker broadcast

### DIFF
--- a/crates/tako/src/internal/server/comm.rs
+++ b/crates/tako/src/internal/server/comm.rs
@@ -82,8 +82,10 @@ impl Comm for CommSender {
             return;
         }
         let data: Bytes = serialize(&message).unwrap().into();
-        for sender in self.workers.values() {
-            sender.send(data.clone()).expect("Send to worker failed");
+        for (worker_id, sender) in &self.workers {
+            if sender.send(data.clone()).is_err() {
+                log::error!("Failed to send message to worker: {worker_id}");
+            }
         }
     }
 


### PR DESCRIPTION
Do not crash when broadcast to a worker failed.