### PR TITLE
worker: expose --heartbeat through hq alloc add

### DIFF
--- a/crates/hyperqueue/src/client/commands/autoalloc.rs
+++ b/crates/hyperqueue/src/client/commands/autoalloc.rs
@@ -327,6 +327,7 @@ wasted allocation duration."
         detect_resources,
         no_hyper_threading,
         idle_timeout,
+        heartbeat,
         overview_interval,
         min_utilization,
     } = worker_args;
@@ -370,6 +371,12 @@ wasted allocation duration."
         worker_args.extend([
             "--overview-interval".to_string(),
             format!("\"{}\"", overview_interval.into_original_input()),
+        ]);
+    }
+    if let Some(heartbeat) = heartbeat {
+        worker_args.extend([
+            "--heartbeat".to_string(),
+            format!("\"{}\"", format_duration(heartbeat)),
         ]);
     }
 

--- a/crates/hyperqueue/src/client/commands/worker.rs
+++ b/crates/hyperqueue/src/client/commands/worker.rs
@@ -49,6 +49,10 @@ use crate::worker::parser::{
 use crate::{DEFAULT_WORKER_GROUP_NAME, rpc_call};
 use tako::WorkerId;
 
+/// Default worker heartbeat interval, applied when `--heartbeat` is not passed
+/// (both for `hq worker start` and for `hq alloc add` pilot workers).
+const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(8);
+
 #[derive(clap::ValueEnum, Clone)]
 pub enum WorkerFilter {
     Running,
@@ -136,6 +140,13 @@ pub struct SharedWorkerStartOpts {
         help = duration_doc!("Duration after which will an idle worker automatically stop")
     )]
     pub idle_timeout: Option<Duration>,
+
+    #[arg(
+        long,
+        value_parser = parse_hms_or_human_time,
+        help = duration_doc!("How often heartbeats are sent\n\nHeartbeats are used to detect worker's liveness. If the worker does not send a heartbeat for given time, then the worker is considered as lost.\n\nDefaults to 8s.")
+    )]
+    pub heartbeat: Option<Duration>,
 
     /// The period of reporting the overview to the server
     ///
@@ -253,14 +264,6 @@ pub struct WorkerStartOpts {
 
     #[arg(
         long,
-        default_value = "8s",
-        value_parser = parse_hms_or_human_time,
-        help = duration_doc!("How often heartbeats are sent\n\nHeartbeats are used to detect worker's liveness. If the worker does not send a heartbeat for given time, then the worker is considered as lost.")
-    )]
-    pub heartbeat: Duration,
-
-    #[arg(
-        long,
         value_parser = parse_hms_or_human_time,
         help = duration_doc!("Worker time limit\n\nWorker exits after given time.")
     )]
@@ -334,10 +337,10 @@ fn gather_configuration(opts: WorkerStartOpts) -> anyhow::Result<WorkerConfigura
                 detect_resources: detect_resources_cli,
                 no_hyper_threading,
                 idle_timeout,
+                heartbeat,
                 overview_interval,
                 min_utilization,
             },
-        heartbeat,
         time_limit,
         manager,
         hostname,
@@ -465,7 +468,7 @@ fn gather_configuration(opts: WorkerStartOpts) -> anyhow::Result<WorkerConfigura
         group,
         work_dir,
         on_server_lost: on_server_lost.into(),
-        heartbeat_interval: heartbeat,
+        heartbeat_interval: heartbeat.unwrap_or(DEFAULT_HEARTBEAT_INTERVAL),
         idle_timeout,
         overview_configuration,
         extra,


### PR DESCRIPTION
## Summary
- `hq worker start` already accepted `--heartbeat`, but `hq alloc add slurm`/`hq alloc add pbs` had no way to set it — the field lived on `WorkerStartOpts`, not the `SharedWorkerStartOpts` that autoalloc's generated worker command reuses.
- Moves `heartbeat` onto `SharedWorkerStartOpts` (`Option<Duration>`, no default so we can detect "not set") and forwards it into the generated `hq worker start ...` invocation in `autoalloc.rs` only when explicitly provided, preserving the existing 8s default otherwise.

## Motivation
On a busy server (e.g. mid MILP scheduler solve, or handling a burst of other workers registering), the single-threaded executor can go long enough without polling that an already-connected worker's heartbeat looks lost even though nothing is actually wrong. Autoalloc-managed workers had no way to raise their heartbeat interval to ride this out, since the flag was never wired through `hq alloc add`. Plain `hq worker start` was unaffected — this only closes the gap for the autoalloc path.

## Test plan
- [x] `cargo check -p hyperqueue -p tako`
- [x] `cargo test -p tako` (no regressions)
- [x] Manually verified `hq alloc add slurm --heartbeat 45s` renders `--heartbeat "45s"` in the generated sbatch worker command